### PR TITLE
feat: 거래처 별 제품 crud

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -36,6 +36,12 @@ public enum BaseResponseStatus {
     PAYMENT_BILLING_INVALID_OWNER(false, 4104, "결제 수단의 소유자가 아닙니다."),
     PAYMENT_BILLING_REQUIRED(false, 4105, "최소 1개의 결제 수단이 필요합니다."),
     PAYMENT_DEFAULT_BILLING_REQUIRED(false, 4106, "기본 결제 수단이 존재하지 않습니다."),
+
+    // 4200번대~ 공급처별 제품 (CEN-027~031, 033)
+    VENDOR_NOT_FOUND(false, 4200, "거래처를 찾을 수 없습니다."),
+    VENDOR_PRODUCT_NOT_FOUND(false, 4201, "공급처별 제품 계약을 찾을 수 없습니다."),
+    DUPLICATE_VENDOR_PRODUCT_CODE(false, 4202, "이미 등록된 거래처-제품 코드 조합입니다."),
+
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");
 

--- a/src/main/java/org/example/stockitbe/vendor/VendorController.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorController.java
@@ -1,0 +1,32 @@
+package org.example.stockitbe.vendor;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.vendor.model.VendorDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Vendor read-only Controller — 등록/수정/삭제는 SQL 로 직접 처리.
+ */
+@RestController
+@RequestMapping("/api/vendors")
+@RequiredArgsConstructor
+public class VendorController {
+
+    private final VendorService service;
+
+    @GetMapping
+    public BaseResponse<List<VendorDto.ListRes>> list() {
+        return BaseResponse.success(service.findAll());
+    }
+
+    @GetMapping("/{code}")
+    public BaseResponse<VendorDto.ListRes> detail(@PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code));
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/VendorProductController.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorProductController.java
@@ -1,0 +1,50 @@
+package org.example.stockitbe.vendor;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.vendor.model.VendorProductDto;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/vendor-products")
+@RequiredArgsConstructor
+public class VendorProductController {
+
+    private final VendorProductService service;
+
+    @GetMapping
+    public BaseResponse<List<VendorProductDto.ListRes>> list(@RequestParam String vendorCode) {
+        return BaseResponse.success(service.findByVendor(vendorCode));
+    }
+
+    @GetMapping("/{code}")
+    public BaseResponse<VendorProductDto.DetailRes> detail(@PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code));
+    }
+
+    @PostMapping
+    public BaseResponse<VendorProductDto.DetailRes> create(@Valid @RequestBody VendorProductDto.CreateReq req) {
+        return BaseResponse.success(service.create(req));
+    }
+
+    @PatchMapping("/{code}")
+    public BaseResponse<VendorProductDto.DetailRes> update(@PathVariable String code,
+                                                            @Valid @RequestBody VendorProductDto.UpdateReq req) {
+        return BaseResponse.success(service.update(code, req));
+    }
+
+    @PatchMapping("/{code}/status")
+    public BaseResponse<VendorProductDto.DetailRes> updateStatus(@PathVariable String code,
+                                                                  @Valid @RequestBody VendorProductDto.StatusUpdateReq req) {
+        return BaseResponse.success(service.updateStatus(code, req));
+    }
+
+    @DeleteMapping("/{code}")
+    public BaseResponse<Void> delete(@PathVariable String code) {
+        service.delete(code);
+        return BaseResponse.success(null);
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/VendorProductRepository.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorProductRepository.java
@@ -1,0 +1,19 @@
+package org.example.stockitbe.vendor;
+
+import org.example.stockitbe.vendor.model.VendorProduct;
+import org.example.stockitbe.vendor.model.VendorProductStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface VendorProductRepository extends JpaRepository<VendorProduct, Long> {
+
+    Optional<VendorProduct> findByCode(String code);
+
+    List<VendorProduct> findAllByVendorIdAndStatusNotOrderByIdDesc(Long vendorId, VendorProductStatus excluded);
+
+    boolean existsByVendorIdAndProductCodeAndStatusNot(Long vendorId, String productCode, VendorProductStatus excluded);
+
+    long countByVendorId(Long vendorId);
+}

--- a/src/main/java/org/example/stockitbe/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorProductService.java
@@ -1,0 +1,107 @@
+package org.example.stockitbe.vendor;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.vendor.model.Vendor;
+import org.example.stockitbe.vendor.model.VendorProduct;
+import org.example.stockitbe.vendor.model.VendorProductDto;
+import org.example.stockitbe.vendor.model.VendorProductStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VendorProductService {
+
+    private final VendorRepository vendorRepository;
+    private final VendorProductRepository vendorProductRepository;
+
+    @Transactional(readOnly = true)
+    public List<VendorProductDto.ListRes> findByVendor(String vendorCode) {
+        Vendor vendor = lookupVendor(vendorCode);
+        List<VendorProduct> list = vendorProductRepository
+                .findAllByVendorIdAndStatusNotOrderByIdDesc(vendor.getId(), VendorProductStatus.DELETED);
+        return list.stream()
+                .map(vp -> VendorProductDto.ListRes.from(vp, vendor))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public VendorProductDto.DetailRes findByCode(String code) {
+        VendorProduct vp = lookupVendorProduct(code);
+        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+        return VendorProductDto.DetailRes.from(vp, vendor);
+    }
+
+    @Transactional
+    public VendorProductDto.DetailRes create(VendorProductDto.CreateReq req) {
+        Vendor vendor = lookupVendor(req.getVendorCode());
+
+        boolean duplicate = vendorProductRepository
+                .existsByVendorIdAndProductCodeAndStatusNot(vendor.getId(), req.getProductCode(), VendorProductStatus.DELETED);
+        if (duplicate) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_VENDOR_PRODUCT_CODE);
+        }
+
+        String code = generateCode(vendor);
+        VendorProduct entity = req.toEntity(vendor, code);
+        VendorProduct saved = vendorProductRepository.save(entity);
+        return VendorProductDto.DetailRes.from(saved, vendor);
+    }
+
+    @Transactional
+    public VendorProductDto.DetailRes update(String code, VendorProductDto.UpdateReq req) {
+        VendorProduct vp = lookupVendorProduct(code);
+        vp.updateContract(
+                req.getProductName(),
+                req.getUnitPrice(),
+                req.getMoq(),
+                req.getLeadTimeDays(),
+                req.getContractStart(),
+                req.getContractEnd()
+        );
+        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+        return VendorProductDto.DetailRes.from(vp, vendor);
+    }
+
+    @Transactional
+    public VendorProductDto.DetailRes updateStatus(String code, VendorProductDto.StatusUpdateReq req) {
+        VendorProduct vp = lookupVendorProduct(code);
+        vp.changeStatus(req.getStatus());
+        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+        return VendorProductDto.DetailRes.from(vp, vendor);
+    }
+
+    @Transactional
+    public void delete(String code) {
+        VendorProduct vp = lookupVendorProduct(code);
+        vp.softDelete();
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private Vendor lookupVendor(String vendorCode) {
+        return vendorRepository.findByCode(vendorCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+    }
+
+    private VendorProduct lookupVendorProduct(String code) {
+        return vendorProductRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_PRODUCT_NOT_FOUND));
+    }
+
+    /**
+     * 비즈니스 코드 자동 생성 — VP-{vendorCode}-{seq:3자리}
+     * seq 는 해당 vendor 의 product 총 개수 + 1 (DELETED 포함, 충돌 방지).
+     */
+    private String generateCode(Vendor vendor) {
+        long seq = vendorProductRepository.countByVendorId(vendor.getId()) + 1;
+        return String.format("VP-%s-%03d", vendor.getCode(), seq);
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/VendorRepository.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorRepository.java
@@ -1,0 +1,11 @@
+package org.example.stockitbe.vendor;
+
+import org.example.stockitbe.vendor.model.Vendor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface VendorRepository extends JpaRepository<Vendor, Long> {
+
+    Optional<Vendor> findByCode(String code);
+}

--- a/src/main/java/org/example/stockitbe/vendor/VendorService.java
+++ b/src/main/java/org/example/stockitbe/vendor/VendorService.java
@@ -1,0 +1,36 @@
+package org.example.stockitbe.vendor;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.vendor.model.Vendor;
+import org.example.stockitbe.vendor.model.VendorDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Vendor read-only Service.
+ * 등록/수정/삭제는 SQL 로 직접 — 컨트롤러도 조회 전용.
+ */
+@Service
+@RequiredArgsConstructor
+public class VendorService {
+
+    private final VendorRepository vendorRepository;
+
+    @Transactional(readOnly = true)
+    public List<VendorDto.ListRes> findAll() {
+        return vendorRepository.findAll().stream()
+                .map(VendorDto.ListRes::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public VendorDto.ListRes findByCode(String code) {
+        Vendor vendor = vendorRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+        return VendorDto.ListRes.from(vendor);
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/Vendor.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/Vendor.java
@@ -1,0 +1,39 @@
+package org.example.stockitbe.vendor.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "vendor", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_vendor_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vendor extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 128)
+    private String name;
+
+    @Column(name = "contact_name", length = 64)
+    private String contactName;
+
+    @Column(name = "contact_phone", length = 32)
+    private String contactPhone;
+
+    @Column(name = "contact_email", length = 128)
+    private String contactEmail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private VendorStatus status;
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/VendorDto.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/VendorDto.java
@@ -1,0 +1,31 @@
+package org.example.stockitbe.vendor.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class VendorDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ListRes {
+        private String code;
+        private String name;
+        private String contactName;
+        private String contactPhone;
+        private String contactEmail;
+        private VendorStatus status;
+
+        public static ListRes from(Vendor vendor) {
+            return ListRes.builder()
+                    .code(vendor.getCode())
+                    .name(vendor.getName())
+                    .contactName(vendor.getContactName())
+                    .contactPhone(vendor.getContactPhone())
+                    .contactEmail(vendor.getContactEmail())
+                    .status(vendor.getStatus())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/VendorProduct.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/VendorProduct.java
@@ -1,0 +1,94 @@
+package org.example.stockitbe.vendor.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "vendor_product", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_vendor_product_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VendorProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 64)
+    private String code;
+
+    @Column(name = "vendor_id", nullable = false)
+    private Long vendorId;
+
+    // 마스터 제품 logical reference (FK 제약 없음 — 마스터 제품 BE 미구현)
+    @Column(name = "product_code", nullable = false, length = 64)
+    private String productCode;
+
+    // 계약 당시 제품명 (시점 복사)
+    @Column(name = "product_name", nullable = false, length = 256)
+    private String productName;
+
+    @Column(name = "unit_price", nullable = false)
+    private Long unitPrice;
+
+    @Column(name = "moq")
+    private Integer moq;
+
+    @Column(name = "lead_time_days")
+    private Integer leadTimeDays;
+
+    @Column(name = "contract_start")
+    private LocalDate contractStart;
+
+    @Column(name = "contract_end")
+    private LocalDate contractEnd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private VendorProductStatus status;
+
+    @Builder
+    private VendorProduct(String code, Long vendorId, String productCode, String productName,
+                          Long unitPrice, Integer moq, Integer leadTimeDays,
+                          LocalDate contractStart, LocalDate contractEnd, VendorProductStatus status) {
+        this.code = code;
+        this.vendorId = vendorId;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.unitPrice = unitPrice;
+        this.moq = moq;
+        this.leadTimeDays = leadTimeDays;
+        this.contractStart = contractStart;
+        this.contractEnd = contractEnd;
+        this.status = status == null ? VendorProductStatus.ACTIVE : status;
+    }
+
+    /**
+     * 계약 정보 수정 (단가·MOQ·납기·계약기간·제품명).
+     * status 변경은 changeStatus() 통해서만.
+     */
+    public void updateContract(String productName, Long unitPrice, Integer moq, Integer leadTimeDays,
+                                LocalDate contractStart, LocalDate contractEnd) {
+        if (productName != null) this.productName = productName;
+        if (unitPrice != null) this.unitPrice = unitPrice;
+        if (moq != null) this.moq = moq;
+        if (leadTimeDays != null) this.leadTimeDays = leadTimeDays;
+        if (contractStart != null) this.contractStart = contractStart;
+        if (contractEnd != null) this.contractEnd = contractEnd;
+    }
+
+    public void changeStatus(VendorProductStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public void softDelete() {
+        this.status = VendorProductStatus.DELETED;
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/VendorProductDto.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/VendorProductDto.java
@@ -1,0 +1,148 @@
+package org.example.stockitbe.vendor.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+public class VendorProductDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateReq {
+        @NotBlank
+        private String vendorCode;
+        @NotBlank
+        private String productCode;
+        @NotBlank
+        private String productName;
+        @NotNull
+        @Min(0)
+        private Long unitPrice;
+        @Min(1)
+        private Integer moq;
+        @Min(0)
+        private Integer leadTimeDays;
+        private LocalDate contractStart;
+        private LocalDate contractEnd;
+
+        // DTO → Entity 변환은 DTO 책임 (사용자 컨벤션)
+        public VendorProduct toEntity(Vendor vendor, String code) {
+            return VendorProduct.builder()
+                    .code(code)
+                    .vendorId(vendor.getId())
+                    .productCode(this.productCode)
+                    .productName(this.productName)
+                    .unitPrice(this.unitPrice)
+                    .moq(this.moq)
+                    .leadTimeDays(this.leadTimeDays)
+                    .contractStart(this.contractStart)
+                    .contractEnd(this.contractEnd)
+                    .status(VendorProductStatus.ACTIVE)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateReq {
+        private String productName;
+        @Min(0)
+        private Long unitPrice;
+        @Min(1)
+        private Integer moq;
+        @Min(0)
+        private Integer leadTimeDays;
+        private LocalDate contractStart;
+        private LocalDate contractEnd;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StatusUpdateReq {
+        @NotNull
+        private VendorProductStatus status;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ListRes {
+        private String code;
+        private String vendorCode;
+        private String vendorName;
+        private String productCode;
+        private String productName;
+        private Long unitPrice;
+        private Integer moq;
+        private Integer leadTimeDays;
+        private LocalDate contractStart;
+        private LocalDate contractEnd;
+        private VendorProductStatus status;
+
+        public static ListRes from(VendorProduct vp, Vendor vendor) {
+            return ListRes.builder()
+                    .code(vp.getCode())
+                    .vendorCode(vendor.getCode())
+                    .vendorName(vendor.getName())
+                    .productCode(vp.getProductCode())
+                    .productName(vp.getProductName())
+                    .unitPrice(vp.getUnitPrice())
+                    .moq(vp.getMoq())
+                    .leadTimeDays(vp.getLeadTimeDays())
+                    .contractStart(vp.getContractStart())
+                    .contractEnd(vp.getContractEnd())
+                    .status(vp.getStatus())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DetailRes {
+        private String code;
+        private String vendorCode;
+        private String vendorName;
+        private String productCode;
+        private String productName;
+        private Long unitPrice;
+        private Integer moq;
+        private Integer leadTimeDays;
+        private LocalDate contractStart;
+        private LocalDate contractEnd;
+        private VendorProductStatus status;
+        private Date createdAt;
+        private Date updatedAt;
+
+        public static DetailRes from(VendorProduct vp, Vendor vendor) {
+            return DetailRes.builder()
+                    .code(vp.getCode())
+                    .vendorCode(vendor.getCode())
+                    .vendorName(vendor.getName())
+                    .productCode(vp.getProductCode())
+                    .productName(vp.getProductName())
+                    .unitPrice(vp.getUnitPrice())
+                    .moq(vp.getMoq())
+                    .leadTimeDays(vp.getLeadTimeDays())
+                    .contractStart(vp.getContractStart())
+                    .contractEnd(vp.getContractEnd())
+                    .status(vp.getStatus())
+                    .createdAt(vp.getCreatedAt())
+                    .updatedAt(vp.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/VendorProductStatus.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/VendorProductStatus.java
@@ -1,0 +1,8 @@
+package org.example.stockitbe.vendor.model;
+
+public enum VendorProductStatus {
+    ACTIVE,
+    SUSPENDED,
+    EXPIRED,
+    DELETED, // SOFT DELETE 마커
+}

--- a/src/main/java/org/example/stockitbe/vendor/model/VendorStatus.java
+++ b/src/main/java/org/example/stockitbe/vendor/model/VendorStatus.java
@@ -1,0 +1,6 @@
+package org.example.stockitbe.vendor.model;
+
+public enum VendorStatus {
+    ACTIVE,
+    INACTIVE,
+}


### PR DESCRIPTION
## 📌 요약
- 거래처(Vendor) 및 거래처 계약 제품(VendorProduct) 관리 **백엔드 API 구현** — 거래처 조회 2종 + 계약 제품 CRUD 6종 (총 8개 엔드포인트)

<br><br>

## 🎯 작업 내용
- **Domain / Entity 설계**
  - `Vendor` (거래처): code(PK), name, contactName, contactPhone, contactEmail, status(ACTIVE/INACTIVE)
  - `VendorProduct` (거래처 계약 제품): code(PK), vendorCode(FK), productCode, productName, unitPrice, moq, leadTimeDays, contractStart, contractEnd, status(ACTIVE/INACTIVE/DELETED)
- **API 8종 구현** — 모든 응답은 공통 `BaseResponse<T>` (success / message / result) 래핑
  - `GET  /api/vendors` — 거래처 목록 조회
  - `GET  /api/vendors/{code}` — 거래처 단건 조회
  - `GET  /api/vendor-products?vendorCode=` — 특정 거래처 계약 제품 목록
  - `GET  /api/vendor-products/{code}` — 계약 제품 단건 조회
  - `POST /api/vendor-products` — 계약 제품 등록
  - `PATCH /api/vendor-products/{code}` — 계약 제품 정보 수정
  - `PATCH /api/vendor-products/{code}/status` — 계약 제품 상태 변경
  - `DELETE /api/vendor-products/{code}` — 계약 제품 삭제 (**SOFT DELETE**, status = DELETED)
- **Layer 구성**: Controller → Service → Repository(JPA) + Request/Response DTO + 전역 예외 처리
- **유효성 검증**: `productCode` 중복 검사, 거래처 존재 여부 검증, 계약 기간(start ≤ end) 검증, MOQ·단가 음수 방지

<br><br>

## ✔️ 참고 사항
- 삭제는 **물리 삭제가 아닌 SOFT DELETE** — status를 `DELETED`로 변경하며, 목록 조회 시 DELETED는 기본 제외
- 상태 enum은 BE는 대문자(`ACTIVE`), FE는 소문자(`active`)로 사용 → FE 매핑 레이어에서 변환 처리됨
- FE `src/api/vendor.js`의 axios 호출 스펙(파라미터·request body 필드명)에 맞춰 DTO 필드명 정합성 유지
- 응답 포맷은 기존 도메인과 동일하게 `BaseResponse` 통일

<br><br>

## ✔️ 관련 이슈
- Close #117 

<br><br>