### PR TITLE
fix(vendor): 거래처 시드를 dev 부팅 시 자동 INSERT + 12건으로 확장

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
@@ -1,0 +1,64 @@
+package org.example.stockitbe.hq.vendor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorStatus;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * dev 프로파일 부팅 시 vendor 테이블이 비어 있으면 거래처 12개를 자동 INSERT.
+ * 운영(prod) 에선 동작하지 않음 — 운영 거래처 데이터는 운영자가 별도 관리.
+ *
+ * 빈 테이블 조건(count == 0) — 이미 데이터 있으면 건너뜀.
+ */
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+@Slf4j
+public class VendorSeedRunner implements CommandLineRunner {
+
+    private final VendorRepository vendorRepository;
+
+    @Override
+    public void run(String... args) {
+        if (vendorRepository.count() > 0) {
+            log.info("[VendorSeedRunner] vendor 테이블에 데이터 존재 — 시드 건너뜀");
+            return;
+        }
+
+        List<Vendor> seed = List.of(
+                vendor("VND-001", "(주)테크서플라이",     "김민준", "02-1234-5678",  "minjun.kim@techsupply.co.kr",     VendorStatus.ACTIVE),
+                vendor("VND-002", "한국생활물산",          "이수연", "031-9876-5432", "suyeon.lee@kliving.co.kr",        VendorStatus.ACTIVE),
+                vendor("VND-003", "글로벌오피스",          "박재현", "02-5555-3333",  "jaehyun.park@globaloffice.com",   VendorStatus.ACTIVE),
+                vendor("VND-004", "위생물자(주)",          "최영희", "032-7777-8888", "younghee.choi@hygiene.co.kr",     VendorStatus.INACTIVE),
+                vendor("VND-005", "스마트주방솔루션",      "정도현", "051-4444-2222", "dohyun.jung@smartkitchen.kr",     VendorStatus.ACTIVE),
+                vendor("VND-006", "패션라인(주)",          "한지윤", "02-2222-1111",  "jiyoon.han@fashionline.co.kr",    VendorStatus.ACTIVE),
+                vendor("VND-007", "슈즈모아",              "임도현", "053-3333-4444", "dohyun.lim@shoesmoa.com",         VendorStatus.ACTIVE),
+                vendor("VND-008", "코스메틱플러스",        "윤서연", "02-8888-9999",  "seoyeon.yoon@cosmeticplus.kr",    VendorStatus.ACTIVE),
+                vendor("VND-009", "오피스인테리어(주)",    "강민호", "031-2222-3333", "minho.kang@officeint.co.kr",      VendorStatus.ACTIVE),
+                vendor("VND-010", "푸드유통센터",          "송지원", "02-7777-1111",  "jiwon.song@fooddist.co.kr",       VendorStatus.ACTIVE),
+                vendor("VND-011", "그린리빙코리아",        "노승현", "042-5555-6666", "seunghyun.noh@greenliving.kr",    VendorStatus.ACTIVE),
+                vendor("VND-012", "베스트가전",            "신유정", "02-3333-7777",  "yujung.shin@bestappliance.co.kr", VendorStatus.INACTIVE)
+        );
+
+        vendorRepository.saveAll(seed);
+        log.info("[VendorSeedRunner] vendor 시드 {}건 INSERT 완료", seed.size());
+    }
+
+    private Vendor vendor(String code, String name, String contactName, String contactPhone,
+                           String contactEmail, VendorStatus status) {
+        return Vendor.builder()
+                .code(code)
+                .name(name)
+                .contactName(contactName)
+                .contactPhone(contactPhone)
+                .contactEmail(contactEmail)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/Vendor.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/Vendor.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.hq.vendor.model;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.stockitbe.common.model.BaseEntity;
@@ -36,4 +37,15 @@ public class Vendor extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 16)
     private VendorStatus status;
+
+    @Builder
+    private Vendor(String code, String name, String contactName, String contactPhone,
+                    String contactEmail, VendorStatus status) {
+        this.code = code;
+        this.name = name;
+        this.contactName = contactName;
+        this.contactPhone = contactPhone;
+        this.contactEmail = contactEmail;
+        this.status = status;
+    }
 }


### PR DESCRIPTION
## 📌 요약
- **dev 프로파일 부팅 시 거래처(Vendor) 시드 12건이 자동 INSERT** 되도록 구성 (기존 수동 INSERT + 5건 → 자동화 + 카테고리 확장)

<br><br>

## 🎯 작업 내용
- **시드 데이터 확장 (5건 → 12건)**
  - 카테고리 다양성 확보를 위해 의류·신발·화장품·가전·식음료 등으로 거래처 구성 확장
- **자동 시드 적재 로직 추가**
  - `CommandLineRunner` 기반 시드 컴포넌트 신규 작성
  - `@Profile("dev")` 적용 — 운영(prod) 부팅에는 영향 없음
  - `vendorRepository.count() == 0` 일 때만 `saveAll()` 실행하도록 가드 처리 → **재부팅 시 중복 INSERT 방지**
- **Vendor 엔티티 보강**
  - 시드 적재 전용 `@Builder` 추가
  - 외부 무분별한 인스턴스화는 기존 접근 제어로 차단 유지

<br><br>

## ✔️ 참고 사항
- 운영(prod) 환경에서는 시드 로직이 동작하지 않음 — 프로파일 분기로 안전하게 격리
- count 가드 방식이라 기존 데이터가 1건이라도 있으면 시드는 skip → 운영자가 수기로 추가한 데이터 보존
- 향후 거래처 계약 제품(VendorProduct) 시드도 동일 패턴으로 확장 가능

<br><br>

## ✔️ 관련 이슈
- Close #129 

<br><br>