### PR TITLE
feat: 본사 발주 BE 도메인 풀 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -42,6 +42,13 @@ public enum BaseResponseStatus {
     VENDOR_PRODUCT_NOT_FOUND(false, 4201, "공급처별 제품 계약을 찾을 수 없습니다."),
     DUPLICATE_VENDOR_PRODUCT_CODE(false, 4202, "이미 등록된 거래처-제품 코드 조합입니다."),
 
+    // 4300번대~ 본사 발주 (CEN-035~040)
+    PURCHASE_ORDER_NOT_FOUND(false, 4300, "본사 발주를 찾을 수 없습니다."),
+    PURCHASE_ORDER_INVALID_STATUS_TRANSITION(false, 4301, "허용되지 않는 발주 상태 전환입니다."),
+    PURCHASE_ORDER_EMPTY_ITEMS(false, 4302, "발주 품목이 비어 있습니다."),
+    PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH(false, 4303, "발주 거래처와 품목의 거래처가 일치하지 않습니다."),
+    PURCHASE_ORDER_CANCEL_REASON_REQUIRED(false, 4304, "발주 취소 사유는 필수입니다."),
+
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");
 

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
@@ -1,0 +1,66 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq/purchase-orders")
+@RequiredArgsConstructor
+public class PurchaseOrderController {
+
+    private final PurchaseOrderService service;
+
+    @GetMapping
+    public BaseResponse<List<PurchaseOrderDto.ListRes>> list(
+            @RequestParam(required = false) String vendorCode,
+            @RequestParam(required = false) PurchaseOrderStatus status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return BaseResponse.success(service.findAll(vendorCode, status, from, to));
+    }
+
+    @GetMapping("/{code}")
+    public BaseResponse<PurchaseOrderDto.DetailRes> detail(@PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code));
+    }
+
+    @PostMapping
+    public BaseResponse<PurchaseOrderDto.DetailRes> create(@Valid @RequestBody PurchaseOrderDto.CreateReq req) {
+        return BaseResponse.success(service.create(req));
+    }
+
+    @PatchMapping("/{code}")
+    public BaseResponse<PurchaseOrderDto.DetailRes> update(@PathVariable String code,
+                                                             @Valid @RequestBody PurchaseOrderDto.UpdateReq req) {
+        return BaseResponse.success(service.update(code, req));
+    }
+
+    @PostMapping("/{code}/approve")
+    public BaseResponse<PurchaseOrderDto.DetailRes> approve(@PathVariable String code) {
+        return BaseResponse.success(service.approve(code));
+    }
+
+    @PostMapping("/{code}/start-shipping")
+    public BaseResponse<PurchaseOrderDto.DetailRes> startShipping(@PathVariable String code) {
+        return BaseResponse.success(service.startShipping(code));
+    }
+
+    @PostMapping("/{code}/complete")
+    public BaseResponse<PurchaseOrderDto.DetailRes> complete(@PathVariable String code) {
+        return BaseResponse.success(service.complete(code));
+    }
+
+    @PostMapping("/{code}/cancel")
+    public BaseResponse<PurchaseOrderDto.DetailRes> cancel(@PathVariable String code,
+                                                             @Valid @RequestBody PurchaseOrderDto.CancelReq req) {
+        return BaseResponse.success(service.cancel(code, req));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderItemRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderItemRepository.java
@@ -1,0 +1,16 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface PurchaseOrderItemRepository extends JpaRepository<PurchaseOrderItem, Long> {
+
+    List<PurchaseOrderItem> findAllByPurchaseOrderId(Long purchaseOrderId);
+
+    List<PurchaseOrderItem> findAllByPurchaseOrderIdIn(Collection<Long> purchaseOrderIds);
+
+    void deleteAllByPurchaseOrderId(Long purchaseOrderId);
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
@@ -1,0 +1,15 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Optional;
+
+public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>,
+                                                  JpaSpecificationExecutor<PurchaseOrder> {
+
+    Optional<PurchaseOrder> findByCode(String code);
+
+    long countByCodeStartingWith(String prefix);
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -1,0 +1,280 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderItem;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatusHistory;
+import org.example.stockitbe.hq.vendor.VendorProductRepository;
+import org.example.stockitbe.hq.vendor.VendorRepository;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorProduct;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PurchaseOrderService {
+
+    private static final String CHANGED_BY_PLACEHOLDER = "본사 관리자";
+    private static final DateTimeFormatter CODE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final PurchaseOrderItemRepository itemRepository;
+    private final PurchaseOrderStatusHistoryRepository historyRepository;
+    private final VendorRepository vendorRepository;
+    private final VendorProductRepository vendorProductRepository;
+
+    @Transactional(readOnly = true)
+    public List<PurchaseOrderDto.ListRes> findAll(String vendorCode, PurchaseOrderStatus status,
+                                                    LocalDate from, LocalDate to) {
+        Long vendorIdFilter = null;
+        if (vendorCode != null && !vendorCode.isBlank()) {
+            Vendor vendor = lookupVendor(vendorCode);
+            vendorIdFilter = vendor.getId();
+        }
+
+        Specification<PurchaseOrder> spec = buildSpec(vendorIdFilter, status, from, to);
+        List<PurchaseOrder> orders = purchaseOrderRepository.findAll(spec);
+        if (orders.isEmpty()) {
+            return List.of();
+        }
+
+        // vendor / itemCount 매핑
+        Set<Long> vendorIds = orders.stream().map(PurchaseOrder::getVendorId).collect(Collectors.toSet());
+        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
+                .collect(Collectors.toMap(Vendor::getId, v -> v));
+
+        Set<Long> orderIds = orders.stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
+        Map<Long, Long> itemCountMap = itemRepository.findAllByPurchaseOrderIdIn(orderIds).stream()
+                .collect(Collectors.groupingBy(PurchaseOrderItem::getPurchaseOrderId, Collectors.counting()));
+
+        return orders.stream()
+                .map(po -> {
+                    Vendor vendor = vendorMap.get(po.getVendorId());
+                    if (vendor == null) {
+                        throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
+                    }
+                    int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
+                    return PurchaseOrderDto.ListRes.from(po, vendor, count);
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PurchaseOrderDto.DetailRes findByCode(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes create(PurchaseOrderDto.CreateReq req) {
+        if (req.getItems() == null || req.getItems().isEmpty()) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_EMPTY_ITEMS);
+        }
+
+        Vendor vendor = lookupVendor(req.getVendorCode());
+
+        // items 의 vendorProduct 모두 조회 + vendor 일치 검증
+        List<VendorProduct> vendorProducts = req.getItems().stream()
+                .map(itemReq -> {
+                    VendorProduct vp = lookupVendorProduct(itemReq.getVendorProductCode());
+                    if (!vp.getVendorId().equals(vendor.getId())) {
+                        throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH);
+                    }
+                    return vp;
+                })
+                .toList();
+
+        long totalAmount = 0L;
+        for (int i = 0; i < req.getItems().size(); i++) {
+            totalAmount += vendorProducts.get(i).getUnitPrice() * req.getItems().get(i).getQuantity();
+        }
+
+        String code = generateCode();
+        PurchaseOrder entity = req.toEntity(vendor, code, totalAmount);
+        PurchaseOrder saved = purchaseOrderRepository.save(entity);
+
+        // items 저장 (purchaseOrderId 채움)
+        List<PurchaseOrderItem> items = new ArrayList<>();
+        for (int i = 0; i < req.getItems().size(); i++) {
+            PurchaseOrderItem item = req.getItems().get(i).toEntity(saved.getId(), vendorProducts.get(i));
+            items.add(item);
+        }
+        itemRepository.saveAll(items);
+
+        appendHistory(saved, null);
+
+        return buildDetailRes(saved);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes update(String code, PurchaseOrderDto.UpdateReq req) {
+        if (req.getItems() == null || req.getItems().isEmpty()) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_EMPTY_ITEMS);
+        }
+
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        if (po.getStatus() != PurchaseOrderStatus.PENDING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+
+        // items 의 vendorProduct 검증 (vendor 일치)
+        List<VendorProduct> vendorProducts = req.getItems().stream()
+                .map(itemReq -> {
+                    VendorProduct vp = lookupVendorProduct(itemReq.getVendorProductCode());
+                    if (!vp.getVendorId().equals(po.getVendorId())) {
+                        throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH);
+                    }
+                    return vp;
+                })
+                .toList();
+
+        // 기존 items 삭제
+        itemRepository.deleteAllByPurchaseOrderId(po.getId());
+        itemRepository.flush();
+
+        // 신규 items 빌드/save
+        List<PurchaseOrderItem> newItems = new ArrayList<>();
+        for (int i = 0; i < req.getItems().size(); i++) {
+            newItems.add(req.getItems().get(i).toEntity(po.getId(), vendorProducts.get(i)));
+        }
+        itemRepository.saveAll(newItems);
+
+        // 창고/회원 logical reference 업데이트 + totalAmount 재계산
+        po.updateLogistics(req.getWarehouseId(), req.getWarehouseName());
+        po.recalculateTotalAmount(newItems);
+
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes approve(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markApproved();
+        appendHistory(po, null);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes startShipping(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markShipping();
+        appendHistory(po, null);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes complete(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markCompleted();
+        appendHistory(po, null);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes cancel(String code, PurchaseOrderDto.CancelReq req) {
+        if (req.getCancelReason() == null || req.getCancelReason().isBlank()) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_CANCEL_REASON_REQUIRED);
+        }
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markRejected(req.getCancelReason());
+        appendHistory(po, req.getCancelReason());
+        return buildDetailRes(po);
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private Vendor lookupVendor(String vendorCode) {
+        return vendorRepository.findByCode(vendorCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+    }
+
+    private PurchaseOrder lookupPurchaseOrder(String code) {
+        return purchaseOrderRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PURCHASE_ORDER_NOT_FOUND));
+    }
+
+    private VendorProduct lookupVendorProduct(String vendorProductCode) {
+        return vendorProductRepository.findByCode(vendorProductCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_PRODUCT_NOT_FOUND));
+    }
+
+    /**
+     * 코드 자동 생성 — PO-{YYYYMMDD}-{NNN}.
+     * NNN 은 같은 날 prefix count + 1 (3자리 zero-pad).
+     */
+    private String generateCode() {
+        String today = LocalDate.now().format(CODE_DATE_FORMAT);
+        String prefix = "PO-" + today + "-";
+        long seq = purchaseOrderRepository.countByCodeStartingWith(prefix) + 1;
+        return String.format("%s%03d", prefix, seq);
+    }
+
+    private void appendHistory(PurchaseOrder po, String note) {
+        PurchaseOrderStatusHistory entry = PurchaseOrderStatusHistory.builder()
+                .purchaseOrderId(po.getId())
+                .status(po.getStatus())
+                .changedByName(CHANGED_BY_PLACEHOLDER)
+                .note(note)
+                .build();
+        historyRepository.save(entry);
+    }
+
+    private PurchaseOrderDto.DetailRes buildDetailRes(PurchaseOrder po) {
+        Vendor vendor = vendorRepository.findById(po.getVendorId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+
+        List<PurchaseOrderItem> items = itemRepository.findAllByPurchaseOrderId(po.getId());
+        List<PurchaseOrderStatusHistory> history = historyRepository.findAllByPurchaseOrderIdOrderByChangedAtAsc(po.getId());
+
+        // vendorProductId → vendorProductCode 맵 (FE 친화 응답용)
+        Set<Long> vendorProductIds = items.stream().map(PurchaseOrderItem::getVendorProductId).collect(Collectors.toSet());
+        Map<Long, String> codeMap = new HashMap<>();
+        if (!vendorProductIds.isEmpty()) {
+            vendorProductRepository.findAllById(vendorProductIds)
+                    .forEach(vp -> codeMap.put(vp.getId(), vp.getCode()));
+        }
+
+        return PurchaseOrderDto.DetailRes.from(po, vendor, items, history, codeMap);
+    }
+
+    private Specification<PurchaseOrder> buildSpec(Long vendorId, PurchaseOrderStatus status,
+                                                     LocalDate from, LocalDate to) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (vendorId != null) {
+                predicates.add(cb.equal(root.get("vendorId"), vendorId));
+            }
+            if (status != null) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (from != null) {
+                Date fromDate = Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), fromDate));
+            }
+            if (to != null) {
+                Date toDate = Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+                predicates.add(cb.lessThan(root.get("createdAt"), toDate));
+            }
+            query.orderBy(cb.desc(root.get("createdAt")));
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderStatusHistoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderStatusHistoryRepository.java
@@ -1,0 +1,11 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PurchaseOrderStatusHistoryRepository extends JpaRepository<PurchaseOrderStatusHistory, Long> {
+
+    List<PurchaseOrderStatusHistory> findAllByPurchaseOrderIdOrderByChangedAtAsc(Long purchaseOrderId);
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
@@ -1,0 +1,117 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseEntity;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+
+import java.util.List;
+
+@Entity
+@Table(name = "purchase_order", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_purchase_order_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PurchaseOrder extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "vendor_id", nullable = false)
+    private Long vendorId;
+
+    // 창고 BE 미구현 — logical reference (id String + name 시점 복사)
+    @Column(name = "warehouse_id", length = 32)
+    private String warehouseId;
+
+    @Column(name = "warehouse_name", length = 128)
+    private String warehouseName;
+
+    // 회원 BE 미구현, 인증 미정 — logical reference
+    @Column(name = "member_id", length = 32)
+    private String memberId;
+
+    @Column(name = "member_name", length = 64)
+    private String memberName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private PurchaseOrderStatus status;
+
+    @Column(name = "total_amount", nullable = false)
+    private Long totalAmount;
+
+    @Column(name = "cancel_reason", length = 256)
+    private String cancelReason;
+
+    @Builder
+    private PurchaseOrder(String code, Long vendorId, String warehouseId, String warehouseName,
+                          String memberId, String memberName, Long totalAmount) {
+        this.code = code;
+        this.vendorId = vendorId;
+        this.warehouseId = warehouseId;
+        this.warehouseName = warehouseName;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.totalAmount = totalAmount == null ? 0L : totalAmount;
+        this.status = PurchaseOrderStatus.PENDING;
+    }
+
+    public void markApproved() {
+        if (this.status != PurchaseOrderStatus.PENDING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.APPROVED;
+    }
+
+    public void markShipping() {
+        if (this.status != PurchaseOrderStatus.APPROVED) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.SHIPPING;
+    }
+
+    public void markCompleted() {
+        if (this.status != PurchaseOrderStatus.SHIPPING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.COMPLETED;
+    }
+
+    public void markRejected(String reason) {
+        if (this.status != PurchaseOrderStatus.PENDING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.REJECTED;
+        this.cancelReason = reason;
+    }
+
+    /**
+     * items 교체 + totalAmount 재계산. PENDING 만 허용.
+     * Service 가 기존 items 를 별도로 삭제하고 신규 items 를 save 한 뒤 호출.
+     */
+    public void recalculateTotalAmount(List<PurchaseOrderItem> items) {
+        if (this.status != PurchaseOrderStatus.PENDING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        long sum = items.stream().mapToLong(PurchaseOrderItem::getSubtotal).sum();
+        this.totalAmount = sum;
+    }
+
+    public void updateLogistics(String warehouseId, String warehouseName) {
+        if (this.status != PurchaseOrderStatus.PENDING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        if (warehouseId != null) this.warehouseId = warehouseId;
+        if (warehouseName != null) this.warehouseName = warehouseName;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
@@ -1,0 +1,218 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorProduct;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class PurchaseOrderDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateReq {
+        @NotBlank
+        private String vendorCode;
+        private String warehouseId;
+        private String warehouseName;
+        // 인증 미정 — placeholder OK
+        private String memberId;
+        private String memberName;
+        @Valid
+        @NotEmpty
+        private List<ItemReq> items;
+
+        public PurchaseOrder toEntity(Vendor vendor, String code, Long totalAmount) {
+            return PurchaseOrder.builder()
+                    .code(code)
+                    .vendorId(vendor.getId())
+                    .warehouseId(this.warehouseId)
+                    .warehouseName(this.warehouseName)
+                    .memberId(this.memberId)
+                    .memberName(this.memberName)
+                    .totalAmount(totalAmount)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ItemReq {
+        @NotBlank
+        private String vendorProductCode;
+        @NotNull
+        @Min(1)
+        private Integer quantity;
+
+        public PurchaseOrderItem toEntity(Long purchaseOrderId, VendorProduct vp) {
+            return PurchaseOrderItem.builder()
+                    .purchaseOrderId(purchaseOrderId)
+                    .vendorProductId(vp.getId())
+                    .productCode(vp.getProductCode())
+                    .productName(vp.getProductName())
+                    .unitPrice(vp.getUnitPrice())
+                    .quantity(this.quantity)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateReq {
+        private String warehouseId;
+        private String warehouseName;
+        @Valid
+        @NotEmpty
+        private List<ItemReq> items;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CancelReq {
+        @NotBlank
+        private String cancelReason;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ListRes {
+        private String code;
+        private String vendorCode;
+        private String vendorName;
+        private String warehouseId;
+        private String warehouseName;
+        private String memberName;
+        private PurchaseOrderStatus status;
+        private Long totalAmount;
+        private Integer itemCount;
+        private Date createdAt;
+        private Date updatedAt;
+
+        public static ListRes from(PurchaseOrder po, Vendor vendor, int itemCount) {
+            return ListRes.builder()
+                    .code(po.getCode())
+                    .vendorCode(vendor.getCode())
+                    .vendorName(vendor.getName())
+                    .warehouseId(po.getWarehouseId())
+                    .warehouseName(po.getWarehouseName())
+                    .memberName(po.getMemberName())
+                    .status(po.getStatus())
+                    .totalAmount(po.getTotalAmount())
+                    .itemCount(itemCount)
+                    .createdAt(po.getCreatedAt())
+                    .updatedAt(po.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DetailRes {
+        private String code;
+        private String vendorCode;
+        private String vendorName;
+        private String warehouseId;
+        private String warehouseName;
+        private String memberId;
+        private String memberName;
+        private PurchaseOrderStatus status;
+        private Long totalAmount;
+        private String cancelReason;
+        private Date createdAt;
+        private Date updatedAt;
+        private List<ItemRes> items;
+        private List<HistoryRes> statusHistory;
+
+        public static DetailRes from(PurchaseOrder po, Vendor vendor,
+                                      List<PurchaseOrderItem> items,
+                                      List<PurchaseOrderStatusHistory> history,
+                                      Map<Long, String> vendorProductCodeById) {
+            List<ItemRes> itemRes = items.stream()
+                    .map(item -> ItemRes.from(item, vendorProductCodeById.get(item.getVendorProductId())))
+                    .toList();
+            List<HistoryRes> historyRes = history.stream()
+                    .map(HistoryRes::from)
+                    .toList();
+            return DetailRes.builder()
+                    .code(po.getCode())
+                    .vendorCode(vendor.getCode())
+                    .vendorName(vendor.getName())
+                    .warehouseId(po.getWarehouseId())
+                    .warehouseName(po.getWarehouseName())
+                    .memberId(po.getMemberId())
+                    .memberName(po.getMemberName())
+                    .status(po.getStatus())
+                    .totalAmount(po.getTotalAmount())
+                    .cancelReason(po.getCancelReason())
+                    .createdAt(po.getCreatedAt())
+                    .updatedAt(po.getUpdatedAt())
+                    .items(itemRes)
+                    .statusHistory(historyRes)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ItemRes {
+        private Long vendorProductId;
+        private String vendorProductCode;
+        private String productCode;
+        private String productName;
+        private Long unitPrice;
+        private Integer quantity;
+        private Long subtotal;
+
+        public static ItemRes from(PurchaseOrderItem item, String vendorProductCode) {
+            return ItemRes.builder()
+                    .vendorProductId(item.getVendorProductId())
+                    .vendorProductCode(vendorProductCode)
+                    .productCode(item.getProductCode())
+                    .productName(item.getProductName())
+                    .unitPrice(item.getUnitPrice())
+                    .quantity(item.getQuantity())
+                    .subtotal(item.getSubtotal())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class HistoryRes {
+        private PurchaseOrderStatus status;
+        private Date changedAt;
+        private String changedByName;
+        private String note;
+
+        public static HistoryRes from(PurchaseOrderStatusHistory h) {
+            return HistoryRes.builder()
+                    .status(h.getStatus())
+                    .changedAt(h.getChangedAt())
+                    .changedByName(h.getChangedByName())
+                    .note(h.getNote())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
@@ -1,0 +1,58 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "purchase_order_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PurchaseOrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "purchase_order_id", nullable = false)
+    private Long purchaseOrderId;
+
+    @Column(name = "vendor_product_id", nullable = false)
+    private Long vendorProductId;
+
+    // 마스터 제품 logical reference (시점 복사)
+    @Column(name = "product_code", nullable = false, length = 64)
+    private String productCode;
+
+    @Column(name = "product_name", nullable = false, length = 256)
+    private String productName;
+
+    // 발주 시점 단가 복사
+    @Column(name = "unit_price", nullable = false)
+    private Long unitPrice;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "subtotal", nullable = false)
+    private Long subtotal;
+
+    @Builder
+    private PurchaseOrderItem(Long purchaseOrderId, Long vendorProductId,
+                              String productCode, String productName,
+                              Long unitPrice, Integer quantity) {
+        this.purchaseOrderId = purchaseOrderId;
+        this.vendorProductId = vendorProductId;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.unitPrice = unitPrice;
+        this.quantity = quantity;
+        this.subtotal = unitPrice * quantity;
+    }
+
+    public void linkToPurchaseOrder(Long purchaseOrderId) {
+        this.purchaseOrderId = purchaseOrderId;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
@@ -1,0 +1,5 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+public enum PurchaseOrderStatus {
+    PENDING, APPROVED, SHIPPING, COMPLETED, REJECTED
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatusHistory.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatusHistory.java
@@ -1,0 +1,47 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "purchase_order_status_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PurchaseOrderStatusHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "purchase_order_id", nullable = false)
+    private Long purchaseOrderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private PurchaseOrderStatus status;
+
+    @Column(name = "changed_at", nullable = false)
+    private Date changedAt;
+
+    // 인증 미정 — placeholder, 추후 실제 사용자명
+    @Column(name = "changed_by_name", length = 64)
+    private String changedByName;
+
+    @Column(name = "note", length = 256)
+    private String note;
+
+    @Builder
+    private PurchaseOrderStatusHistory(Long purchaseOrderId, PurchaseOrderStatus status,
+                                        String changedByName, String note) {
+        this.purchaseOrderId = purchaseOrderId;
+        this.status = status;
+        this.changedAt = new Date();
+        this.changedByName = changedByName;
+        this.note = note;
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 본사 발주(CEN-035~040) BE를 **0 → 1로 신규 구현** — `hq.purchaseorder` 패키지에 엔티티 3종(`PurchaseOrder` / `Item` / `StatusHistory`) + 8개 엔드포인트(`/api/hq/purchase-orders` 목록·상세·생성·수정·승인·출고·완료·취소)를 한 번에 구축

<br><br>

## 🎯 작업 내용
- **엔티티 및 상태머신 설계**
  - `PurchaseOrder`, `PurchaseOrderItem`, `PurchaseOrderStatusHistory` 신규 (`hq.purchaseorder` 패키지)
  - 상태 전이 검증을 Entity 의 `markXxx()` 메소드 내부에 캡슐화 → **Service 분기 제거**
  - 부수효과 없는 단순 시그니처로 정리 → 후속 사이클(SYS-001 자동 승인 배치)이 동일 Service 메소드를 그대로 호출 가능
- **API 8종 구현 (`/api/hq/purchase-orders`)**
  - 목록 / 상세 / 생성 / 수정 / 승인 / 출고 / 완료 / 취소
  - 동적 필터(vendorCode / status / from / to)는 **의존성 추가 없이 `JpaSpecificationExecutor`** 로 처리
  - 진행 이력은 별도 테이블 **append-only** 로 적재 (RDB 정석 유지)
- **컨벤션 정합성 (vendor 도메인 패턴 미러링)**
  - `@JoinColumn` 없는 Long FK soft reference
  - DTO inner class `Req` / `Res` 구조
  - `findByCode` lookup 패턴
  - DTO 내부 `toEntity` / `from` 변환 메소드
- **공통 응답 코드 추가** — `BaseResponseStatus` 4300번대 5건
  - `NOT_FOUND`
  - `INVALID_STATUS_TRANSITION`
  - `EMPTY_ITEMS`
  - `VENDOR_PRODUCT_MISMATCH`
  - `CANCEL_REASON_REQUIRED`

<br><br>

## ✔️ 참고 사항
- 마스터 제품·창고·회원 도메인이 아직 미구현 상태 → `productCode` / `warehouseId` / `memberId` 는 **시점 복사 logical reference** 로 처리 (FK 제약 없이 값 보관)
- 상태머신을 Entity에 박아둔 덕에 Service는 단순 위임만 수행 → 추후 자동 승인 배치(SYS-001)에서 동일 메소드 재사용 가능
- vendor 도메인과 동일한 컨벤션을 의도적으로 미러링 — 팀원이 같은 멘탈 모델로 코드 리딩 가능하도록 정합성 유지

<br><br>

## ✔️ 관련 이슈
- Close #118 

<br><br>