### PR TITLE
115 feat 본사 관리자 제품 카테고리 관리

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/WebCorsConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/WebCorsConfig.java
@@ -1,0 +1,18 @@
+package org.example.stockitbe.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebCorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -41,6 +41,12 @@ public enum BaseResponseStatus {
     VENDOR_NOT_FOUND(false, 4200, "거래처를 찾을 수 없습니다."),
     VENDOR_PRODUCT_NOT_FOUND(false, 4201, "공급처별 제품 계약을 찾을 수 없습니다."),
     DUPLICATE_VENDOR_PRODUCT_CODE(false, 4202, "이미 등록된 거래처-제품 코드 조합입니다."),
+    CATEGORY_NOT_FOUND(false, 4203, "카테고리를 찾을 수 없습니다."),
+    DUPLICATE_CATEGORY_NAME(false, 4204, "동일한 범위에 같은 카테고리명이 이미 존재합니다."),
+    CATEGORY_PARENT_REQUIRED(false, 4205, "소분류 등록 시 상위 카테고리가 필요합니다."),
+    CATEGORY_PARENT_NOT_FOUND(false, 4206, "상위 카테고리를 찾을 수 없습니다."),
+    CATEGORY_PARENT_NOT_ROOT(false, 4207, "상위 카테고리는 대분류만 지정할 수 있습니다."),
+    CATEGORY_ROOT_PARENT_DISALLOWED(false, 4208, "대분류는 상위 카테고리를 가질 수 없습니다."),
 
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -47,6 +47,7 @@ public enum BaseResponseStatus {
     CATEGORY_PARENT_NOT_FOUND(false, 4206, "상위 카테고리를 찾을 수 없습니다."),
     CATEGORY_PARENT_NOT_ROOT(false, 4207, "상위 카테고리는 대분류만 지정할 수 있습니다."),
     CATEGORY_ROOT_PARENT_DISALLOWED(false, 4208, "대분류는 상위 카테고리를 가질 수 없습니다."),
+    CATEGORY_DELETE_HAS_CHILDREN(false, 4209, "하위 카테고리가 존재하여 삭제할 수 없습니다."),
 
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryController.java
@@ -29,4 +29,16 @@ public class CategoryController {
     public BaseResponse<CategoryDto.DetailRes> create(@Valid @RequestBody CategoryDto.CreateReq req) {
         return BaseResponse.success(service.create(req));
     }
+
+    @PatchMapping("/{code}")
+    public BaseResponse<CategoryDto.DetailRes> update(@PathVariable String code,
+                                                      @Valid @RequestBody CategoryDto.UpdateReq req) {
+        return BaseResponse.success(service.update(code, req));
+    }
+
+    @DeleteMapping("/{code}")
+    public BaseResponse<Void> delete(@PathVariable String code) {
+        service.delete(code);
+        return BaseResponse.success(null);
+    }
 }

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryController.java
@@ -1,0 +1,32 @@
+package org.example.stockitbe.hq.category;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.category.model.CategoryDto;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService service;
+
+    @GetMapping
+    public BaseResponse<List<CategoryDto.TreeRes>> list() {
+        return BaseResponse.success(service.findAllTree());
+    }
+
+    @GetMapping("/{code}")
+    public BaseResponse<CategoryDto.DetailRes> detail(@PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code));
+    }
+
+    @PostMapping
+    public BaseResponse<CategoryDto.DetailRes> create(@Valid @RequestBody CategoryDto.CreateReq req) {
+        return BaseResponse.success(service.create(req));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryRepository.java
@@ -10,6 +10,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByCode(String code);
 
+    List<Category> findAllByOrderByIdAsc();
+
     List<Category> findAllByParentIdIsNullOrderBySortOrderAscIdAsc();
 
     List<Category> findAllByParentIdOrderBySortOrderAscIdAsc(Long parentId);
@@ -17,6 +19,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByParentIdIsNullAndNameIgnoreCase(String name);
 
     boolean existsByParentIdAndNameIgnoreCase(Long parentId, String name);
+
+    boolean existsByParentIdIsNullAndNameIgnoreCaseAndIdNot(String name, Long id);
+
+    boolean existsByParentIdAndNameIgnoreCaseAndIdNot(Long parentId, String name, Long id);
+
+    boolean existsByParentId(Long parentId);
 
     long countByParentIdIsNull();
 

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryRepository.java
@@ -1,0 +1,26 @@
+package org.example.stockitbe.hq.category;
+
+import org.example.stockitbe.hq.category.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByCode(String code);
+
+    List<Category> findAllByParentIdIsNullOrderBySortOrderAscIdAsc();
+
+    List<Category> findAllByParentIdOrderBySortOrderAscIdAsc(Long parentId);
+
+    boolean existsByParentIdIsNullAndNameIgnoreCase(String name);
+
+    boolean existsByParentIdAndNameIgnoreCase(Long parentId, String name);
+
+    long countByParentIdIsNull();
+
+    long countByParentId(Long parentId);
+
+    long count();
+}

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryService.java
@@ -6,15 +6,19 @@ import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.category.model.Category;
 import org.example.stockitbe.hq.category.model.CategoryDto;
 import org.example.stockitbe.hq.category.model.CategoryLevel;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
+    private static final Pattern CATEGORY_CODE_PATTERN = Pattern.compile("^CAT-(\\d{4,})$");
 
     private final CategoryRepository categoryRepository;
 
@@ -49,18 +53,50 @@ public class CategoryService {
     public CategoryDto.DetailRes create(CategoryDto.CreateReq req) {
         if (req.getLevel() == CategoryLevel.ROOT) {
             validateRootCreate(req);
-            String code = generateCode();
             int sortOrder = (int) categoryRepository.countByParentIdIsNull() + 1;
-            Category saved = categoryRepository.save(req.toEntity(code, null, sortOrder));
+            Category saved = saveWithGeneratedCode(req, null, sortOrder);
             return CategoryDto.DetailRes.from(saved, null);
         }
 
         Category parent = resolveParent(req.getParentCode());
         validateChildCreate(req, parent);
-        String code = generateCode();
         int sortOrder = (int) categoryRepository.countByParentId(parent.getId()) + 1;
-        Category saved = categoryRepository.save(req.toEntity(code, parent.getId(), sortOrder));
+        Category saved = saveWithGeneratedCode(req, parent.getId(), sortOrder);
         return CategoryDto.DetailRes.from(saved, parent.getCode());
+    }
+
+    @Transactional
+    public CategoryDto.DetailRes update(String code, CategoryDto.UpdateReq req) {
+        Category category = lookupCategory(code);
+        String normalizedName = req.getName().trim();
+
+        if (category.getLevel() == CategoryLevel.ROOT) {
+            boolean duplicated = categoryRepository
+                    .existsByParentIdIsNullAndNameIgnoreCaseAndIdNot(normalizedName, category.getId());
+            if (duplicated) {
+                throw BaseException.from(BaseResponseStatus.DUPLICATE_CATEGORY_NAME);
+            }
+        } else {
+            boolean duplicated = categoryRepository
+                    .existsByParentIdAndNameIgnoreCaseAndIdNot(category.getParentId(), normalizedName, category.getId());
+            if (duplicated) {
+                throw BaseException.from(BaseResponseStatus.DUPLICATE_CATEGORY_NAME);
+            }
+        }
+
+        category.updateInfo(normalizedName, req.getStatus());
+        String parentCode = resolveParentCode(category);
+        return CategoryDto.DetailRes.from(category, parentCode);
+    }
+
+    @Transactional
+    public void delete(String code) {
+        Category category = lookupCategory(code);
+        if (category.getLevel() == CategoryLevel.ROOT
+                && categoryRepository.existsByParentId(category.getId())) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_DELETE_HAS_CHILDREN);
+        }
+        categoryRepository.delete(category);
     }
 
     private void validateRootCreate(CategoryDto.CreateReq req) {
@@ -96,8 +132,46 @@ public class CategoryService {
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND));
     }
 
+    private String resolveParentCode(Category category) {
+        if (category.getParentId() == null) {
+            return null;
+        }
+        Category parent = categoryRepository.findById(category.getParentId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.CATEGORY_PARENT_NOT_FOUND));
+        return parent.getCode();
+    }
+
     private String generateCode() {
-        long seq = categoryRepository.count() + 1;
-        return String.format("CAT-%04d", seq);
+        long maxSeq = categoryRepository.findAllByOrderByIdAsc().stream()
+                .map(Category::getCode)
+                .mapToLong(this::extractSeq)
+                .max()
+                .orElse(0L);
+        return String.format("CAT-%04d", maxSeq + 1);
+    }
+
+    private long extractSeq(String code) {
+        if (code == null) return 0L;
+        Matcher matcher = CATEGORY_CODE_PATTERN.matcher(code.trim());
+        if (!matcher.matches()) return 0L;
+        try {
+            return Long.parseLong(matcher.group(1));
+        } catch (NumberFormatException ignored) {
+            return 0L;
+        }
+    }
+
+    private Category saveWithGeneratedCode(CategoryDto.CreateReq req, Long parentId, int sortOrder) {
+        for (int attempt = 0; attempt < 2; attempt++) {
+            String code = generateCode();
+            try {
+                return categoryRepository.save(req.toEntity(code, parentId, sortOrder));
+            } catch (DataIntegrityViolationException e) {
+                if (attempt == 1) {
+                    throw e;
+                }
+            }
+        }
+        throw BaseException.from(BaseResponseStatus.FAIL);
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/category/CategoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/category/CategoryService.java
@@ -1,0 +1,103 @@
+package org.example.stockitbe.hq.category;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.category.model.Category;
+import org.example.stockitbe.hq.category.model.CategoryDto;
+import org.example.stockitbe.hq.category.model.CategoryLevel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<CategoryDto.TreeRes> findAllTree() {
+        List<Category> roots = categoryRepository.findAllByParentIdIsNullOrderBySortOrderAscIdAsc();
+        List<CategoryDto.TreeRes> result = new ArrayList<>();
+
+        for (Category root : roots) {
+            List<Category> children = categoryRepository.findAllByParentIdOrderBySortOrderAscIdAsc(root.getId());
+            List<CategoryDto.TreeRes> childRes = children.stream()
+                    .map(child -> CategoryDto.TreeRes.from(child, root.getCode(), List.of()))
+                    .toList();
+            result.add(CategoryDto.TreeRes.from(root, null, childRes));
+        }
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryDto.DetailRes findByCode(String code) {
+        Category category = lookupCategory(code);
+        String parentCode = null;
+        if (category.getParentId() != null) {
+            Category parent = categoryRepository.findById(category.getParentId())
+                    .orElseThrow(() -> BaseException.from(BaseResponseStatus.CATEGORY_PARENT_NOT_FOUND));
+            parentCode = parent.getCode();
+        }
+        return CategoryDto.DetailRes.from(category, parentCode);
+    }
+
+    @Transactional
+    public CategoryDto.DetailRes create(CategoryDto.CreateReq req) {
+        if (req.getLevel() == CategoryLevel.ROOT) {
+            validateRootCreate(req);
+            String code = generateCode();
+            int sortOrder = (int) categoryRepository.countByParentIdIsNull() + 1;
+            Category saved = categoryRepository.save(req.toEntity(code, null, sortOrder));
+            return CategoryDto.DetailRes.from(saved, null);
+        }
+
+        Category parent = resolveParent(req.getParentCode());
+        validateChildCreate(req, parent);
+        String code = generateCode();
+        int sortOrder = (int) categoryRepository.countByParentId(parent.getId()) + 1;
+        Category saved = categoryRepository.save(req.toEntity(code, parent.getId(), sortOrder));
+        return CategoryDto.DetailRes.from(saved, parent.getCode());
+    }
+
+    private void validateRootCreate(CategoryDto.CreateReq req) {
+        if (req.getParentCode() != null && !req.getParentCode().isBlank()) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_ROOT_PARENT_DISALLOWED);
+        }
+        boolean duplicated = categoryRepository.existsByParentIdIsNullAndNameIgnoreCase(req.getName().trim());
+        if (duplicated) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_CATEGORY_NAME);
+        }
+    }
+
+    private void validateChildCreate(CategoryDto.CreateReq req, Category parent) {
+        boolean duplicated = categoryRepository.existsByParentIdAndNameIgnoreCase(parent.getId(), req.getName().trim());
+        if (duplicated) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_CATEGORY_NAME);
+        }
+    }
+
+    private Category resolveParent(String parentCode) {
+        if (parentCode == null || parentCode.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_PARENT_REQUIRED);
+        }
+        Category parent = lookupCategory(parentCode);
+        if (parent.getLevel() != CategoryLevel.ROOT) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_PARENT_NOT_ROOT);
+        }
+        return parent;
+    }
+
+    private Category lookupCategory(String code) {
+        return categoryRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND));
+    }
+
+    private String generateCode() {
+        long seq = categoryRepository.count() + 1;
+        return String.format("CAT-%04d", seq);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/category/model/Category.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/Category.java
@@ -1,0 +1,52 @@
+package org.example.stockitbe.hq.category.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "category", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_category_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 64)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level", nullable = false, length = 16)
+    private CategoryLevel level;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private CategoryStatus status;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Builder
+    private Category(String code, String name, CategoryLevel level, Long parentId,
+                     CategoryStatus status, Integer sortOrder) {
+        this.code = code;
+        this.name = name;
+        this.level = level;
+        this.parentId = parentId;
+        this.status = status == null ? CategoryStatus.ACTIVE : status;
+        this.sortOrder = sortOrder == null ? 0 : sortOrder;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/category/model/Category.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/Category.java
@@ -49,4 +49,13 @@ public class Category extends BaseEntity {
         this.status = status == null ? CategoryStatus.ACTIVE : status;
         this.sortOrder = sortOrder == null ? 0 : sortOrder;
     }
+
+    public void updateInfo(String name, CategoryStatus status) {
+        if (name != null && !name.isBlank()) {
+            this.name = name.trim();
+        }
+        if (status != null) {
+            this.status = status;
+        }
+    }
 }

--- a/src/main/java/org/example/stockitbe/hq/category/model/CategoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/CategoryDto.java
@@ -36,6 +36,17 @@ public class CategoryDto {
     }
 
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateReq {
+        @NotBlank
+        private String name;
+        @NotNull
+        private CategoryStatus status;
+    }
+
+    @Getter
     @AllArgsConstructor
     @Builder
     public static class TreeRes {

--- a/src/main/java/org/example/stockitbe/hq/category/model/CategoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/CategoryDto.java
@@ -1,0 +1,87 @@
+package org.example.stockitbe.hq.category.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class CategoryDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateReq {
+        @NotBlank
+        private String name;
+        @NotNull
+        private CategoryLevel level;
+        private String parentCode;
+        @NotNull
+        private CategoryStatus status;
+
+        public Category toEntity(String code, Long parentId, Integer sortOrder) {
+            return Category.builder()
+                    .code(code)
+                    .name(this.name.trim())
+                    .level(this.level)
+                    .parentId(parentId)
+                    .status(this.status)
+                    .sortOrder(sortOrder)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class TreeRes {
+        private String code;
+        private String name;
+        private CategoryLevel level;
+        private CategoryStatus status;
+        private String parentCode;
+        private Date updatedAt;
+        private List<TreeRes> children;
+
+        public static TreeRes from(Category category, String parentCode, List<TreeRes> children) {
+            return TreeRes.builder()
+                    .code(category.getCode())
+                    .name(category.getName())
+                    .level(category.getLevel())
+                    .status(category.getStatus())
+                    .parentCode(parentCode)
+                    .updatedAt(category.getUpdatedAt())
+                    .children(children == null ? Collections.emptyList() : children)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DetailRes {
+        private String code;
+        private String name;
+        private CategoryLevel level;
+        private CategoryStatus status;
+        private String parentCode;
+        private Date createdAt;
+        private Date updatedAt;
+
+        public static DetailRes from(Category category, String parentCode) {
+            return DetailRes.builder()
+                    .code(category.getCode())
+                    .name(category.getName())
+                    .level(category.getLevel())
+                    .status(category.getStatus())
+                    .parentCode(parentCode)
+                    .createdAt(category.getCreatedAt())
+                    .updatedAt(category.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/category/model/CategoryLevel.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/CategoryLevel.java
@@ -1,0 +1,6 @@
+package org.example.stockitbe.hq.category.model;
+
+public enum CategoryLevel {
+    ROOT,
+    CHILD
+}

--- a/src/main/java/org/example/stockitbe/hq/category/model/CategoryStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/CategoryStatus.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.hq.category.model;
+
+public enum CategoryStatus {
+    ACTIVE,
+    SUSPENDED,
+    INACTIVE
+}


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 카테고리 도메인에 등록/조회에 이어 수정/삭제 API를 추가했습니다.
- 카테고리 코드 생성 충돌 이슈를 보완해 중복 코드 예외 재발 가능성을 낮췄습니다.

<br><br>

## 🎯 작업 내용
- `PATCH /api/hq/categories/{code}` 추가: 카테고리 이름/상태 수정
- `DELETE /api/hq/categories/{code}` 추가: 카테고리 하드 삭제
- 삭제 정책 반영: 대분류(ROOT)는 하위 카테고리 존재 시 삭제 차단, 소분류(CHILD)는 삭제 허용
- 중복 검증 보강: 수정 시 동일 부모 범위 내 이름 중복 검사(자기 자신 제외)
- 코드 생성 보강: `count()+1` 방식 제거, 기존 코드 최대 시퀀스 기반 생성 + 유니크 충돌 시 재시도 로직 추가
- `Category`, `CategoryDto`, `CategoryRepository`, `CategoryService`, `CategoryController`, `BaseResponseStatus` 확장

<br><br>

## ✔️ 참고 사항
- 카테고리 삭제는 소프트 삭제가 아닌 하드 삭제로 구현되어 데이터가 실제 제거됩니다.
- 기존 카테고리 코드 형식(`CAT-0001`)을 유지하면서 최대 시퀀스 기준으로 다음 코드를 발급합니다.

<br><br>

## ✔️ 관련 이슈

- Close #115

<br><br>
