### PR TITLE
feat: 새 발주 페이지 거래처 품목 조회

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductController.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.vendor.model.VendorProductDto;
+import org.example.stockitbe.hq.vendor.model.VendorProductStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,8 +17,13 @@ public class VendorProductController {
     private final VendorProductService service;
 
     @GetMapping
-    public BaseResponse<List<VendorProductDto.ListRes>> list(@RequestParam String vendorCode) {
-        return BaseResponse.success(service.findByVendor(vendorCode));
+    public BaseResponse<List<VendorProductDto.ListRes>> list(
+            @RequestParam(required = false) String vendorCode,
+            @RequestParam(required = false) VendorProductStatus status) {
+        if (vendorCode != null && !vendorCode.isBlank()) {
+            return BaseResponse.success(service.findByVendor(vendorCode));
+        }
+        return BaseResponse.success(service.findAll(status));
     }
 
     @GetMapping("/{code}")

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductRepository.java
@@ -13,6 +13,10 @@ public interface VendorProductRepository extends JpaRepository<VendorProduct, Lo
 
     List<VendorProduct> findAllByVendorIdAndStatusNotOrderByIdDesc(Long vendorId, VendorProductStatus excluded);
 
+    List<VendorProduct> findAllByStatusOrderByIdDesc(VendorProductStatus status);
+
+    List<VendorProduct> findAllByStatusNotOrderByIdDesc(VendorProductStatus excluded);
+
     boolean existsByVendorIdAndProductCodeAndStatusNot(Long vendorId, String productCode, VendorProductStatus excluded);
 
     long countByVendorId(Long vendorId);

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +29,36 @@ public class VendorProductService {
                 .findAllByVendorIdAndStatusNotOrderByIdDesc(vendor.getId(), VendorProductStatus.DELETED);
         return list.stream()
                 .map(vp -> VendorProductDto.ListRes.from(vp, vendor))
+                .toList();
+    }
+
+    /**
+     * 전체 거래처의 제품 일괄 조회 (CEN-035 발주 작성 페이지 카탈로그용).
+     * statusFilter == null → DELETED 만 제외한 전체.
+     * statusFilter != null → 정확히 그 status 만 (DELETED 도 호출자가 의도하면 그대로 통과).
+     */
+    @Transactional(readOnly = true)
+    public List<VendorProductDto.ListRes> findAll(VendorProductStatus statusFilter) {
+        List<VendorProduct> list = (statusFilter == null)
+                ? vendorProductRepository.findAllByStatusNotOrderByIdDesc(VendorProductStatus.DELETED)
+                : vendorProductRepository.findAllByStatusOrderByIdDesc(statusFilter);
+        if (list.isEmpty()) {
+            return List.of();
+        }
+
+        // N+1 방지 — vendorIds 일괄 lookup
+        Set<Long> vendorIds = list.stream().map(VendorProduct::getVendorId).collect(Collectors.toSet());
+        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
+                .collect(Collectors.toMap(Vendor::getId, v -> v));
+
+        return list.stream()
+                .map(vp -> {
+                    Vendor vendor = vendorMap.get(vp.getVendorId());
+                    if (vendor == null) {
+                        throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
+                    }
+                    return VendorProductDto.ListRes.from(vp, vendor);
+                })
                 .toList();
     }
 


### PR DESCRIPTION
## 📌 요약
- 발주 작성 페이지(CEN-035) 카탈로그가 **모든 거래처의 활성 제품을 단일 호출로 수신**할 수 있도록 `GET /api/vendor-products` 시그니처 확장
- `vendorCode`를 optional로 변경하고 `status` 필터 파라미터 추가

<br><br>

## 🎯 작업 내용
- **엔드포인트 시그니처 확장 (`GET /api/vendor-products`)**
  - `vendorCode` 파라미터 → **optional** 처리
  - `status` 필터 파라미터 신규 추가 (활성 제품만 조회 가능)
- **Service 분기 처리**
  - `vendorCode` 존재 시 → 기존 단일 거래처 조회 흐름 그대로 유지 (하위 호환)
  - `vendorCode` 미존재 시 → 신규 `findAll` 분기로 흐름 분기
- **N+1 회피 처리**
  - 결과로 추출된 `vendorIds`(또는 vendorCodes)를 **일괄 lookup**해 응답 조립
  - 거래처 정보(name 등)가 결합되는 응답에서 거래처 수만큼 쿼리가 폭발하지 않도록 단일 IN 조회로 처리

<br><br>

## ✔️ 참고 사항
- 기존 `vendorCode` 기반 호출(거래처 관리 화면)은 시그니처 변경 없이 그대로 동작 — **하위 호환 유지**
- `status` 기본값은 미지정 시 전체 노출 → FE는 발주 작성 카탈로그에서 `ACTIVE`로 명시 호출
- vendor 도메인 응답 매핑 컨벤션(code↔id, status 대문자) 변경 없음

<br><br>

## ✔️ 관련 이슈
- Close #132 