### PR TITLE
feat(purchase-order): 본사 발주 자동 전환 배치 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/StockitBeApplication.java
+++ b/src/main/java/org/example/stockitbe/StockitBeApplication.java
@@ -2,8 +2,10 @@ package org.example.stockitbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class StockitBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
@@ -1,0 +1,26 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * SYS-001 본사 발주 자동 전환 스케줄러.
+ *
+ * fixedDelay 주기로 {@link PurchaseOrderBatchService#run(boolean)} 을 시간 조건 모드(force=false)로 호출.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseOrderAutoTransitionScheduler {
+
+    private final PurchaseOrderBatchService batchService;
+
+    @Scheduled(fixedDelayString = "${purchase-order.batch.delay-ms:300000}")
+    public void run() {
+        log.info("[SYS-001] 배치 시작");
+        PurchaseOrderBatchService.BatchResult result = batchService.run(false);
+        log.info("[SYS-001] 배치 완료 — approved={}, shipping={}", result.approved(), result.shipping());
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchController.java
@@ -1,0 +1,26 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * SYS-001 강제 트리거 — 시연·QA·장애 대응용.
+ *
+ * 시간 조건(wait-minutes)을 무시하고 모든 PENDING/APPROVED 발주를 즉시 다음 단계로 전환한다.
+ * 운영 환경에서는 {@link PurchaseOrderAutoTransitionScheduler} 가 5분마다 자동 호출.
+ */
+@RestController
+@RequestMapping("/api/hq/purchase-orders/batch")
+@RequiredArgsConstructor
+public class PurchaseOrderBatchController {
+
+    private final PurchaseOrderBatchService batchService;
+
+    @PostMapping("/run")
+    public BaseResponse<PurchaseOrderBatchService.BatchResult> run() {
+        return BaseResponse.success(batchService.run(true));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
@@ -1,0 +1,66 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * SYS-001 본사 발주 자동 전환 배치 서비스.
+ *
+ * 5분 주기 스케줄러({@link PurchaseOrderAutoTransitionScheduler}) 와 시연용 강제 트리거
+ * 컨트롤러({@link PurchaseOrderBatchController}) 모두 이 서비스의 {@link #run(boolean)} 을 호출한다.
+ *
+ * 1건 1트랜잭션 — {@link PurchaseOrderService#approve(String)} / {@link PurchaseOrderService#startShipping(String)}
+ * 가 자체 {@code @Transactional} 이므로 이 클래스에는 트랜잭션 어노테이션을 절대 달지 않는다.
+ * 한 건 실패는 try/catch 로 격리하고 다음 건을 계속 처리한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseOrderBatchService {
+
+    private final PurchaseOrderRepository repo;
+    private final PurchaseOrderService service;
+
+    @Value("${purchase-order.batch.wait-minutes:30}")
+    private long waitMinutes;
+
+    /**
+     * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 모든 PENDING/APPROVED 즉시 처리.
+     *              false 면 {@code updatedAt < now - waitMinutes} 인 건만.
+     */
+    public BatchResult run(boolean force) {
+        int approved = autoTransition(PurchaseOrderStatus.PENDING,  force, code -> service.approve(code));
+        int shipping = autoTransition(PurchaseOrderStatus.APPROVED, force, code -> service.startShipping(code));
+        return new BatchResult(approved, shipping);
+    }
+
+    private int autoTransition(PurchaseOrderStatus from, boolean force, Consumer<String> action) {
+        List<PurchaseOrder> targets = force
+                ? repo.findAllByStatus(from)
+                : repo.findAllByStatusAndUpdatedAtBefore(
+                        from,
+                        Date.from(Instant.now().minus(Duration.ofMinutes(waitMinutes))));
+        int success = 0;
+        for (PurchaseOrder po : targets) {
+            try {
+                action.accept(po.getCode());
+                success++;
+            } catch (Exception e) {
+                log.warn("[SYS-001] 자동 전환 실패 from={} code={}", from, po.getCode(), e);
+            }
+        }
+        return success;
+    }
+
+    public record BatchResult(int approved, int shipping) {}
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
@@ -43,16 +43,6 @@ public class PurchaseOrderController {
         return BaseResponse.success(service.update(code, req));
     }
 
-    @PostMapping("/{code}/approve")
-    public BaseResponse<PurchaseOrderDto.DetailRes> approve(@PathVariable String code) {
-        return BaseResponse.success(service.approve(code));
-    }
-
-    @PostMapping("/{code}/start-shipping")
-    public BaseResponse<PurchaseOrderDto.DetailRes> startShipping(@PathVariable String code) {
-        return BaseResponse.success(service.startShipping(code));
-    }
-
     @PostMapping("/{code}/complete")
     public BaseResponse<PurchaseOrderDto.DetailRes> complete(@PathVariable String code) {
         return BaseResponse.success(service.complete(code));

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
@@ -1,9 +1,12 @@
 package org.example.stockitbe.hq.purchaseorder;
 
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>,
@@ -12,4 +15,9 @@ public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Lo
     Optional<PurchaseOrder> findByCode(String code);
 
     long countByCodeStartingWith(String prefix);
+
+    // SYS-001 배치용
+    List<PurchaseOrder> findAllByStatus(PurchaseOrderStatus status);
+
+    List<PurchaseOrder> findAllByStatusAndUpdatedAtBefore(PurchaseOrderStatus status, Date cutoff);
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 public class PurchaseOrderService {
 
     private static final String CHANGED_BY_PLACEHOLDER = "본사 관리자";
+    private static final String SYSTEM_BATCH_ACTOR = "시스템(SYS-001)";
     private static final DateTimeFormatter CODE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final PurchaseOrderRepository purchaseOrderRepository;
@@ -228,10 +229,14 @@ public class PurchaseOrderService {
     }
 
     private void appendHistory(PurchaseOrder po, String note) {
+        String changedByName = switch (po.getStatus()) {
+            case APPROVED, SHIPPING -> SYSTEM_BATCH_ACTOR;
+            default -> CHANGED_BY_PLACEHOLDER;
+        };
         PurchaseOrderStatusHistory entry = PurchaseOrderStatusHistory.builder()
                 .purchaseOrderId(po.getId())
                 .status(po.getStatus())
-                .changedByName(CHANGED_BY_PLACEHOLDER)
+                .changedByName(changedByName)
                 .note(note)
                 .build();
         historyRepository.save(entry);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,9 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+# SYS-001 본사 발주 자동 전환 배치
+purchase-order:
+  batch:
+    delay-ms: 300000      # 스케줄러 fixedDelay (5분)
+    wait-minutes: 1       # dev 에선 짧게 (시연·테스트 편의)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,9 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+# SYS-001 본사 발주 자동 전환 배치
+purchase-order:
+  batch:
+    delay-ms: 300000      # 스케줄러 fixedDelay (5분)
+    wait-minutes: 30      # PENDING/APPROVED 30분 경과 시 자동 전환


### PR DESCRIPTION
## 📌 요약
- SYS-001 배치(`@Scheduled` 5분 주기)가 30분 경과한 PENDING/APPROVED 발주를 자동 전환하도록 구현
- ADR-013 임시 hack(본사 단건 트리거 2종) 영구 정리

<br><br>

## 🎯 작업 내용
- `PurchaseOrderBatchService` 신규 — **1건 1트랜잭션**으로 `service.approve` / `startShipping` 호출, 1건 실패 try/catch 격리
- `PurchaseOrderAutoTransitionScheduler` 신규 — `@Scheduled fixedDelay` 5분 주기
- 시연·QA용 `POST /batch/run` 추가 — `force=true`로 시간 조건 무시
- 본사 단건 컨트롤러 메소드 2개(`approve` / `startShipping`) 제거 (Service 메소드는 배치가 호출하므로 유지)
- 진행 이력 `changedByName` — 배치 전환 시 `"시스템(SYS-001)"` 기록
- 대기 시간 외부화: `application*.yml` 의 `purchase-order.batch.wait-minutes` (dev=1분, prod=30분)

<br><br>

## ✔️ 참고 사항
- BatchService에는 `@Transactional` 미부여 — Service 메소드 자체 트랜잭션을 활용한 1건 1트랜잭션 보장
- 본사가 자기 발주를 자기가 승인하던 도메인 위반 영구 해결

<br><br>

## ✔️ 관련 이슈
- Close #135 

<br><br>