### PR TITLE
feat(inbound): 창고 관리자 입고 BE 도메인 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
@@ -1,0 +1,50 @@
+package org.example.stockitbe.warehouse.inbound;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * WHS-005/007/008 — 창고 관리자 입고 컨트롤러.
+ *
+ * 권한군 prefix: /api/warehouse/...
+ * 인증 미정(ADR-011) 이라 warehouseId 는 query 파라미터로 받음 — 임시 신뢰 모델.
+ * 인증 도입 시 @AuthenticationPrincipal 로 me.warehouseId 자동 주입으로 마이그레이션.
+ */
+@RestController
+@RequestMapping("/api/warehouse/inbound")
+@RequiredArgsConstructor
+public class InboundController {
+
+    private final InboundService service;
+
+    @GetMapping
+    public BaseResponse<List<PurchaseOrderDto.ListRes>> list(
+            @RequestParam(required = false) PurchaseOrderStatus status,
+            @RequestParam(required = false) String warehouseId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return BaseResponse.success(service.findAll(status, warehouseId, from, to));
+    }
+
+    @GetMapping("/{code}")
+    public BaseResponse<PurchaseOrderDto.DetailRes> detail(@PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code));
+    }
+
+    @PostMapping("/{code}/confirm")
+    public BaseResponse<PurchaseOrderDto.DetailRes> confirm(@PathVariable String code) {
+        return BaseResponse.success(service.confirm(code));
+    }
+}

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -1,0 +1,60 @@
+package org.example.stockitbe.warehouse.inbound;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.hq.purchaseorder.PurchaseOrderService;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * WHS-005/007/008 — 창고 관리자 입고 도메인 (thin layer).
+ *
+ * 별 테이블 만들지 않고 PurchaseOrder + statusHistory 단일 진실 원천 활용 (ADR-015).
+ * PurchaseOrderService 메소드를 위임 호출만 한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class InboundService {
+
+    private final PurchaseOrderService purchaseOrderService;
+
+    /**
+     * 입고 목록 — 창고 관심사는 SHIPPING/COMPLETED 만.
+     * status 미지정 시 두 상태 모두, 지정 시 그 status 만 (SHIPPING/COMPLETED 외엔 빈 결과).
+     */
+    @Transactional(readOnly = true)
+    public List<PurchaseOrderDto.ListRes> findAll(PurchaseOrderStatus status,
+                                                    String warehouseId,
+                                                    LocalDate from, LocalDate to) {
+        // PurchaseOrderService.findAll 의 시그니처: (vendorCode, status, from, to).
+        // vendorCode 는 창고 관심사 아니므로 null. status 가 PENDING/APPROVED/REJECTED 등 비-입고 상태면
+        // 위임이 그 status 결과를 줄 텐데, isInboundStatus 필터로 빈 결과 보장.
+        List<PurchaseOrderDto.ListRes> all = purchaseOrderService.findAll(null, status, from, to);
+        return all.stream()
+                .filter(po -> isInboundStatus(po.getStatus()))
+                .filter(po -> warehouseId == null || warehouseId.isBlank()
+                        || warehouseId.equals(po.getWarehouseId()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PurchaseOrderDto.DetailRes findByCode(String code) {
+        return purchaseOrderService.findByCode(code);
+    }
+
+    /**
+     * 입고 확정 (WHS-007) — SHIPPING → COMPLETED.
+     * 상태 검증·전환·history append 는 PurchaseOrder.markCompleted + Service.appendHistory 가 처리.
+     */
+    public PurchaseOrderDto.DetailRes confirm(String code) {
+        return purchaseOrderService.complete(code);
+    }
+
+    private static boolean isInboundStatus(PurchaseOrderStatus s) {
+        return s == PurchaseOrderStatus.SHIPPING || s == PurchaseOrderStatus.COMPLETED;
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 창고가 본사 권한군 API(`POST /api/hq/purchase-orders/{code}/complete`)를 호출하던 도메인 위반 구조 해소
- `org.example.stockitbe.warehouse.inbound` 패키지 신설(warehouse/ 첫 패키지) — **thin layer**로만 구성, PurchaseOrderService 위임 호출

<br><br>

## 🎯 작업 내용
- **패키지 / 엔드포인트 신설**
  - `org.example.stockitbe.warehouse.inbound` 패키지 신규 (warehouse 도메인 첫 패키지)
  - `InboundController` — `/api/warehouse/inbound` 3종 노출 (`GET` 목록 / `GET {code}` 상세 / `POST {code}/confirm`)
  - 모든 응답은 기존 컨벤션대로 `BaseResponse` 래핑
- **Thin Layer 위임 구조**
  - `InboundService`가 `PurchaseOrderService`를 주입받아 `findAll` / `findByCode` / `complete`를 위임 호출
  - 별도 Entity / Repository / 테이블 / DTO **추가하지 않음**
  - `PurchaseOrderDto.ListRes` / `DetailRes`를 cross-package로 재사용
- **ADR-015 정합 유지 — 단일 진실 원천**
  - PurchaseOrder + statusHistory 단일 출처 그대로 유지 → DB 스키마 변경 **0건**
  - 검수 정보 / 사진 / 사유 필드 추가하지 않음 (ADR-015의 WHS-006 제외 결정과 정합)
- **목록 필터링 / 인증 임시 처리**
  - `findAll`은 SHIPPING / COMPLETED 상태만 in-memory 필터링
  - `warehouseId`는 인증 미정(ADR-011)으로 인해 **임시 query 파라미터**로 수신 → 인증 도입 시 `me.warehouseId` 자동 주입 마이그레이션 예정

<br><br>

## ✔️ 참고 사항
- 본 PR은 **BE 신설**만 다루며, FE는 후속 PR에서 신규 prefix(`/api/warehouse/inbound`)로 호출 경로 갈아끼움
- thin layer로만 둔 의도 — 권한군 분리는 정합 확보하되, 도메인 로직 중복 / 단일 진실 원천 위반은 회피
- 인증 도입 전까지 `warehouseId` query 파라미터는 임시 — 도입 후 동일 시그니처에서 자동 주입 방식으로 전환

<br><br>

## ✔️ 관련 이슈
- Close #137 

<br><br>