### PR TITLE
feat: 본사 관리자 제품 마스터 API 및 SKU 관리 기능 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -48,6 +48,15 @@ public enum BaseResponseStatus {
     CATEGORY_PARENT_NOT_ROOT(false, 4207, "상위 카테고리는 대분류만 지정할 수 있습니다."),
     CATEGORY_ROOT_PARENT_DISALLOWED(false, 4208, "대분류는 상위 카테고리를 가질 수 없습니다."),
     CATEGORY_DELETE_HAS_CHILDREN(false, 4209, "하위 카테고리가 존재하여 삭제할 수 없습니다."),
+    STORE_NOT_FOUND(false, 4210, "매장을 찾을 수 없습니다."),
+    WAREHOUSE_NOT_FOUND(false, 4211, "창고를 찾을 수 없습니다."),
+    DUPLICATE_STORE_NAME(false, 4212, "이미 등록된 매장명입니다."),
+    DUPLICATE_WAREHOUSE_NAME(false, 4213, "이미 등록된 창고명입니다."),
+    PRODUCT_MASTER_NOT_FOUND(false, 4214, "제품 마스터를 찾을 수 없습니다."),
+    PRODUCT_SKU_NOT_FOUND(false, 4215, "SKU를 찾을 수 없습니다."),
+    DUPLICATE_PRODUCT_MASTER_NAME(false, 4216, "이미 등록된 제품명입니다."),
+    DUPLICATE_PRODUCT_SKU_OPTION(false, 4217, "이미 등록된 SKU 옵션입니다."),
+    INVALID_SKU_PRICE(false, 4218, "SKU 가격은 0 이상이어야 합니다."),
 
     // 4300번대~ 본사 발주 (CEN-035~040)
     PURCHASE_ORDER_NOT_FOUND(false, 4300, "본사 발주를 찾을 수 없습니다."),

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureController.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureController.java
@@ -1,0 +1,54 @@
+package org.example.stockitbe.hq.infrastructure;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.infrastructure.model.InfraStatus;
+import org.example.stockitbe.hq.infrastructure.model.InfrastructureDto;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq")
+@RequiredArgsConstructor
+public class InfrastructureController {
+
+    private final InfrastructureService service;
+
+    @GetMapping("/stores")
+    public BaseResponse<List<InfrastructureDto.StoreRes>> listStores(@RequestParam(required = false) String keyword,
+                                                                     @RequestParam(required = false) String region,
+                                                                     @RequestParam(required = false) InfraStatus status) {
+        return BaseResponse.success(service.findStores(keyword, region, status));
+    }
+
+    @PostMapping("/stores")
+    public BaseResponse<InfrastructureDto.StoreRes> createStore(@Valid @RequestBody InfrastructureDto.StoreUpsertReq req) {
+        return BaseResponse.success(service.createStore(req));
+    }
+
+    @PatchMapping("/stores/{code}")
+    public BaseResponse<InfrastructureDto.StoreRes> updateStore(@PathVariable String code,
+                                                                 @Valid @RequestBody InfrastructureDto.StoreUpsertReq req) {
+        return BaseResponse.success(service.updateStore(code, req));
+    }
+
+    @GetMapping("/warehouses")
+    public BaseResponse<List<InfrastructureDto.WarehouseRes>> listWarehouses(@RequestParam(required = false) String keyword,
+                                                                             @RequestParam(required = false) String region,
+                                                                             @RequestParam(required = false) InfraStatus status) {
+        return BaseResponse.success(service.findWarehouses(keyword, region, status));
+    }
+
+    @PostMapping("/warehouses")
+    public BaseResponse<InfrastructureDto.WarehouseRes> createWarehouse(@Valid @RequestBody InfrastructureDto.WarehouseUpsertReq req) {
+        return BaseResponse.success(service.createWarehouse(req));
+    }
+
+    @PatchMapping("/warehouses/{code}")
+    public BaseResponse<InfrastructureDto.WarehouseRes> updateWarehouse(@PathVariable String code,
+                                                                         @Valid @RequestBody InfrastructureDto.WarehouseUpsertReq req) {
+        return BaseResponse.success(service.updateWarehouse(code, req));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureService.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureService.java
@@ -1,0 +1,136 @@
+package org.example.stockitbe.hq.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.model.*;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InfrastructureService {
+
+    private final StoreRepository storeRepository;
+    private final WarehouseRepository warehouseRepository;
+
+    @Transactional(readOnly = true)
+    public List<InfrastructureDto.StoreRes> findStores(String keyword, String region, InfraStatus status) {
+        String safeKeyword = keyword == null ? "" : keyword.trim();
+        String safeRegion = region == null ? "" : region.trim();
+        List<Store> stores;
+        if (status != null && !safeRegion.isBlank()) {
+            stores = storeRepository.findByRegionContainingIgnoreCaseAndStatusAndNameContainingIgnoreCaseOrderByIdDesc(safeRegion, status, safeKeyword);
+        } else if (!safeRegion.isBlank()) {
+            stores = storeRepository.findByRegionContainingIgnoreCaseAndNameContainingIgnoreCaseOrderByIdDesc(safeRegion, safeKeyword);
+        } else if (status != null) {
+            stores = storeRepository.findByStatusAndNameContainingIgnoreCaseOrderByIdDesc(status, safeKeyword);
+        } else {
+            stores = storeRepository.findByNameContainingIgnoreCaseOrderByIdDesc(safeKeyword);
+        }
+        return stores.stream().map(InfrastructureDto.StoreRes::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<InfrastructureDto.WarehouseRes> findWarehouses(String keyword, String region, InfraStatus status) {
+        String safeKeyword = keyword == null ? "" : keyword.trim();
+        String safeRegion = region == null ? "" : region.trim();
+        List<Warehouse> warehouses;
+        if (status != null && !safeRegion.isBlank()) {
+            warehouses = warehouseRepository.findByRegionContainingIgnoreCaseAndStatusAndNameContainingIgnoreCaseOrderByIdDesc(safeRegion, status, safeKeyword);
+        } else if (!safeRegion.isBlank()) {
+            warehouses = warehouseRepository.findByRegionContainingIgnoreCaseAndNameContainingIgnoreCaseOrderByIdDesc(safeRegion, safeKeyword);
+        } else if (status != null) {
+            warehouses = warehouseRepository.findByStatusAndNameContainingIgnoreCaseOrderByIdDesc(status, safeKeyword);
+        } else {
+            warehouses = warehouseRepository.findByNameContainingIgnoreCaseOrderByIdDesc(safeKeyword);
+        }
+        return warehouses.stream().map(w -> InfrastructureDto.WarehouseRes.from(w, storeRepository.countByWarehouseCode(w.getCode()))).toList();
+    }
+
+    @Transactional
+    public InfrastructureDto.StoreRes createStore(InfrastructureDto.StoreUpsertReq req) {
+        if (!warehouseRepository.existsByCode(req.getWarehouseCode().trim())) {
+            throw BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND);
+        }
+        if (storeRepository.existsByNameIgnoreCase(req.getName().trim())) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_STORE_NAME);
+        }
+        Store saved = saveStoreWithGeneratedCode(req);
+        return InfrastructureDto.StoreRes.from(saved);
+    }
+
+    @Transactional
+    public InfrastructureDto.StoreRes updateStore(String code, InfrastructureDto.StoreUpsertReq req) {
+        Store store = storeRepository.findByCode(code).orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_NOT_FOUND));
+        if (!warehouseRepository.existsByCode(req.getWarehouseCode().trim())) {
+            throw BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND);
+        }
+        if (storeRepository.existsByNameIgnoreCaseAndCodeNot(req.getName().trim(), code)) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_STORE_NAME);
+        }
+        store.update(req.getName().trim(), req.getRegion().trim(), req.getType(), req.getManagerName().trim(), req.getContact().trim(), req.getAddress().trim(), req.getWarehouseCode().trim(), req.getStatus());
+        return InfrastructureDto.StoreRes.from(store);
+    }
+
+    @Transactional
+    public InfrastructureDto.WarehouseRes createWarehouse(InfrastructureDto.WarehouseUpsertReq req) {
+        if (warehouseRepository.existsByNameIgnoreCase(req.getName().trim())) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_WAREHOUSE_NAME);
+        }
+        Warehouse saved = saveWarehouseWithGeneratedCode(req);
+        return InfrastructureDto.WarehouseRes.from(saved, 0);
+    }
+
+    @Transactional
+    public InfrastructureDto.WarehouseRes updateWarehouse(String code, InfrastructureDto.WarehouseUpsertReq req) {
+        Warehouse warehouse = warehouseRepository.findByCode(code).orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND));
+        if (warehouseRepository.existsByNameIgnoreCaseAndCodeNot(req.getName().trim(), code)) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_WAREHOUSE_NAME);
+        }
+        warehouse.update(req.getName().trim(), req.getRegion().trim(), req.getManagerName().trim(), req.getContact().trim(), req.getAddress().trim(), req.getCapacity().trim(), req.getStatus());
+        return InfrastructureDto.WarehouseRes.from(warehouse, storeRepository.countByWarehouseCode(warehouse.getCode()));
+    }
+
+    private Store saveStoreWithGeneratedCode(InfrastructureDto.StoreUpsertReq req) {
+        for (int i = 0; i < 2; i++) {
+            String code = nextCode(storeRepository.findAllByOrderByIdDesc().stream().map(Store::getCode).toList(), "ST");
+            try {
+                return storeRepository.save(req.toEntity(code));
+            } catch (DataIntegrityViolationException e) {
+                if (i == 1) throw e;
+            }
+        }
+        throw BaseException.from(BaseResponseStatus.FAIL);
+    }
+
+    private Warehouse saveWarehouseWithGeneratedCode(InfrastructureDto.WarehouseUpsertReq req) {
+        for (int i = 0; i < 2; i++) {
+            String code = nextCode(warehouseRepository.findAllByOrderByIdDesc().stream().map(Warehouse::getCode).toList(), "WH");
+            try {
+                return warehouseRepository.save(req.toEntity(code));
+            } catch (DataIntegrityViolationException e) {
+                if (i == 1) throw e;
+            }
+        }
+        throw BaseException.from(BaseResponseStatus.FAIL);
+    }
+
+    private String nextCode(List<String> codes, String prefix) {
+        long max = codes.stream()
+                .filter(c -> c != null && c.startsWith(prefix + "-"))
+                .mapToLong(c -> {
+                    try {
+                        return Long.parseLong(c.substring(prefix.length() + 1));
+                    } catch (Exception e) {
+                        return 0L;
+                    }
+                })
+                .max()
+                .orElse(0L);
+        return String.format("%s-%04d", prefix, max + 1);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/StoreRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/StoreRepository.java
@@ -1,0 +1,20 @@
+package org.example.stockitbe.hq.infrastructure;
+
+import org.example.stockitbe.hq.infrastructure.model.Store;
+import org.example.stockitbe.hq.infrastructure.model.InfraStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    Optional<Store> findByCode(String code);
+    List<Store> findAllByOrderByIdDesc();
+    long countByWarehouseCode(String warehouseCode);
+    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndCodeNot(String name, String code);
+    List<Store> findByRegionContainingIgnoreCaseAndStatusAndNameContainingIgnoreCaseOrderByIdDesc(String region, InfraStatus status, String keyword);
+    List<Store> findByRegionContainingIgnoreCaseAndNameContainingIgnoreCaseOrderByIdDesc(String region, String keyword);
+    List<Store> findByStatusAndNameContainingIgnoreCaseOrderByIdDesc(InfraStatus status, String keyword);
+    List<Store> findByNameContainingIgnoreCaseOrderByIdDesc(String keyword);
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/WarehouseRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/WarehouseRepository.java
@@ -1,0 +1,20 @@
+package org.example.stockitbe.hq.infrastructure;
+
+import org.example.stockitbe.hq.infrastructure.model.Warehouse;
+import org.example.stockitbe.hq.infrastructure.model.InfraStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WarehouseRepository extends JpaRepository<Warehouse, Long> {
+    Optional<Warehouse> findByCode(String code);
+    boolean existsByCode(String code);
+    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndCodeNot(String name, String code);
+    List<Warehouse> findByRegionContainingIgnoreCaseAndStatusAndNameContainingIgnoreCaseOrderByIdDesc(String region, InfraStatus status, String keyword);
+    List<Warehouse> findByRegionContainingIgnoreCaseAndNameContainingIgnoreCaseOrderByIdDesc(String region, String keyword);
+    List<Warehouse> findByStatusAndNameContainingIgnoreCaseOrderByIdDesc(InfraStatus status, String keyword);
+    List<Warehouse> findByNameContainingIgnoreCaseOrderByIdDesc(String keyword);
+    List<Warehouse> findAllByOrderByIdDesc();
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/InfraStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/InfraStatus.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.hq.infrastructure.model;
+
+public enum InfraStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/InfrastructureDto.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/InfrastructureDto.java
@@ -1,0 +1,128 @@
+package org.example.stockitbe.hq.infrastructure.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.Date;
+
+public class InfrastructureDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StoreUpsertReq {
+        @NotBlank private String name;
+        @NotBlank private String region;
+        @NotNull private StoreType type;
+        @NotBlank private String managerName;
+        @NotBlank private String contact;
+        @NotBlank private String address;
+        @NotBlank private String warehouseCode;
+        @NotNull private InfraStatus status;
+
+        public Store toEntity(String code) {
+            return Store.builder()
+                    .code(code)
+                    .name(name.trim())
+                    .region(region.trim())
+                    .type(type)
+                    .managerName(managerName.trim())
+                    .contact(contact.trim())
+                    .address(address.trim())
+                    .warehouseCode(warehouseCode.trim())
+                    .status(status)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WarehouseUpsertReq {
+        @NotBlank private String name;
+        @NotBlank private String region;
+        @NotBlank private String managerName;
+        @NotBlank private String contact;
+        @NotBlank private String address;
+        @NotBlank private String capacity;
+        @NotNull private InfraStatus status;
+
+        public Warehouse toEntity(String code) {
+            return Warehouse.builder()
+                    .code(code)
+                    .name(name.trim())
+                    .region(region.trim())
+                    .managerName(managerName.trim())
+                    .contact(contact.trim())
+                    .address(address.trim())
+                    .capacity(capacity.trim())
+                    .status(status)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class StoreRes {
+        private String code;
+        private String name;
+        private String region;
+        private StoreType type;
+        private String managerName;
+        private String contact;
+        private String address;
+        private String warehouseCode;
+        private InfraStatus status;
+        private Date updatedAt;
+
+        public static StoreRes from(Store store) {
+            return StoreRes.builder()
+                    .code(store.getCode())
+                    .name(store.getName())
+                    .region(store.getRegion())
+                    .type(store.getType())
+                    .managerName(store.getManagerName())
+                    .contact(store.getContact())
+                    .address(store.getAddress())
+                    .warehouseCode(store.getWarehouseCode())
+                    .status(store.getStatus())
+                    .updatedAt(store.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class WarehouseRes {
+        private String code;
+        private String name;
+        private String region;
+        private String managerName;
+        private String contact;
+        private String address;
+        private String capacity;
+        private InfraStatus status;
+        private long mappedStoreCount;
+        private Date updatedAt;
+
+        public static WarehouseRes from(Warehouse warehouse, long mappedStoreCount) {
+            return WarehouseRes.builder()
+                    .code(warehouse.getCode())
+                    .name(warehouse.getName())
+                    .region(warehouse.getRegion())
+                    .managerName(warehouse.getManagerName())
+                    .contact(warehouse.getContact())
+                    .address(warehouse.getAddress())
+                    .capacity(warehouse.getCapacity())
+                    .status(warehouse.getStatus())
+                    .mappedStoreCount(mappedStoreCount)
+                    .updatedAt(warehouse.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/Store.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/Store.java
@@ -1,0 +1,75 @@
+package org.example.stockitbe.hq.infrastructure.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "store", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_store_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 128)
+    private String name;
+
+    @Column(name = "region", nullable = false, length = 32)
+    private String region;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 16)
+    private StoreType type;
+
+    @Column(name = "manager_name", nullable = false, length = 64)
+    private String managerName;
+
+    @Column(name = "contact", nullable = false, length = 32)
+    private String contact;
+
+    @Column(name = "address", nullable = false, length = 256)
+    private String address;
+
+    @Column(name = "warehouse_code", nullable = false, length = 32)
+    private String warehouseCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private InfraStatus status;
+
+    @Builder
+    private Store(String code, String name, String region, StoreType type, String managerName,
+                  String contact, String address, String warehouseCode, InfraStatus status) {
+        this.code = code;
+        this.name = name;
+        this.region = region;
+        this.type = type;
+        this.managerName = managerName;
+        this.contact = contact;
+        this.address = address;
+        this.warehouseCode = warehouseCode;
+        this.status = status == null ? InfraStatus.ACTIVE : status;
+    }
+
+    public void update(String name, String region, StoreType type, String managerName,
+                       String contact, String address, String warehouseCode, InfraStatus status) {
+        this.name = name;
+        this.region = region;
+        this.type = type;
+        this.managerName = managerName;
+        this.contact = contact;
+        this.address = address;
+        this.warehouseCode = warehouseCode;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/StoreType.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/StoreType.java
@@ -1,0 +1,6 @@
+package org.example.stockitbe.hq.infrastructure.model;
+
+public enum StoreType {
+    DIRECT,
+    FRANCHISE
+}

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/Warehouse.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/Warehouse.java
@@ -1,0 +1,69 @@
+package org.example.stockitbe.hq.infrastructure.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "warehouse", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_warehouse_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Warehouse extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 128)
+    private String name;
+
+    @Column(name = "region", nullable = false, length = 32)
+    private String region;
+
+    @Column(name = "manager_name", nullable = false, length = 64)
+    private String managerName;
+
+    @Column(name = "contact", nullable = false, length = 32)
+    private String contact;
+
+    @Column(name = "address", nullable = false, length = 256)
+    private String address;
+
+    @Column(name = "capacity", nullable = false, length = 64)
+    private String capacity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private InfraStatus status;
+
+    @Builder
+    private Warehouse(String code, String name, String region, String managerName,
+                      String contact, String address, String capacity, InfraStatus status) {
+        this.code = code;
+        this.name = name;
+        this.region = region;
+        this.managerName = managerName;
+        this.contact = contact;
+        this.address = address;
+        this.capacity = capacity;
+        this.status = status == null ? InfraStatus.ACTIVE : status;
+    }
+
+    public void update(String name, String region, String managerName,
+                       String contact, String address, String capacity, InfraStatus status) {
+        this.name = name;
+        this.region = region;
+        this.managerName = managerName;
+        this.contact = contact;
+        this.address = address;
+        this.capacity = capacity;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterController.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterController.java
@@ -1,0 +1,86 @@
+package org.example.stockitbe.hq.product;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.product.model.ProductDto;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq")
+@RequiredArgsConstructor
+public class ProductMasterController {
+
+    private final ProductMasterService service;
+
+    @GetMapping("/products")
+    public BaseResponse<List<ProductDto.ProductMasterRes>> listProducts(@RequestParam(required = false) String keyword,
+                                                                        @RequestParam(required = false) String categoryCode) {
+        return BaseResponse.success(service.findProducts(keyword, categoryCode));
+    }
+
+    @GetMapping("/products/{code}")
+    public BaseResponse<ProductDto.ProductMasterRes> detailProduct(@PathVariable String code) {
+        return BaseResponse.success(service.findProductByCode(code));
+    }
+
+    @PostMapping("/products")
+    public BaseResponse<ProductDto.ProductMasterRes> createProduct(@Valid @RequestBody ProductDto.ProductMasterUpsertReq req) {
+        return BaseResponse.success(service.createProduct(req));
+    }
+
+    @PatchMapping("/products/{code}")
+    public BaseResponse<ProductDto.ProductMasterRes> updateProduct(@PathVariable String code,
+                                                                    @Valid @RequestBody ProductDto.ProductMasterUpsertReq req) {
+        return BaseResponse.success(service.updateProduct(code, req));
+    }
+
+    @DeleteMapping("/products/{code}")
+    public BaseResponse<Void> deleteProduct(@PathVariable String code) {
+        service.deleteProduct(code);
+        return BaseResponse.success(null);
+    }
+
+    @GetMapping("/products/{code}/skus")
+    public BaseResponse<List<ProductDto.ProductSkuRes>> listSkus(@PathVariable String code) {
+        return BaseResponse.success(service.findSkus(code));
+    }
+
+    @PostMapping("/products/{code}/skus")
+    public BaseResponse<ProductDto.ProductSkuRes> createSku(@PathVariable String code,
+                                                            @Valid @RequestBody ProductDto.ProductSkuUpsertReq req) {
+        return BaseResponse.success(service.createSku(code, req));
+    }
+
+    @PostMapping("/products/{code}/skus/bulk")
+    public BaseResponse<ProductDto.ProductSkuBulkCreateRes> createSkusBulk(@PathVariable String code,
+                                                                            @Valid @RequestBody ProductDto.ProductSkuBulkCreateReq req) {
+        return BaseResponse.success(service.bulkCreateSkus(code, req));
+    }
+
+    @PatchMapping("/skus/{skuCode}")
+    public BaseResponse<ProductDto.ProductSkuRes> updateSku(@PathVariable String skuCode,
+                                                             @Valid @RequestBody ProductDto.ProductSkuUpsertReq req) {
+        return BaseResponse.success(service.updateSku(skuCode, req));
+    }
+
+    @PatchMapping("/products/{code}/skus/price")
+    public BaseResponse<ProductDto.ProductSkuPriceBulkUpdateRes> updateSkuPrices(@PathVariable String code,
+                                                                                  @Valid @RequestBody ProductDto.ProductSkuPriceBulkUpdateReq req) {
+        return BaseResponse.success(service.updateAllSkuPrices(code, req));
+    }
+
+    @PatchMapping("/products/{code}/skus/status")
+    public BaseResponse<ProductDto.ProductSkuStatusBulkUpdateRes> updateSkuStatus(@PathVariable String code,
+                                                                                   @Valid @RequestBody ProductDto.ProductSkuStatusBulkUpdateReq req) {
+        return BaseResponse.success(service.updateAllSkuStatus(code, req));
+    }
+
+    @DeleteMapping("/skus/{skuCode}")
+    public BaseResponse<Void> deleteSku(@PathVariable String skuCode) {
+        service.deleteSku(skuCode);
+        return BaseResponse.success(null);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterRepository.java
@@ -1,0 +1,15 @@
+package org.example.stockitbe.hq.product;
+
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductMasterRepository extends JpaRepository<ProductMaster, Long> {
+    Optional<ProductMaster> findByCode(String code);
+    boolean existsByNameIgnoreCase(String name);
+    boolean existsByNameIgnoreCaseAndCodeNot(String name, String code);
+    List<ProductMaster> findByNameContainingIgnoreCaseAndCategoryCodeContainingIgnoreCaseOrderByIdDesc(String keyword, String categoryCode);
+    List<ProductMaster> findAllByOrderByIdDesc();
+}

--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
@@ -1,0 +1,248 @@
+package org.example.stockitbe.hq.product;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.category.CategoryRepository;
+import org.example.stockitbe.hq.product.model.ProductDto;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMasterService {
+
+    private final ProductMasterRepository productMasterRepository;
+    private final ProductSkuRepository productSkuRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProductDto.ProductMasterRes> findProducts(String keyword, String categoryCode) {
+        String safeKeyword = keyword == null ? "" : keyword.trim();
+        String safeCategoryCode = categoryCode == null ? "" : categoryCode.trim();
+        return productMasterRepository
+                .findByNameContainingIgnoreCaseAndCategoryCodeContainingIgnoreCaseOrderByIdDesc(safeKeyword, safeCategoryCode)
+                .stream()
+                .map(p -> ProductDto.ProductMasterRes.from(p, productSkuRepository.countByProductCode(p.getCode())))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProductDto.ProductMasterRes findProductByCode(String code) {
+        ProductMaster product = productMasterRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        return ProductDto.ProductMasterRes.from(product, productSkuRepository.countByProductCode(product.getCode()));
+    }
+
+    @Transactional
+    public ProductDto.ProductMasterRes createProduct(ProductDto.ProductMasterUpsertReq req) {
+        validateCreate(req);
+        ProductMaster saved = saveWithGeneratedCode(req);
+        return ProductDto.ProductMasterRes.from(saved, 0);
+    }
+
+    @Transactional
+    public ProductDto.ProductMasterRes updateProduct(String code, ProductDto.ProductMasterUpsertReq req) {
+        ProductMaster product = productMasterRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        validateUpdate(req, code);
+        product.update(req.getName().trim(), req.getCategoryCode().trim(), req.getBasePrice(), req.getLeadTimeDays(), req.getMainVendorCode().trim(), req.getStatus());
+        return ProductDto.ProductMasterRes.from(product, productSkuRepository.countByProductCode(product.getCode()));
+    }
+
+    @Transactional
+    public void deleteProduct(String code) {
+        ProductMaster product = productMasterRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        productSkuRepository.deleteByProductCode(product.getCode());
+        productMasterRepository.delete(product);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductDto.ProductSkuRes> findSkus(String productCode) {
+        productMasterRepository.findByCode(productCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        return productSkuRepository.findByProductCodeOrderByIdDesc(productCode)
+                .stream().map(ProductDto.ProductSkuRes::from).toList();
+    }
+
+    @Transactional
+    public ProductDto.ProductSkuRes createSku(String productCode, ProductDto.ProductSkuUpsertReq req) {
+        productMasterRepository.findByCode(productCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        validateSkuDuplicate(productCode, req.getOptionName().trim(), req.getOptionValue().trim(), null);
+        ProductSku saved = saveSkuWithGeneratedCode(productCode, req);
+        return ProductDto.ProductSkuRes.from(saved);
+    }
+
+    @Transactional
+    public ProductDto.ProductSkuRes updateSku(String skuCode, ProductDto.ProductSkuUpsertReq req) {
+        ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
+        String optionName = req.getOptionName().trim();
+        String optionValue = req.getOptionValue().trim();
+        validateSkuDuplicate(sku.getProductCode(), optionName, optionValue, skuCode);
+        sku.update(optionName, optionValue, req.getUnitPrice(), req.getStatus());
+        return ProductDto.ProductSkuRes.from(sku);
+    }
+
+    @Transactional
+    public void deleteSku(String skuCode) {
+        ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
+        productSkuRepository.delete(sku);
+    }
+
+    @Transactional
+    public ProductDto.ProductSkuBulkCreateRes bulkCreateSkus(String productCode, ProductDto.ProductSkuBulkCreateReq req) {
+        productMasterRepository.findByCode(productCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+
+        String optionName = req.getOptionName().trim();
+        Set<String> uniqueValues = new LinkedHashSet<>();
+        for (String raw : req.getOptionValues()) {
+            if (raw == null) continue;
+            String trimmed = raw.trim();
+            if (!trimmed.isEmpty()) uniqueValues.add(trimmed);
+        }
+
+        int requestedCount = uniqueValues.size();
+        int createdCount = 0;
+        int skippedCount = 0;
+
+        for (String optionValue : uniqueValues) {
+            boolean duplicated = productSkuRepository.existsByProductCodeAndOptionNameAndOptionValue(productCode, optionName, optionValue);
+            if (duplicated) {
+                skippedCount++;
+                continue;
+            }
+            ProductDto.ProductSkuUpsertReq createReq = ProductDto.ProductSkuUpsertReq.builder()
+                    .optionName(optionName)
+                    .optionValue(optionValue)
+                    .unitPrice(req.getUnitPrice())
+                    .status(req.getStatus())
+                    .build();
+            saveSkuWithGeneratedCode(productCode, createReq);
+            createdCount++;
+        }
+
+        return ProductDto.ProductSkuBulkCreateRes.builder()
+                .productCode(productCode)
+                .requestedCount(requestedCount)
+                .createdCount(createdCount)
+                .skippedCount(skippedCount)
+                .build();
+    }
+
+    @Transactional
+    public ProductDto.ProductSkuPriceBulkUpdateRes updateAllSkuPrices(String productCode, ProductDto.ProductSkuPriceBulkUpdateReq req) {
+        productMasterRepository.findByCode(productCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+
+        if (req.getUnitPrice() == null || req.getUnitPrice() < 0) {
+            throw BaseException.from(BaseResponseStatus.INVALID_SKU_PRICE);
+        }
+
+        List<ProductSku> targetSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
+        for (ProductSku sku : targetSkus) {
+            sku.update(sku.getOptionName(), sku.getOptionValue(), req.getUnitPrice(), sku.getStatus());
+        }
+
+        return ProductDto.ProductSkuPriceBulkUpdateRes.builder()
+                .productCode(productCode)
+                .updatedCount(targetSkus.size())
+                .unitPrice(req.getUnitPrice())
+                .build();
+    }
+
+    @Transactional
+    public ProductDto.ProductSkuStatusBulkUpdateRes updateAllSkuStatus(String productCode, ProductDto.ProductSkuStatusBulkUpdateReq req) {
+        productMasterRepository.findByCode(productCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+
+        List<ProductSku> targetSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
+        for (ProductSku sku : targetSkus) {
+            sku.update(sku.getOptionName(), sku.getOptionValue(), sku.getUnitPrice(), req.getStatus());
+        }
+
+        return ProductDto.ProductSkuStatusBulkUpdateRes.builder()
+                .productCode(productCode)
+                .updatedCount(targetSkus.size())
+                .status(req.getStatus())
+                .build();
+    }
+
+    private void validateCreate(ProductDto.ProductMasterUpsertReq req) {
+        if (!categoryRepository.findByCode(req.getCategoryCode().trim()).isPresent()) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND);
+        }
+        if (productMasterRepository.existsByNameIgnoreCase(req.getName().trim())) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_MASTER_NAME);
+        }
+    }
+
+    private void validateUpdate(ProductDto.ProductMasterUpsertReq req, String code) {
+        if (!categoryRepository.findByCode(req.getCategoryCode().trim()).isPresent()) {
+            throw BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND);
+        }
+        if (productMasterRepository.existsByNameIgnoreCaseAndCodeNot(req.getName().trim(), code)) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_MASTER_NAME);
+        }
+    }
+
+    private ProductMaster saveWithGeneratedCode(ProductDto.ProductMasterUpsertReq req) {
+        for (int i = 0; i < 2; i++) {
+            String code = nextCode(productMasterRepository.findAllByOrderByIdDesc().stream().map(ProductMaster::getCode).toList(), "PM");
+            try {
+                return productMasterRepository.save(req.toEntity(code));
+            } catch (DataIntegrityViolationException e) {
+                if (i == 1) throw e;
+            }
+        }
+        throw BaseException.from(BaseResponseStatus.FAIL);
+    }
+
+    private ProductSku saveSkuWithGeneratedCode(String productCode, ProductDto.ProductSkuUpsertReq req) {
+        for (int i = 0; i < 2; i++) {
+            String code = nextCode(productSkuRepository.findAllByOrderByIdDesc().stream().map(ProductSku::getSkuCode).toList(), "SKU");
+            try {
+                return productSkuRepository.save(req.toEntity(code, productCode));
+            } catch (DataIntegrityViolationException e) {
+                if (i == 1) throw e;
+            }
+        }
+        throw BaseException.from(BaseResponseStatus.FAIL);
+    }
+
+    private void validateSkuDuplicate(String productCode, String optionName, String optionValue, String selfSkuCode) {
+        List<ProductSku> sameProductSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
+        boolean duplicated = sameProductSkus.stream()
+                .anyMatch(s -> s.getOptionName().equalsIgnoreCase(optionName)
+                        && s.getOptionValue().equalsIgnoreCase(optionValue)
+                        && (selfSkuCode == null || !s.getSkuCode().equals(selfSkuCode)));
+        if (duplicated) {
+            throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_SKU_OPTION);
+        }
+    }
+
+    private String nextCode(List<String> codes, String prefix) {
+        long max = codes.stream()
+                .filter(c -> c != null && c.startsWith(prefix + "-"))
+                .mapToLong(c -> {
+                    try {
+                        return Long.parseLong(c.substring(prefix.length() + 1));
+                    } catch (Exception e) {
+                        return 0L;
+                    }
+                })
+                .max().orElse(0L);
+        return String.format("%s-%04d", prefix, max + 1);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
@@ -1,0 +1,16 @@
+package org.example.stockitbe.hq.product;
+
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
+    Optional<ProductSku> findBySkuCode(String skuCode);
+    List<ProductSku> findByProductCodeOrderByIdDesc(String productCode);
+    long countByProductCode(String productCode);
+    List<ProductSku> findAllByOrderByIdDesc();
+    boolean existsByProductCodeAndOptionNameAndOptionValue(String productCode, String optionName, String optionValue);
+    long deleteByProductCode(String productCode);
+}

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
@@ -1,0 +1,168 @@
+package org.example.stockitbe.hq.product.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+
+public class ProductDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ProductMasterUpsertReq {
+        @NotBlank private String name;
+        @NotBlank private String categoryCode;
+        @NotNull @Min(0) private Long basePrice;
+        @NotNull @Min(0) private Integer leadTimeDays;
+        @NotBlank private String mainVendorCode;
+        @NotNull private ProductStatus status;
+
+        public ProductMaster toEntity(String code) {
+            return ProductMaster.builder()
+                    .code(code)
+                    .name(name.trim())
+                    .categoryCode(categoryCode.trim())
+                    .basePrice(basePrice)
+                    .leadTimeDays(leadTimeDays)
+                    .mainVendorCode(mainVendorCode.trim())
+                    .status(status)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuUpsertReq {
+        @NotBlank private String optionName;
+        @NotBlank private String optionValue;
+        @NotNull @Min(0) private Long unitPrice;
+        @NotNull private ProductStatus status;
+
+        public ProductSku toEntity(String skuCode, String productCode) {
+            return ProductSku.builder()
+                    .skuCode(skuCode)
+                    .productCode(productCode)
+                    .optionName(optionName.trim())
+                    .optionValue(optionValue.trim())
+                    .unitPrice(unitPrice)
+                    .status(status)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuBulkCreateReq {
+        @NotBlank private String optionName;
+        @NotNull private List<String> optionValues;
+        @NotNull @Min(0) private Long unitPrice;
+        @NotNull private ProductStatus status;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuPriceBulkUpdateReq {
+        @NotNull @Min(0) private Long unitPrice;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuStatusBulkUpdateReq {
+        @NotNull private ProductStatus status;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ProductMasterRes {
+        private String code;
+        private String name;
+        private String categoryCode;
+        private Long basePrice;
+        private Integer leadTimeDays;
+        private String mainVendorCode;
+        private ProductStatus status;
+        private long skuCount;
+        private Date updatedAt;
+
+        public static ProductMasterRes from(ProductMaster m, long skuCount) {
+            return ProductMasterRes.builder()
+                    .code(m.getCode())
+                    .name(m.getName())
+                    .categoryCode(m.getCategoryCode())
+                    .basePrice(m.getBasePrice())
+                    .leadTimeDays(m.getLeadTimeDays())
+                    .mainVendorCode(m.getMainVendorCode())
+                    .status(m.getStatus())
+                    .skuCount(skuCount)
+                    .updatedAt(m.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuRes {
+        private String skuCode;
+        private String productCode;
+        private String optionName;
+        private String optionValue;
+        private Long unitPrice;
+        private ProductStatus status;
+        private Date updatedAt;
+
+        public static ProductSkuRes from(ProductSku sku) {
+            return ProductSkuRes.builder()
+                    .skuCode(sku.getSkuCode())
+                    .productCode(sku.getProductCode())
+                    .optionName(sku.getOptionName())
+                    .optionValue(sku.getOptionValue())
+                    .unitPrice(sku.getUnitPrice())
+                    .status(sku.getStatus())
+                    .updatedAt(sku.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuBulkCreateRes {
+        private String productCode;
+        private int requestedCount;
+        private int createdCount;
+        private int skippedCount;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuPriceBulkUpdateRes {
+        private String productCode;
+        private long updatedCount;
+        private Long unitPrice;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ProductSkuStatusBulkUpdateRes {
+        private String productCode;
+        private long updatedCount;
+        private ProductStatus status;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
@@ -1,0 +1,63 @@
+package org.example.stockitbe.hq.product.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "product_master", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_product_master_code", columnNames = "code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductMaster extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 32)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 128)
+    private String name;
+
+    @Column(name = "category_code", nullable = false, length = 32)
+    private String categoryCode;
+
+    @Column(name = "base_price", nullable = false)
+    private Long basePrice;
+
+    @Column(name = "lead_time_days", nullable = false)
+    private Integer leadTimeDays;
+
+    @Column(name = "main_vendor_code", nullable = false, length = 32)
+    private String mainVendorCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private ProductStatus status;
+
+    @Builder
+    private ProductMaster(String code, String name, String categoryCode, Long basePrice, Integer leadTimeDays,
+                          String mainVendorCode, ProductStatus status) {
+        this.code = code;
+        this.name = name;
+        this.categoryCode = categoryCode;
+        this.basePrice = basePrice;
+        this.leadTimeDays = leadTimeDays;
+        this.mainVendorCode = mainVendorCode;
+        this.status = status == null ? ProductStatus.ACTIVE : status;
+    }
+
+    public void update(String name, String categoryCode, Long basePrice, Integer leadTimeDays, String mainVendorCode, ProductStatus status) {
+        this.name = name;
+        this.categoryCode = categoryCode;
+        this.basePrice = basePrice;
+        this.leadTimeDays = leadTimeDays;
+        this.mainVendorCode = mainVendorCode;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
@@ -1,0 +1,57 @@
+package org.example.stockitbe.hq.product.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "product_sku", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_product_sku_code", columnNames = "sku_code")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSku extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "sku_code", nullable = false, length = 32)
+    private String skuCode;
+
+    @Column(name = "product_code", nullable = false, length = 32)
+    private String productCode;
+
+    @Column(name = "option_name", nullable = false, length = 64)
+    private String optionName;
+
+    @Column(name = "option_value", nullable = false, length = 64)
+    private String optionValue;
+
+    @Column(name = "unit_price", nullable = false)
+    private Long unitPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private ProductStatus status;
+
+    @Builder
+    private ProductSku(String skuCode, String productCode, String optionName, String optionValue,
+                       Long unitPrice, ProductStatus status) {
+        this.skuCode = skuCode;
+        this.productCode = productCode;
+        this.optionName = optionName;
+        this.optionValue = optionValue;
+        this.unitPrice = unitPrice;
+        this.status = status == null ? ProductStatus.ACTIVE : status;
+    }
+
+    public void update(String optionName, String optionValue, Long unitPrice, ProductStatus status) {
+        this.optionName = optionName;
+        this.optionValue = optionValue;
+        this.unitPrice = unitPrice;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductStatus.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.hq.product.model;
+
+public enum ProductStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED
+}


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 제품 마스터 백엔드 API를 신규/확장하여 제품 및 SKU의 등록·조회·수정·삭제 흐름을 완성했습니다.
- 제품 삭제 시 연관 SKU 정리, SKU bulk 생성, 가격/상태 일괄 변경까지 운영 기능을 포함했습니다.

<br><br>

## 🎯 작업 내용
- 제품 마스터 API 구현: 조회/등록/수정/삭제 (`/api/hq/products`)
- SKU API 구현: 조회/등록/수정/삭제 + bulk 생성 (`/api/hq/products/{code}/skus`, `/api/hq/skus/{skuCode}`)
- SKU 일괄 처리 API 구현: 전체 가격/상태 일괄 변경 (`/api/hq/products/{code}/skus/price`, `/api/hq/products/{code}/skus/status`)

<br><br>

## ✔️ 참고 사항
- 제품 삭제 시 `product_code` 기준 연관 SKU를 먼저 삭제한 뒤 제품을 삭제하도록 처리했습니다.
- SKU 옵션 규칙은 기존 정책(`optionName=COLOR_SIZE`, `optionValue=색상|사이즈`)을 유지했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #116

<br><br>
