### PR TITLE
fix(vendor): 거래처 제품을 마스터 기반 1:1 매핑으로 제한

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -57,6 +57,7 @@ public enum BaseResponseStatus {
     DUPLICATE_PRODUCT_MASTER_NAME(false, 4216, "이미 등록된 제품명입니다."),
     DUPLICATE_PRODUCT_SKU_OPTION(false, 4217, "이미 등록된 SKU 옵션입니다."),
     INVALID_SKU_PRICE(false, 4218, "SKU 가격은 0 이상이어야 합니다."),
+    VENDOR_PRODUCT_VENDOR_MISMATCH(false, 4219, "이 제품의 메인 거래처가 아닙니다."),
 
     // 4300번대~ 본사 발주 (CEN-035~040)
     PURCHASE_ORDER_NOT_FOUND(false, 4300, "본사 발주를 찾을 수 없습니다."),

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorController.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorController.java
@@ -3,6 +3,7 @@ package org.example.stockitbe.hq.vendor;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.vendor.model.VendorDto;
+import org.example.stockitbe.hq.vendor.model.VendorProductDto;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import java.util.List;
 
 /**
  * Vendor read-only Controller — 등록/수정/삭제는 SQL 로 직접 처리.
+ * 거래처 계약 표(E 안)는 vendorProductService.findContractRows 로 mainVendorCode 매칭 ProductMaster + VendorProduct join.
  */
 @RestController
 @RequestMapping("/api/vendors")
@@ -19,6 +21,7 @@ import java.util.List;
 public class VendorController {
 
     private final VendorService service;
+    private final VendorProductService vendorProductService;
 
     @GetMapping
     public BaseResponse<List<VendorDto.ListRes>> list() {
@@ -28,5 +31,14 @@ public class VendorController {
     @GetMapping("/{code}")
     public BaseResponse<VendorDto.ListRes> detail(@PathVariable String code) {
         return BaseResponse.success(service.findByCode(code));
+    }
+
+    /**
+     * 거래처 계약 표 — ProductMaster(mainVendorCode 매칭) 행 + VendorProduct 매칭 join.
+     * VendorProduct 가 없으면 contracted=false (미정) 행으로 반환.
+     */
+    @GetMapping("/{code}/contracts")
+    public BaseResponse<List<VendorProductDto.ContractRowRes>> contracts(@PathVariable String code) {
+        return BaseResponse.success(vendorProductService.findContractRows(code));
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
@@ -3,6 +3,8 @@ package org.example.stockitbe.hq.vendor;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.vendor.model.Vendor;
 import org.example.stockitbe.hq.vendor.model.VendorProduct;
 import org.example.stockitbe.hq.vendor.model.VendorProductDto;
@@ -21,6 +23,7 @@ public class VendorProductService {
 
     private final VendorRepository vendorRepository;
     private final VendorProductRepository vendorProductRepository;
+    private final ProductMasterRepository productMasterRepository;
 
     @Transactional(readOnly = true)
     public List<VendorProductDto.ListRes> findByVendor(String vendorCode) {
@@ -74,6 +77,15 @@ public class VendorProductService {
     public VendorProductDto.DetailRes create(VendorProductDto.CreateReq req) {
         Vendor vendor = lookupVendor(req.getVendorCode());
 
+        // ProductMaster 정합 검증 — 마스터에 없는 productCode 차단
+        ProductMaster product = productMasterRepository.findByCode(req.getProductCode())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+
+        // 한 제품 = 한 거래처 검증 — ProductMaster.mainVendorCode 와 요청 vendor 일치해야 함
+        if (!vendor.getCode().equals(product.getMainVendorCode())) {
+            throw BaseException.from(BaseResponseStatus.VENDOR_PRODUCT_VENDOR_MISMATCH);
+        }
+
         boolean duplicate = vendorProductRepository
                 .existsByVendorIdAndProductCodeAndStatusNot(vendor.getId(), req.getProductCode(), VendorProductStatus.DELETED);
         if (duplicate) {
@@ -81,7 +93,7 @@ public class VendorProductService {
         }
 
         String code = generateCode(vendor);
-        VendorProduct entity = req.toEntity(vendor, code);
+        VendorProduct entity = req.toEntity(vendor, code, product.getName());
         VendorProduct saved = vendorProductRepository.save(entity);
         return VendorProductDto.DetailRes.from(saved, vendor);
     }
@@ -90,7 +102,6 @@ public class VendorProductService {
     public VendorProductDto.DetailRes update(String code, VendorProductDto.UpdateReq req) {
         VendorProduct vp = lookupVendorProduct(code);
         vp.updateContract(
-                req.getProductName(),
                 req.getUnitPrice(),
                 req.getMoq(),
                 req.getLeadTimeDays(),
@@ -100,6 +111,34 @@ public class VendorProductService {
         Vendor vendor = vendorRepository.findById(vp.getVendorId())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
         return VendorProductDto.DetailRes.from(vp, vendor);
+    }
+
+    /**
+     * 거래처 계약 표 (E 안 — UX 친화 inline edit).
+     * mainVendorCode 매칭 ProductMaster 전체를 행으로 보여주고, 매칭되는 VendorProduct 가 있으면 계약 디테일 채움.
+     * VendorProduct 0건이면 모두 contracted=false ("미정") 상태로 반환.
+     */
+    @Transactional(readOnly = true)
+    public List<VendorProductDto.ContractRowRes> findContractRows(String vendorCode) {
+        Vendor vendor = lookupVendor(vendorCode);
+
+        // 이 거래처를 메인으로 둔 ProductMaster (in-memory 필터 — ProductMasterRepository 메소드 추가 회피, 팀원 코드 보호)
+        List<ProductMaster> products = productMasterRepository.findAllByOrderByIdDesc().stream()
+                .filter(p -> vendor.getCode().equals(p.getMainVendorCode()))
+                .toList();
+        if (products.isEmpty()) {
+            return List.of();
+        }
+
+        // 해당 거래처의 active VendorProduct (DELETED 제외)
+        List<VendorProduct> vps = vendorProductRepository
+                .findAllByVendorIdAndStatusNotOrderByIdDesc(vendor.getId(), VendorProductStatus.DELETED);
+        Map<String, VendorProduct> vpByProductCode = vps.stream()
+                .collect(Collectors.toMap(VendorProduct::getProductCode, vp -> vp, (a, b) -> a));
+
+        return products.stream()
+                .map(pm -> VendorProductDto.ContractRowRes.from(pm, vpByProductCode.get(pm.getCode())))
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
@@ -71,12 +71,12 @@ public class VendorProduct extends BaseEntity {
     }
 
     /**
-     * 계약 정보 수정 (단가·MOQ·납기·계약기간·제품명).
+     * 계약 정보 수정 (단가·MOQ·납기·계약기간).
+     * productName 은 ProductMaster 가 진실 원천이라 VendorProduct 측에서 변경 액션 폐기 — 컬럼은 시점 복사로 발주 이력 보호용 유지.
      * status 변경은 changeStatus() 통해서만.
      */
-    public void updateContract(String productName, Long unitPrice, Integer moq, Integer leadTimeDays,
+    public void updateContract(Long unitPrice, Integer moq, Integer leadTimeDays,
                                 LocalDate contractStart, LocalDate contractEnd) {
-        if (productName != null) this.productName = productName;
         if (unitPrice != null) this.unitPrice = unitPrice;
         if (moq != null) this.moq = moq;
         if (leadTimeDays != null) this.leadTimeDays = leadTimeDays;

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.stockitbe.hq.product.model.ProductMaster;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -22,8 +23,6 @@ public class VendorProductDto {
         private String vendorCode;
         @NotBlank
         private String productCode;
-        @NotBlank
-        private String productName;
         @NotNull
         @Min(0)
         private Long unitPrice;
@@ -34,13 +33,14 @@ public class VendorProductDto {
         private LocalDate contractStart;
         private LocalDate contractEnd;
 
-        // DTO → Entity 변환은 DTO 책임 (사용자 컨벤션)
-        public VendorProduct toEntity(Vendor vendor, String code) {
+        // DTO → Entity 변환은 DTO 책임 (사용자 컨벤션).
+        // productName 은 ProductMaster.name 시점 복사 — Service 가 lookup 결과 전달.
+        public VendorProduct toEntity(Vendor vendor, String code, String productName) {
             return VendorProduct.builder()
                     .code(code)
                     .vendorId(vendor.getId())
                     .productCode(this.productCode)
-                    .productName(this.productName)
+                    .productName(productName)
                     .unitPrice(this.unitPrice)
                     .moq(this.moq)
                     .leadTimeDays(this.leadTimeDays)
@@ -56,7 +56,6 @@ public class VendorProductDto {
     @AllArgsConstructor
     @Builder
     public static class UpdateReq {
-        private String productName;
         @Min(0)
         private Long unitPrice;
         @Min(1)
@@ -105,6 +104,50 @@ public class VendorProductDto {
                     .contractStart(vp.getContractStart())
                     .contractEnd(vp.getContractEnd())
                     .status(vp.getStatus())
+                    .build();
+        }
+    }
+
+    /**
+     * 거래처 계약 표 한 행 (E 안 — UX 친화 inline edit).
+     * ProductMaster 가 mainVendorCode 매칭으로 무조건 노출되고, VendorProduct 매칭이 있으면 계약 디테일을 채워서 반환.
+     * contracted=false 인 행 = "미정" 상태 (마스터 제품은 있지만 계약 정보 없음).
+     */
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ContractRowRes {
+        // ProductMaster 측 (필수)
+        private String productCode;
+        private String productName;
+        private String categoryCode;
+        private Long basePrice;
+
+        // VendorProduct 측 (계약 미정이면 null)
+        private String vendorProductCode;
+        private Long contractUnitPrice;
+        private Integer moq;
+        private Integer leadTimeDays;
+        private LocalDate contractStart;
+        private LocalDate contractEnd;
+        private VendorProductStatus status;
+        private boolean contracted;
+
+        public static ContractRowRes from(ProductMaster pm, VendorProduct vp) {
+            boolean has = vp != null;
+            return ContractRowRes.builder()
+                    .productCode(pm.getCode())
+                    .productName(pm.getName())
+                    .categoryCode(pm.getCategoryCode())
+                    .basePrice(pm.getBasePrice())
+                    .vendorProductCode(has ? vp.getCode() : null)
+                    .contractUnitPrice(has ? vp.getUnitPrice() : null)
+                    .moq(has ? vp.getMoq() : null)
+                    .leadTimeDays(has ? vp.getLeadTimeDays() : null)
+                    .contractStart(has ? vp.getContractStart() : null)
+                    .contractEnd(has ? vp.getContractEnd() : null)
+                    .status(has ? vp.getStatus() : null)
+                    .contracted(has)
                     .build();
         }
     }


### PR DESCRIPTION
## 📌 요약
- VendorProduct 등록 시 자유 입력 → **제품 마스터 기반 3단 검증**으로 정합성 회복
- 거래처 우측 패널용 `GET /api/vendors/{code}/contracts` endpoint 신설

<br><br>

## 🎯 작업 내용
- **등록 검증 3단 강화**
  - 마스터 존재 확인
  - 마스터 `mainVendorCode` ↔ 요청 vendor 일치 확인
  - 동일 vendor 내 동일 productCode 중복 차단
- **`productName` 시점 복사**
  - 요청 필드에서 폐기, 등록 시 ProductMaster 이름을 시점 복사
- **계약 현황 endpoint 신설**
  - `GET /api/vendors/{code}/contracts` — `mainVendorCode` 매칭 ProductMaster + VendorProduct join
  - `ContractRowRes` 단일 응답으로 미정 / 계약됨 상태 일괄 표출

<br><br>

## ✔️ 참고 사항
- ProductMaster는 read-only 호출만 — 도메인 코드 변경 0
- 다른 거래처가 동일 productCode 등록 시 `mainVendorCode` 검증으로 자연 차단

<br><br>

## ✔️ 관련 이슈
- Close #143 

<br><br>