### PR TITLE
fix(purchase-order): 발주 리스트 응답에 품목명 노출

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -63,8 +63,14 @@ public class PurchaseOrderService {
                 .collect(Collectors.toMap(Vendor::getId, v -> v));
 
         Set<Long> orderIds = orders.stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
-        Map<Long, Long> itemCountMap = itemRepository.findAllByPurchaseOrderIdIn(orderIds).stream()
+        // batch 1회 조회 결과를 itemCountMap + productNamesMap 두 가지로 활용 (쿼리 0추가)
+        List<PurchaseOrderItem> allItems = itemRepository.findAllByPurchaseOrderIdIn(orderIds);
+        Map<Long, Long> itemCountMap = allItems.stream()
                 .collect(Collectors.groupingBy(PurchaseOrderItem::getPurchaseOrderId, Collectors.counting()));
+        Map<Long, List<String>> productNamesMap = allItems.stream()
+                .collect(Collectors.groupingBy(
+                        PurchaseOrderItem::getPurchaseOrderId,
+                        Collectors.mapping(PurchaseOrderItem::getProductName, Collectors.toList())));
 
         return orders.stream()
                 .map(po -> {
@@ -73,7 +79,8 @@ public class PurchaseOrderService {
                         throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
                     }
                     int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
-                    return PurchaseOrderDto.ListRes.from(po, vendor, count);
+                    List<String> names = productNamesMap.getOrDefault(po.getId(), List.of());
+                    return PurchaseOrderDto.ListRes.from(po, vendor, count, names);
                 })
                 .toList();
     }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
@@ -105,10 +105,12 @@ public class PurchaseOrderDto {
         private PurchaseOrderStatus status;
         private Long totalAmount;
         private Integer itemCount;
+        // 발주의 모든 품목명 (입력 순서). FE 가 첫 품목명 + "외 N건" 표시 + 품목명 검색 매칭에 활용.
+        private List<String> productNames;
         private Date createdAt;
         private Date updatedAt;
 
-        public static ListRes from(PurchaseOrder po, Vendor vendor, int itemCount) {
+        public static ListRes from(PurchaseOrder po, Vendor vendor, int itemCount, List<String> productNames) {
             return ListRes.builder()
                     .code(po.getCode())
                     .vendorCode(vendor.getCode())
@@ -119,6 +121,7 @@ public class PurchaseOrderDto {
                     .status(po.getStatus())
                     .totalAmount(po.getTotalAmount())
                     .itemCount(itemCount)
+                    .productNames(productNames)
                     .createdAt(po.getCreatedAt())
                     .updatedAt(po.getUpdatedAt())
                     .build();


### PR DESCRIPTION
## 📌 요약
- 발주 `ListRes`에 `productNames: List<String>` 필드 추가 — 행 표시 / 품목명 검색 기반 마련

<br><br>

## 🎯 작업 내용
- `PurchaseOrderDto.ListRes`에 `productNames` 필드 신설
- `findAll`의 기존 batch items 조회 결과를 한 번 더 `groupingBy`로 묶어 `productNamesMap` 생성 → 추가 쿼리 0
- `DetailRes`는 이미 `items.productName` 노출 중이라 변경 없음

<br><br>

## ✔️ 참고 사항
- 응답 사이즈 영향 미미 (품목명 문자열만 추가)
- 운영자 검색 효율 ↑ (발주번호 / 거래처명 외 품목명 매칭 가능)

<br><br>

## ✔️ 관련 이슈
- Close #145 

<br><br>