### PR TITLE
fix(purchase-order): 발주 상태에 배송완료(DELIVERED) 단계 추가

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
@@ -21,6 +21,7 @@ public class PurchaseOrderAutoTransitionScheduler {
     public void run() {
         log.info("[SYS-001] 배치 시작");
         PurchaseOrderBatchService.BatchResult result = batchService.run(false);
-        log.info("[SYS-001] 배치 완료 — approved={}, shipping={}", result.approved(), result.shipping());
+        log.info("[SYS-001] 배치 완료 — approved={}, shipping={}, delivered={}",
+                result.approved(), result.shipping(), result.delivered());
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
@@ -35,13 +35,18 @@ public class PurchaseOrderBatchService {
     private long waitMinutes;
 
     /**
-     * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 모든 PENDING/APPROVED 즉시 처리.
+     * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 모든 PENDING/APPROVED/SHIPPING 즉시 처리.
      *              false 면 {@code updatedAt < now - waitMinutes} 인 건만.
+     *
+     * 거래처 책임 단계 3개 모두 SYS-001 자동 전환 (ADR-013/019).
+     * SHIPPING → DELIVERED 도 같은 패턴 — 배송 도착 시점도 거래처 책임이라 자동화.
+     * DELIVERED → COMPLETED 는 창고 [입고 확정] 매뉴얼 트리거(WHS-007) — 배치 처리 안 함.
      */
     public BatchResult run(boolean force) {
-        int approved = autoTransition(PurchaseOrderStatus.PENDING,  force, code -> service.approve(code));
-        int shipping = autoTransition(PurchaseOrderStatus.APPROVED, force, code -> service.startShipping(code));
-        return new BatchResult(approved, shipping);
+        int approved  = autoTransition(PurchaseOrderStatus.PENDING,  force, code -> service.approve(code));
+        int shipping  = autoTransition(PurchaseOrderStatus.APPROVED, force, code -> service.startShipping(code));
+        int delivered = autoTransition(PurchaseOrderStatus.SHIPPING, force, code -> service.deliver(code));
+        return new BatchResult(approved, shipping, delivered);
     }
 
     private int autoTransition(PurchaseOrderStatus from, boolean force, Consumer<String> action) {
@@ -62,5 +67,5 @@ public class PurchaseOrderBatchService {
         return success;
     }
 
-    public record BatchResult(int approved, int shipping) {}
+    public record BatchResult(int approved, int shipping, int delivered) {}
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -189,6 +189,14 @@ public class PurchaseOrderService {
     }
 
     @Transactional
+    public PurchaseOrderDto.DetailRes deliver(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markDelivered();
+        appendHistory(po, null);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
     public PurchaseOrderDto.DetailRes complete(String code) {
         PurchaseOrder po = lookupPurchaseOrder(code);
         po.markCompleted();
@@ -237,7 +245,7 @@ public class PurchaseOrderService {
 
     /**
      * 진행 이력 한 행 추가. changedByName 은 도메인 책임자 기준 분기:
-     *   - APPROVED / SHIPPING : 거래처가 책임 주체 — 발주 시점 거래처명 스냅샷(po.vendorName)
+     *   - APPROVED / SHIPPING / DELIVERED : 거래처가 책임 주체 — 발주 시점 거래처명 스냅샷(po.vendorName)
      *     (실제 트리거는 SYS-001 배치지만 자동화는 구현 디테일이라 도메인 이력에 노출하지 않음, ADR-013/019)
      *   - COMPLETED            : 입고 확정은 창고 관리자 책임
      *   - PENDING(생성) / REJECTED(취소) : 본사 관리자
@@ -245,7 +253,7 @@ public class PurchaseOrderService {
      */
     private void appendHistory(PurchaseOrder po, String note) {
         String changedByName = switch (po.getStatus()) {
-            case APPROVED, SHIPPING -> po.getVendorName();
+            case APPROVED, SHIPPING, DELIVERED -> po.getVendorName();
             case COMPLETED -> WAREHOUSE_MANAGER_ACTOR;
             default -> HQ_MANAGER_ACTOR;
         };

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
@@ -87,8 +87,22 @@ public class PurchaseOrder extends BaseEntity {
         this.status = PurchaseOrderStatus.SHIPPING;
     }
 
-    public void markCompleted() {
+    /**
+     * 배송 완료 — SHIPPING → DELIVERED. SYS-001 배치 자동 (30분 경과) 또는 force 트리거.
+     * 거래처 책임 단계 (운송 도착) — ADR-013 / ADR-019 일관.
+     */
+    public void markDelivered() {
         if (this.status != PurchaseOrderStatus.SHIPPING) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.DELIVERED;
+    }
+
+    /**
+     * 입고 확정 — DELIVERED → COMPLETED. 창고 [입고 확정] 액션 (검수 미구현, ADR-015).
+     */
+    public void markCompleted() {
+        if (this.status != PurchaseOrderStatus.DELIVERED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
         this.status = PurchaseOrderStatus.COMPLETED;

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
@@ -1,5 +1,5 @@
 package org.example.stockitbe.hq.purchaseorder.model;
 
 public enum PurchaseOrderStatus {
-    PENDING, APPROVED, SHIPPING, COMPLETED, REJECTED
+    PENDING, APPROVED, SHIPPING, DELIVERED, COMPLETED, REJECTED
 }

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -23,16 +23,16 @@ public class InboundService {
     private final PurchaseOrderService purchaseOrderService;
 
     /**
-     * 입고 목록 — 창고 관심사는 SHIPPING/COMPLETED 만.
-     * status 미지정 시 두 상태 모두, 지정 시 그 status 만 (SHIPPING/COMPLETED 외엔 빈 결과).
+     * 입고 목록 — 창고 관심사는 DELIVERED(도착됨)/COMPLETED(입고완료) 만.
+     * SHIPPING 은 거래처 단계(운송중)라 창고 화면에서 안 보임 — 본사 발주 화면에서 진행 상황만 확인.
+     * status 미지정 시 두 상태 모두, 지정 시 그 status 만 (DELIVERED/COMPLETED 외엔 빈 결과).
      */
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto.ListRes> findAll(PurchaseOrderStatus status,
                                                     String warehouseId,
                                                     LocalDate from, LocalDate to) {
         // PurchaseOrderService.findAll 의 시그니처: (vendorCode, status, from, to).
-        // vendorCode 는 창고 관심사 아니므로 null. status 가 PENDING/APPROVED/REJECTED 등 비-입고 상태면
-        // 위임이 그 status 결과를 줄 텐데, isInboundStatus 필터로 빈 결과 보장.
+        // vendorCode 는 창고 관심사 아니므로 null. status 가 비-입고 상태면 isInboundStatus 필터로 빈 결과 보장.
         List<PurchaseOrderDto.ListRes> all = purchaseOrderService.findAll(null, status, from, to);
         return all.stream()
                 .filter(po -> isInboundStatus(po.getStatus()))
@@ -47,7 +47,7 @@ public class InboundService {
     }
 
     /**
-     * 입고 확정 (WHS-007) — SHIPPING → COMPLETED.
+     * 입고 확정 (WHS-007) — DELIVERED → COMPLETED.
      * 상태 검증·전환·history append 는 PurchaseOrder.markCompleted + Service.appendHistory 가 처리.
      */
     public PurchaseOrderDto.DetailRes confirm(String code) {
@@ -55,6 +55,6 @@ public class InboundService {
     }
 
     private static boolean isInboundStatus(PurchaseOrderStatus s) {
-        return s == PurchaseOrderStatus.SHIPPING || s == PurchaseOrderStatus.COMPLETED;
+        return s == PurchaseOrderStatus.DELIVERED || s == PurchaseOrderStatus.COMPLETED;
     }
 }


### PR DESCRIPTION
## 📌 요약
- 발주 상태머신을 5상태로 확장 (PENDING / APPROVED / SHIPPING / **DELIVERED** / COMPLETED)
- SHIPPING→DELIVERED는 SYS-001 배치 자동 전환(거래처 책임), DELIVERED→COMPLETED만 창고 매뉴얼 [입고 확정]

<br><br>

## 🎯 작업 내용
- `PurchaseOrderStatus` enum에 `DELIVERED` 추가, 전이 메소드(`markDelivered` / `markCompleted`) 신설
- SYS-001 배치에 SHIPPING→DELIVERED 30분 경과 자동 전환 추가 (1건 1트랜잭션 패턴 동일)
- `appendHistory` 분기에 DELIVERED 도 거래처명 적재 (책임 주체 일관)
- `InboundService` 필터: SHIPPING 제외 → DELIVERED / COMPLETED 노출

<br><br>

## ✔️ 참고 사항
- 검수 단계는 ADR-015 결정대로 도입하지 않음 — 도착 확인은 시간 기반 자동 전환으로 통일

<br><br>

## ✔️ 관련 이슈
- Close #147 