### PR TITLE
refactor(purchase-order): 발주-창고 테이블 FK 매핑

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -65,6 +65,7 @@ public enum BaseResponseStatus {
     PURCHASE_ORDER_EMPTY_ITEMS(false, 4302, "발주 품목이 비어 있습니다."),
     PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH(false, 4303, "발주 거래처와 품목의 거래처가 일치하지 않습니다."),
     PURCHASE_ORDER_CANCEL_REASON_REQUIRED(false, 4304, "발주 취소 사유는 필수입니다."),
+    PURCHASE_ORDER_SKU_PRODUCT_MISMATCH(false, 4305, "발주 품목의 SKU가 거래처 계약 제품의 옵션이 아닙니다."),
 
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -4,6 +4,11 @@ import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.WarehouseRepository;
+import org.example.stockitbe.hq.infrastructure.model.Warehouse;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.hq.product.model.ProductStatus;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderItem;
@@ -41,6 +46,8 @@ public class PurchaseOrderService {
     private final PurchaseOrderStatusHistoryRepository historyRepository;
     private final VendorRepository vendorRepository;
     private final VendorProductRepository vendorProductRepository;
+    private final WarehouseRepository warehouseRepository;
+    private final ProductSkuRepository productSkuRepository;
 
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto.ListRes> findAll(String vendorCode, PurchaseOrderStatus status,
@@ -57,10 +64,14 @@ public class PurchaseOrderService {
             return List.of();
         }
 
-        // vendor / itemCount 매핑
+        // vendor / warehouse / itemCount 매핑
         Set<Long> vendorIds = orders.stream().map(PurchaseOrder::getVendorId).collect(Collectors.toSet());
         Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
                 .collect(Collectors.toMap(Vendor::getId, v -> v));
+
+        Set<Long> warehouseIds = orders.stream().map(PurchaseOrder::getWarehouseId).collect(Collectors.toSet());
+        Map<Long, String> warehouseCodeById = warehouseRepository.findAllById(warehouseIds).stream()
+                .collect(Collectors.toMap(Warehouse::getId, Warehouse::getCode));
 
         Set<Long> orderIds = orders.stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
         // batch 1회 조회 결과를 itemCountMap + productNamesMap 두 가지로 활용 (쿼리 0추가)
@@ -80,7 +91,8 @@ public class PurchaseOrderService {
                     }
                     int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
                     List<String> names = productNamesMap.getOrDefault(po.getId(), List.of());
-                    return PurchaseOrderDto.ListRes.from(po, vendor, count, names);
+                    String warehouseCode = warehouseCodeById.getOrDefault(po.getWarehouseId(), "");
+                    return PurchaseOrderDto.ListRes.from(po, vendor, warehouseCode, count, names);
                 })
                 .toList();
     }
@@ -98,6 +110,7 @@ public class PurchaseOrderService {
         }
 
         Vendor vendor = lookupVendor(req.getVendorCode());
+        Warehouse warehouse = lookupWarehouse(req.getWarehouseCode());
 
         // items 의 vendorProduct 모두 조회 + vendor 일치 검증
         List<VendorProduct> vendorProducts = req.getItems().stream()
@@ -110,19 +123,29 @@ public class PurchaseOrderService {
                 })
                 .toList();
 
+        // items 의 SKU 모두 조회 + vp.productCode 일치 검증
+        List<ProductSku> skus = req.getItems().stream()
+                .map(itemReq -> lookupSku(itemReq.getSkuCode()))
+                .toList();
+        for (int i = 0; i < req.getItems().size(); i++) {
+            if (!skus.get(i).getProductCode().equals(vendorProducts.get(i).getProductCode())) {
+                throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_SKU_PRODUCT_MISMATCH);
+            }
+        }
+
         long totalAmount = 0L;
         for (int i = 0; i < req.getItems().size(); i++) {
-            totalAmount += vendorProducts.get(i).getUnitPrice() * req.getItems().get(i).getQuantity();
+            totalAmount += skus.get(i).getUnitPrice() * req.getItems().get(i).getQuantity();
         }
 
         String code = generateCode();
-        PurchaseOrder entity = req.toEntity(vendor, code, totalAmount);
+        PurchaseOrder entity = req.toEntity(vendor, warehouse, code, totalAmount);
         PurchaseOrder saved = purchaseOrderRepository.save(entity);
 
         // items 저장 (purchaseOrderId 채움)
         List<PurchaseOrderItem> items = new ArrayList<>();
         for (int i = 0; i < req.getItems().size(); i++) {
-            PurchaseOrderItem item = req.getItems().get(i).toEntity(saved.getId(), vendorProducts.get(i));
+            PurchaseOrderItem item = req.getItems().get(i).toEntity(saved.getId(), vendorProducts.get(i), skus.get(i));
             items.add(item);
         }
         itemRepository.saveAll(items);
@@ -143,6 +166,8 @@ public class PurchaseOrderService {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
 
+        Warehouse warehouse = lookupWarehouse(req.getWarehouseCode());
+
         // items 의 vendorProduct 검증 (vendor 일치)
         List<VendorProduct> vendorProducts = req.getItems().stream()
                 .map(itemReq -> {
@@ -154,6 +179,16 @@ public class PurchaseOrderService {
                 })
                 .toList();
 
+        // items 의 SKU 검증 (vp.productCode 일치)
+        List<ProductSku> skus = req.getItems().stream()
+                .map(itemReq -> lookupSku(itemReq.getSkuCode()))
+                .toList();
+        for (int i = 0; i < req.getItems().size(); i++) {
+            if (!skus.get(i).getProductCode().equals(vendorProducts.get(i).getProductCode())) {
+                throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_SKU_PRODUCT_MISMATCH);
+            }
+        }
+
         // 기존 items 삭제
         itemRepository.deleteAllByPurchaseOrderId(po.getId());
         itemRepository.flush();
@@ -161,12 +196,12 @@ public class PurchaseOrderService {
         // 신규 items 빌드/save
         List<PurchaseOrderItem> newItems = new ArrayList<>();
         for (int i = 0; i < req.getItems().size(); i++) {
-            newItems.add(req.getItems().get(i).toEntity(po.getId(), vendorProducts.get(i)));
+            newItems.add(req.getItems().get(i).toEntity(po.getId(), vendorProducts.get(i), skus.get(i)));
         }
         itemRepository.saveAll(newItems);
 
-        // 창고/회원 logical reference 업데이트 + totalAmount 재계산
-        po.updateLogistics(req.getWarehouseId(), req.getWarehouseName());
+        // 창고 스냅샷 갱신 (서버 lookup 결과) + totalAmount 재계산
+        po.updateLogistics(warehouse.getId(), warehouse.getName());
         po.recalculateTotalAmount(newItems);
 
         return buildDetailRes(po);
@@ -232,6 +267,23 @@ public class PurchaseOrderService {
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_PRODUCT_NOT_FOUND));
     }
 
+    private Warehouse lookupWarehouse(String code) {
+        if (code == null || code.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND);
+        }
+        return warehouseRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND));
+    }
+
+    private ProductSku lookupSku(String skuCode) {
+        ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
+        if (sku.getStatus() != ProductStatus.ACTIVE) {
+            throw BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND);
+        }
+        return sku;
+    }
+
     /**
      * 코드 자동 생성 — PO-{YYYYMMDD}-{NNN}.
      * NNN 은 같은 날 prefix count + 1 (3자리 zero-pad).
@@ -245,15 +297,16 @@ public class PurchaseOrderService {
 
     /**
      * 진행 이력 한 행 추가. changedByName 은 도메인 책임자 기준 분기:
-     *   - APPROVED / SHIPPING / DELIVERED : 거래처가 책임 주체 — 발주 시점 거래처명 스냅샷(po.vendorName)
+     *   - APPROVED / SHIPPING / DELIVERED : "담당자명 (회사명)" 형식 — 발주 시점 거래처 스냅샷
      *     (실제 트리거는 SYS-001 배치지만 자동화는 구현 디테일이라 도메인 이력에 노출하지 않음, ADR-013/019)
+     *     실무 ERP 표준 — 법적 주체(회사) + 실무 처리자(담당자) 둘 다 노출.
      *   - COMPLETED            : 입고 확정은 창고 관리자 책임
      *   - PENDING(생성) / REJECTED(취소) : 본사 관리자
      * 인증 도입(ADR-011) 후 본사·창고 관리자명은 실제 사용자명으로 교체.
      */
     private void appendHistory(PurchaseOrder po, String note) {
         String changedByName = switch (po.getStatus()) {
-            case APPROVED, SHIPPING, DELIVERED -> po.getVendorName();
+            case APPROVED, SHIPPING, DELIVERED -> po.getVendorContactName() + " (" + po.getVendorName() + ")";
             case COMPLETED -> WAREHOUSE_MANAGER_ACTOR;
             default -> HQ_MANAGER_ACTOR;
         };
@@ -270,6 +323,11 @@ public class PurchaseOrderService {
         Vendor vendor = vendorRepository.findById(po.getVendorId())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
 
+        // warehouse code lookup (응답용 — id → code 변환)
+        String warehouseCode = warehouseRepository.findById(po.getWarehouseId())
+                .map(Warehouse::getCode)
+                .orElse("");
+
         List<PurchaseOrderItem> items = itemRepository.findAllByPurchaseOrderId(po.getId());
         List<PurchaseOrderStatusHistory> history = historyRepository.findAllByPurchaseOrderIdOrderByChangedAtAsc(po.getId());
 
@@ -281,7 +339,7 @@ public class PurchaseOrderService {
                     .forEach(vp -> codeMap.put(vp.getId(), vp.getCode()));
         }
 
-        return PurchaseOrderDto.DetailRes.from(po, vendor, items, history, codeMap);
+        return PurchaseOrderDto.DetailRes.from(po, vendor, warehouseCode, items, history, codeMap);
     }
 
     private Specification<PurchaseOrder> buildSpec(Long vendorId, PurchaseOrderStatus status,

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
@@ -30,15 +30,20 @@ public class PurchaseOrder extends BaseEntity {
     private Long vendorId;
 
     // vendor.name 시점 복사 — 발주 시점의 거래처명 스냅샷 (warehouseName/memberName 패턴과 동일).
-    // statusHistory.changedByName 에 거래처 책임 전환(APPROVED/SHIPPING) 주체로 박힘.
     @Column(name = "vendor_name", nullable = false, length = 128)
     private String vendorName;
 
-    // 창고 BE 미구현 — logical reference (id String + name 시점 복사)
-    @Column(name = "warehouse_id", length = 32)
-    private String warehouseId;
+    // vendor.contactName 시점 복사 — 거래처 담당자명. statusHistory.changedByName 에
+    // APPROVED/SHIPPING/DELIVERED 단계 주체로 박힘 (회사명보다 사람 이름이 자연).
+    @Column(name = "vendor_contact_name", nullable = false, length = 64)
+    private String vendorContactName;
 
-    @Column(name = "warehouse_name", length = 128)
+    // warehouse FK — Long ID 참조 + name 시점 복사 스냅샷 (vendor 패턴 일관, 결합 차단 4패턴 #1).
+    // @ManyToOne 박지 않음 — N+1/lazy 함정 회피, 패키지 결합 차단. DB FK 제약은 별 마이그레이션 SQL.
+    @Column(name = "warehouse_id", nullable = false)
+    private Long warehouseId;
+
+    @Column(name = "warehouse_name", nullable = false, length = 128)
     private String warehouseName;
 
     // 회원 BE 미구현, 인증 미정 — logical reference
@@ -59,12 +64,13 @@ public class PurchaseOrder extends BaseEntity {
     private String cancelReason;
 
     @Builder
-    private PurchaseOrder(String code, Long vendorId, String vendorName,
-                          String warehouseId, String warehouseName,
+    private PurchaseOrder(String code, Long vendorId, String vendorName, String vendorContactName,
+                          Long warehouseId, String warehouseName,
                           String memberId, String memberName, Long totalAmount) {
         this.code = code;
         this.vendorId = vendorId;
         this.vendorName = vendorName;
+        this.vendorContactName = vendorContactName;
         this.warehouseId = warehouseId;
         this.warehouseName = warehouseName;
         this.memberId = memberId;
@@ -128,7 +134,7 @@ public class PurchaseOrder extends BaseEntity {
         this.totalAmount = sum;
     }
 
-    public void updateLogistics(String warehouseId, String warehouseName) {
+    public void updateLogistics(Long warehouseId, String warehouseName) {
         if (this.status != PurchaseOrderStatus.PENDING) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
@@ -9,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.stockitbe.hq.infrastructure.model.Warehouse;
+import org.example.stockitbe.hq.product.model.ProductSku;
 import org.example.stockitbe.hq.vendor.model.Vendor;
 import org.example.stockitbe.hq.vendor.model.VendorProduct;
 
@@ -25,8 +27,9 @@ public class PurchaseOrderDto {
     public static class CreateReq {
         @NotBlank
         private String vendorCode;
-        private String warehouseId;
-        private String warehouseName;
+        @NotBlank
+        private String warehouseCode;
+        // warehouseName 필드 폐기 — 서버가 lookupWarehouse 후 name 박음 (vendor 패턴 일관)
         // 인증 미정 — placeholder OK
         private String memberId;
         private String memberName;
@@ -34,13 +37,14 @@ public class PurchaseOrderDto {
         @NotEmpty
         private List<ItemReq> items;
 
-        public PurchaseOrder toEntity(Vendor vendor, String code, Long totalAmount) {
+        public PurchaseOrder toEntity(Vendor vendor, Warehouse warehouse, String code, Long totalAmount) {
             return PurchaseOrder.builder()
                     .code(code)
                     .vendorId(vendor.getId())
                     .vendorName(vendor.getName())
-                    .warehouseId(this.warehouseId)
-                    .warehouseName(this.warehouseName)
+                    .vendorContactName(vendor.getContactName())
+                    .warehouseId(warehouse.getId())
+                    .warehouseName(warehouse.getName())
                     .memberId(this.memberId)
                     .memberName(this.memberName)
                     .totalAmount(totalAmount)
@@ -55,17 +59,22 @@ public class PurchaseOrderDto {
     public static class ItemReq {
         @NotBlank
         private String vendorProductCode;
+        @NotBlank
+        private String skuCode;
         @NotNull
         @Min(1)
         private Integer quantity;
 
-        public PurchaseOrderItem toEntity(Long purchaseOrderId, VendorProduct vp) {
+        public PurchaseOrderItem toEntity(Long purchaseOrderId, VendorProduct vp, ProductSku sku) {
             return PurchaseOrderItem.builder()
                     .purchaseOrderId(purchaseOrderId)
                     .vendorProductId(vp.getId())
                     .productCode(vp.getProductCode())
                     .productName(vp.getProductName())
-                    .unitPrice(vp.getUnitPrice())
+                    .skuCode(sku.getSkuCode())
+                    .optionName(sku.getOptionName())
+                    .optionValue(sku.getOptionValue())
+                    .unitPrice(sku.getUnitPrice())  // sku 단가 우선 (옵션별 차등 가능)
                     .quantity(this.quantity)
                     .build();
         }
@@ -76,8 +85,9 @@ public class PurchaseOrderDto {
     @AllArgsConstructor
     @Builder
     public static class UpdateReq {
-        private String warehouseId;
-        private String warehouseName;
+        @NotBlank
+        private String warehouseCode;
+        // warehouseName 필드 폐기 — 서버가 lookupWarehouse 후 name 박음
         @Valid
         @NotEmpty
         private List<ItemReq> items;
@@ -99,7 +109,8 @@ public class PurchaseOrderDto {
         private String code;
         private String vendorCode;
         private String vendorName;
-        private String warehouseId;
+        private Long warehouseId;
+        private String warehouseCode;
         private String warehouseName;
         private String memberName;
         private PurchaseOrderStatus status;
@@ -110,12 +121,14 @@ public class PurchaseOrderDto {
         private Date createdAt;
         private Date updatedAt;
 
-        public static ListRes from(PurchaseOrder po, Vendor vendor, int itemCount, List<String> productNames) {
+        public static ListRes from(PurchaseOrder po, Vendor vendor, String warehouseCode,
+                                    int itemCount, List<String> productNames) {
             return ListRes.builder()
                     .code(po.getCode())
                     .vendorCode(vendor.getCode())
                     .vendorName(po.getVendorName())
                     .warehouseId(po.getWarehouseId())
+                    .warehouseCode(warehouseCode)
                     .warehouseName(po.getWarehouseName())
                     .memberName(po.getMemberName())
                     .status(po.getStatus())
@@ -135,7 +148,8 @@ public class PurchaseOrderDto {
         private String code;
         private String vendorCode;
         private String vendorName;
-        private String warehouseId;
+        private Long warehouseId;
+        private String warehouseCode;
         private String warehouseName;
         private String memberId;
         private String memberName;
@@ -147,7 +161,7 @@ public class PurchaseOrderDto {
         private List<ItemRes> items;
         private List<HistoryRes> statusHistory;
 
-        public static DetailRes from(PurchaseOrder po, Vendor vendor,
+        public static DetailRes from(PurchaseOrder po, Vendor vendor, String warehouseCode,
                                       List<PurchaseOrderItem> items,
                                       List<PurchaseOrderStatusHistory> history,
                                       Map<Long, String> vendorProductCodeById) {
@@ -162,6 +176,7 @@ public class PurchaseOrderDto {
                     .vendorCode(vendor.getCode())
                     .vendorName(po.getVendorName())
                     .warehouseId(po.getWarehouseId())
+                    .warehouseCode(warehouseCode)
                     .warehouseName(po.getWarehouseName())
                     .memberId(po.getMemberId())
                     .memberName(po.getMemberName())
@@ -184,6 +199,9 @@ public class PurchaseOrderDto {
         private String vendorProductCode;
         private String productCode;
         private String productName;
+        private String skuCode;
+        private String optionName;
+        private String optionValue;
         private Long unitPrice;
         private Integer quantity;
         private Long subtotal;
@@ -194,6 +212,9 @@ public class PurchaseOrderDto {
                     .vendorProductCode(vendorProductCode)
                     .productCode(item.getProductCode())
                     .productName(item.getProductName())
+                    .skuCode(item.getSkuCode())
+                    .optionName(item.getOptionName())
+                    .optionValue(item.getOptionValue())
                     .unitPrice(item.getUnitPrice())
                     .quantity(item.getQuantity())
                     .subtotal(item.getSubtotal())

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
@@ -29,7 +29,18 @@ public class PurchaseOrderItem {
     @Column(name = "product_name", nullable = false, length = 256)
     private String productName;
 
-    // 발주 시점 단가 복사
+    // SKU 식별자 + 옵션 스냅샷 (결합 차단 4패턴 #1 — String ID + 시점 복사, @ManyToOne ProductSku 미사용)
+    // 슬래시 합성 컨벤션 — 다차원이면 optionName="색상/사이즈" optionValue="화이트/L", 단일이면 슬래시 없음
+    @Column(name = "sku_code", nullable = false, length = 32)
+    private String skuCode;
+
+    @Column(name = "option_name", nullable = false, length = 64)
+    private String optionName;
+
+    @Column(name = "option_value", nullable = false, length = 64)
+    private String optionValue;
+
+    // 발주 시점 단가 복사 — sku.unitPrice 우선 (옵션별 차등 가능)
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
@@ -42,11 +53,15 @@ public class PurchaseOrderItem {
     @Builder
     private PurchaseOrderItem(Long purchaseOrderId, Long vendorProductId,
                               String productCode, String productName,
+                              String skuCode, String optionName, String optionValue,
                               Long unitPrice, Integer quantity) {
         this.purchaseOrderId = purchaseOrderId;
         this.vendorProductId = vendorProductId;
         this.productCode = productCode;
         this.productName = productName;
+        this.skuCode = skuCode;
+        this.optionName = optionName;
+        this.optionValue = optionValue;
         this.unitPrice = unitPrice;
         this.quantity = quantity;
         this.subtotal = unitPrice * quantity;

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
@@ -32,18 +32,18 @@ public class VendorSeedRunner implements CommandLineRunner {
         }
 
         List<Vendor> seed = List.of(
-                vendor("VND-001", "(주)테크서플라이",     "김민준", "02-1234-5678",  "minjun.kim@techsupply.co.kr",     VendorStatus.ACTIVE),
-                vendor("VND-002", "한국생활물산",          "이수연", "031-9876-5432", "suyeon.lee@kliving.co.kr",        VendorStatus.ACTIVE),
-                vendor("VND-003", "글로벌오피스",          "박재현", "02-5555-3333",  "jaehyun.park@globaloffice.com",   VendorStatus.ACTIVE),
-                vendor("VND-004", "위생물자(주)",          "최영희", "032-7777-8888", "younghee.choi@hygiene.co.kr",     VendorStatus.INACTIVE),
-                vendor("VND-005", "스마트주방솔루션",      "정도현", "051-4444-2222", "dohyun.jung@smartkitchen.kr",     VendorStatus.ACTIVE),
-                vendor("VND-006", "패션라인(주)",          "한지윤", "02-2222-1111",  "jiyoon.han@fashionline.co.kr",    VendorStatus.ACTIVE),
-                vendor("VND-007", "슈즈모아",              "임도현", "053-3333-4444", "dohyun.lim@shoesmoa.com",         VendorStatus.ACTIVE),
-                vendor("VND-008", "코스메틱플러스",        "윤서연", "02-8888-9999",  "seoyeon.yoon@cosmeticplus.kr",    VendorStatus.ACTIVE),
-                vendor("VND-009", "오피스인테리어(주)",    "강민호", "031-2222-3333", "minho.kang@officeint.co.kr",      VendorStatus.ACTIVE),
-                vendor("VND-010", "푸드유통센터",          "송지원", "02-7777-1111",  "jiwon.song@fooddist.co.kr",       VendorStatus.ACTIVE),
-                vendor("VND-011", "그린리빙코리아",        "노승현", "042-5555-6666", "seunghyun.noh@greenliving.kr",    VendorStatus.ACTIVE),
-                vendor("VND-012", "베스트가전",            "신유정", "02-3333-7777",  "yujung.shin@bestappliance.co.kr", VendorStatus.INACTIVE)
+                vendor("VND-001", "(주)베이직어패럴",       "김민준", "02-1234-5678",  "minjun.kim@basicapparel.co.kr",   VendorStatus.ACTIVE),
+                vendor("VND-002", "모던셔츠",               "이수연", "031-9876-5432", "suyeon.lee@modernshirt.co.kr",    VendorStatus.ACTIVE),
+                vendor("VND-003", "데일리진",               "박재현", "02-5555-3333",  "jaehyun.park@dailyjean.co.kr",    VendorStatus.ACTIVE),
+                vendor("VND-004", "컴포트팬츠",             "최영희", "032-7777-8888", "younghee.choi@comfortpants.co.kr",VendorStatus.ACTIVE),
+                vendor("VND-005", "니트하우스",             "정도현", "051-4444-2222", "dohyun.jung@knithouse.co.kr",     VendorStatus.ACTIVE),
+                vendor("VND-006", "어반아우터",             "한지윤", "02-2222-1111",  "jiyoon.han@urbanouter.co.kr",     VendorStatus.ACTIVE),
+                vendor("VND-007", "(주)패딩프로",           "임도현", "053-3333-4444", "dohyun.lim@paddingpro.co.kr",     VendorStatus.ACTIVE),
+                vendor("VND-008", "트렌디드레스",           "윤서연", "02-8888-9999",  "seoyeon.yoon@trendydress.co.kr",  VendorStatus.ACTIVE),
+                vendor("VND-009", "슈즈크래프트",           "강민호", "031-2222-3333", "minho.kang@shoecraft.co.kr",      VendorStatus.ACTIVE),
+                vendor("VND-010", "캐주얼백",               "송지원", "02-7777-1111",  "jiwon.song@casualbag.co.kr",      VendorStatus.ACTIVE),
+                vendor("VND-011", "베이직삭스",             "노승현", "042-5555-6666", "seunghyun.noh@basicsocks.co.kr",  VendorStatus.ACTIVE),
+                vendor("VND-012", "헤리티지스카프",         "신유정", "02-3333-7777",  "yujung.shin@heritagescarf.co.kr", VendorStatus.INACTIVE)
         );
 
         vendorRepository.saveAll(seed);

--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardController.java
@@ -27,7 +27,7 @@ public class DashboardController {
 
     @GetMapping("/inbound-progress")
     public BaseResponse<DashboardDto.InboundProgressRes> getInboundProgress(
-            @RequestParam(required = false) String warehouseId,
+            @RequestParam(required = false) Long warehouseId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
         return BaseResponse.success(service.getInboundProgress(warehouseId, from, to));

--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
@@ -38,7 +38,7 @@ public class DashboardService {
     private final PurchaseOrderStatusHistoryRepository historyRepository;
 
     @Transactional(readOnly = true)
-    public DashboardDto.InboundProgressRes getInboundProgress(String warehouseId,
+    public DashboardDto.InboundProgressRes getInboundProgress(Long warehouseId,
                                                                 LocalDate from, LocalDate to) {
         Specification<PurchaseOrder> spec = buildSpec(warehouseId, from, to);
         List<PurchaseOrder> orders = purchaseOrderRepository.findAll(spec);
@@ -126,10 +126,10 @@ public class DashboardService {
         return Math.round(avg * 10.0) / 10.0;
     }
 
-    private Specification<PurchaseOrder> buildSpec(String warehouseId, LocalDate from, LocalDate to) {
+    private Specification<PurchaseOrder> buildSpec(Long warehouseId, LocalDate from, LocalDate to) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            if (warehouseId != null && !warehouseId.isBlank()) {
+            if (warehouseId != null) {
                 predicates.add(cb.equal(root.get("warehouseId"), warehouseId));
             }
             if (from != null) {

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
@@ -32,7 +32,7 @@ public class InboundController {
     @GetMapping
     public BaseResponse<List<PurchaseOrderDto.ListRes>> list(
             @RequestParam(required = false) PurchaseOrderStatus status,
-            @RequestParam(required = false) String warehouseId,
+            @RequestParam(required = false) Long warehouseId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
         return BaseResponse.success(service.findAll(status, warehouseId, from, to));

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -29,15 +29,14 @@ public class InboundService {
      */
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto.ListRes> findAll(PurchaseOrderStatus status,
-                                                    String warehouseId,
+                                                    Long warehouseId,
                                                     LocalDate from, LocalDate to) {
         // PurchaseOrderService.findAll 의 시그니처: (vendorCode, status, from, to).
         // vendorCode 는 창고 관심사 아니므로 null. status 가 비-입고 상태면 isInboundStatus 필터로 빈 결과 보장.
         List<PurchaseOrderDto.ListRes> all = purchaseOrderService.findAll(null, status, from, to);
         return all.stream()
                 .filter(po -> isInboundStatus(po.getStatus()))
-                .filter(po -> warehouseId == null || warehouseId.isBlank()
-                        || warehouseId.equals(po.getWarehouseId()))
+                .filter(po -> warehouseId == null || warehouseId.equals(po.getWarehouseId()))
                 .toList();
     }
 


### PR DESCRIPTION
## 📌 요약
- 발주(`PurchaseOrder`)의 창고 참조를 logical reference(시점 복사)에서 **FK 매핑**으로 정합화

<br><br>

## 🎯 작업 내용
- `PurchaseOrder.warehouseId` FK 제약 / 연관관계 매핑 추가
- 등록 시 창고 마스터 존재 검증 + 미존재 응답 코드 정의
- 목록 / 상세 응답의 창고 정보 batch lookup으로 N+1 회피

<br><br>

## ✔️ 참고 사항
- `warehouseName` 시점 복사 정책은 유지 (이력 무결성)

<br><br>

## ✔️ 관련 이슈
- Close #150 