### PR TITLE
refactor(purchase-order): 새 발주 카탈로그 SKU 단위 응답 엔드포인트 추가

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterRepository.java
@@ -3,6 +3,7 @@ package org.example.stockitbe.hq.product;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,5 @@ public interface ProductMasterRepository extends JpaRepository<ProductMaster, Lo
     boolean existsByNameIgnoreCaseAndCodeNot(String name, String code);
     List<ProductMaster> findByNameContainingIgnoreCaseAndCategoryCodeContainingIgnoreCaseOrderByIdDesc(String keyword, String categoryCode);
     List<ProductMaster> findAllByOrderByIdDesc();
+    List<ProductMaster> findAllByCodeIn(Collection<String> codes);
 }

--- a/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
@@ -3,6 +3,7 @@ package org.example.stockitbe.hq.product;
 import org.example.stockitbe.hq.product.model.ProductSku;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +14,5 @@ public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
     List<ProductSku> findAllByOrderByIdDesc();
     boolean existsByProductCodeAndOptionNameAndOptionValue(String productCode, String optionName, String optionValue);
     long deleteByProductCode(String productCode);
+    List<ProductSku> findAllByProductCodeInOrderByIdAsc(Collection<String> productCodes);
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogController.java
@@ -1,0 +1,24 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderCatalogDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hq/purchase-orders/catalog")
+@RequiredArgsConstructor
+public class PurchaseOrderCatalogController {
+
+    private final PurchaseOrderCatalogService service;
+
+    @GetMapping
+    public BaseResponse<PurchaseOrderCatalogDto.CatalogRes> getCatalog(
+            @RequestParam(required = false) String vendorCode,
+            @RequestParam(required = false) Long warehouseId) {
+        return BaseResponse.success(service.getCatalog(vendorCode, warehouseId));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
@@ -1,0 +1,165 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.hq.product.model.ProductStatus;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderCatalogDto;
+import org.example.stockitbe.hq.vendor.VendorProductRepository;
+import org.example.stockitbe.hq.vendor.VendorRepository;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorProduct;
+import org.example.stockitbe.hq.vendor.model.VendorProductStatus;
+import org.example.stockitbe.hq.vendor.model.VendorStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * 새 발주 페이지 카탈로그 read-only 집계 서비스.
+ *
+ * vendor_product → ProductMaster → ProductSku 를 묶어서 한 번에 응답.
+ * FE 가 마스터 N건마다 SKU 추가 fetch 하는 N+1 회피 목적.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PurchaseOrderCatalogService {
+
+    private final VendorProductRepository vendorProductRepository;
+    private final VendorRepository vendorRepository;
+    private final ProductMasterRepository productMasterRepository;
+    private final ProductSkuRepository productSkuRepository;
+
+    /**
+     * vendorCode 미지정 → 모든 ACTIVE 거래처의 ACTIVE 계약 펼침.
+     * 지정 시 그 거래처만.
+     *
+     * warehouseId 는 본 사이클에선 사용 X (인벤토리 합류 후 stock 필터링용 placeholder).
+     *
+     * 응답 룰:
+     *  - vendor.status != ACTIVE 거래처는 제외
+     *  - vendor_product.status != ACTIVE 계약은 제외
+     *  - product_master.status != ACTIVE 마스터는 제외
+     *  - product_sku.status != ACTIVE SKU 는 제외
+     *  - SKU 0건 마스터는 결과에서 제외 (발주 불가가 자연)
+     */
+    public PurchaseOrderCatalogDto.CatalogRes getCatalog(String vendorCode, Long warehouseId) {
+        // 1) VendorProduct 후보 조회 (ACTIVE 만)
+        List<VendorProduct> vendorProducts = loadActiveVendorProducts(vendorCode);
+        if (vendorProducts.isEmpty()) {
+            return PurchaseOrderCatalogDto.CatalogRes.builder()
+                    .masters(List.of())
+                    .optionFacets(List.of())
+                    .build();
+        }
+
+        // 2) Vendor 일괄 조회 + ACTIVE 만 통과
+        Set<Long> vendorIds = vendorProducts.stream()
+                .map(VendorProduct::getVendorId)
+                .collect(Collectors.toSet());
+        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
+                .filter(v -> v.getStatus() == VendorStatus.ACTIVE)
+                .collect(Collectors.toMap(Vendor::getId, v -> v));
+
+        // 3) ProductMaster 일괄 조회 + ACTIVE 만 통과 (productCode key)
+        Set<String> productCodes = vendorProducts.stream()
+                .map(VendorProduct::getProductCode)
+                .collect(Collectors.toSet());
+        Map<String, ProductMaster> productMap = productMasterRepository.findAllByCodeIn(productCodes).stream()
+                .filter(p -> p.getStatus() == ProductStatus.ACTIVE)
+                .collect(Collectors.toMap(ProductMaster::getCode, p -> p));
+
+        // 4) ProductSku 일괄 조회 + ACTIVE 만 통과 (productCode 별 group)
+        Map<String, List<ProductSku>> skusByProductCode = productSkuRepository
+                .findAllByProductCodeInOrderByIdAsc(productCodes).stream()
+                .filter(s -> s.getStatus() == ProductStatus.ACTIVE)
+                .collect(Collectors.groupingBy(ProductSku::getProductCode));
+
+        // 5) MasterRes 빌드 (SKU 0건 마스터 제외)
+        List<PurchaseOrderCatalogDto.MasterRes> masters = new ArrayList<>();
+        for (VendorProduct vp : vendorProducts) {
+            Vendor vendor = vendorMap.get(vp.getVendorId());
+            if (vendor == null) continue; // vendor 비ACTIVE
+            ProductMaster master = productMap.get(vp.getProductCode());
+            if (master == null) continue; // master 비ACTIVE 또는 없음
+            List<ProductSku> skus = skusByProductCode.getOrDefault(vp.getProductCode(), List.of());
+            if (skus.isEmpty()) continue; // SKU 0건 마스터 제외
+
+            List<PurchaseOrderCatalogDto.SkuRes> skuResList = skus.stream()
+                    .map(s -> PurchaseOrderCatalogDto.SkuRes.builder()
+                            .skuCode(s.getSkuCode())
+                            .optionName(s.getOptionName())
+                            .optionValue(s.getOptionValue())
+                            .unitPrice(s.getUnitPrice())
+                            .build())
+                    .toList();
+            long minPrice = skus.stream().mapToLong(ProductSku::getUnitPrice).min().orElse(0L);
+            long maxPrice = skus.stream().mapToLong(ProductSku::getUnitPrice).max().orElse(0L);
+
+            masters.add(PurchaseOrderCatalogDto.MasterRes.builder()
+                    .vendorCode(vendor.getCode())
+                    .vendorName(vendor.getName())
+                    .vendorProductCode(vp.getCode())
+                    .productCode(master.getCode())
+                    .productName(master.getName())
+                    .contractUnitPrice(vp.getUnitPrice())
+                    .minSkuUnitPrice(minPrice)
+                    .maxSkuUnitPrice(maxPrice)
+                    .skus(skuResList)
+                    .build());
+        }
+
+        // 6) optionFacets 빌드 — axis name 별 unique 값 셋. 슬래시 합성 axis 는 분해
+        Map<String, Set<String>> facetMap = new LinkedHashMap<>();
+        for (PurchaseOrderCatalogDto.MasterRes m : masters) {
+            for (PurchaseOrderCatalogDto.SkuRes s : m.getSkus()) {
+                String[] names = (s.getOptionName() == null ? "" : s.getOptionName()).split("/");
+                String[] values = (s.getOptionValue() == null ? "" : s.getOptionValue()).split("/");
+                int len = Math.min(names.length, values.length);
+                for (int i = 0; i < len; i++) {
+                    String axis = names[i].trim();
+                    String value = values[i].trim();
+                    if (axis.isEmpty() || value.isEmpty()) continue;
+                    facetMap.computeIfAbsent(axis, k -> new TreeSet<>()).add(value);
+                }
+            }
+        }
+        List<PurchaseOrderCatalogDto.FacetRes> facets = facetMap.entrySet().stream()
+                .map(e -> PurchaseOrderCatalogDto.FacetRes.builder()
+                        .name(e.getKey())
+                        .values(new ArrayList<>(e.getValue()))
+                        .build())
+                .sorted(Comparator.comparing(PurchaseOrderCatalogDto.FacetRes::getName))
+                .toList();
+
+        return PurchaseOrderCatalogDto.CatalogRes.builder()
+                .masters(masters)
+                .optionFacets(facets)
+                .build();
+    }
+
+    private List<VendorProduct> loadActiveVendorProducts(String vendorCode) {
+        if (vendorCode != null && !vendorCode.isBlank()) {
+            Vendor vendor = vendorRepository.findByCode(vendorCode)
+                    .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+            return vendorProductRepository
+                    .findAllByVendorIdAndStatusNotOrderByIdDesc(vendor.getId(), VendorProductStatus.DELETED).stream()
+                    .filter(vp -> vp.getStatus() == VendorProductStatus.ACTIVE)
+                    .toList();
+        }
+        return vendorProductRepository.findAllByStatusOrderByIdDesc(VendorProductStatus.ACTIVE);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderCatalogDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderCatalogDto.java
@@ -1,0 +1,59 @@
+package org.example.stockitbe.hq.purchaseorder.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 새 발주 페이지 카탈로그 응답 DTO.
+ *
+ * 카탈로그 한 행 = 한 SKU 표시를 위해 BE 가 마스터 + SKU 묶음 + optionFacets 를 한 번에 내려준다.
+ * vendor_product 도메인 오염 회피를 위해 발주 도메인 안에 신설.
+ *
+ * stock 관련 필드(available/safety)는 인벤토리 도메인 합류 후 SkuRes 에 nullable 추가 예정 — 본 사이클은 제외.
+ */
+public class PurchaseOrderCatalogDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CatalogRes {
+        private List<MasterRes> masters;
+        private List<FacetRes> optionFacets;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class MasterRes {
+        private String vendorCode;
+        private String vendorName;
+        private String vendorProductCode;   // VendorProduct.code (한 마스터의 식별자)
+        private String productCode;          // ProductMaster.code
+        private String productName;
+        private Long contractUnitPrice;      // VendorProduct.unitPrice (계약 기본 단가, SKU 단가 fallback)
+        private Long minSkuUnitPrice;        // 그룹 안 SKU 단가 최소
+        private Long maxSkuUnitPrice;        // 그룹 안 SKU 단가 최대 — 범위 표시 (₩6,800~7,200)
+        private List<SkuRes> skus;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class SkuRes {
+        private String skuCode;
+        private String optionName;           // 슬래시 합성 ("색상/사이즈")
+        private String optionValue;          // 슬래시 합성 ("화이트/L")
+        private Long unitPrice;              // SKU 단가 (sku.unit_price 우선)
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class FacetRes {
+        private String name;                 // 단일 axis name. 슬래시 합성 axis 는 분해해서 각각 facet
+        private List<String> values;         // 자연 정렬
+    }
+}

--- a/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
+++ b/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
@@ -1,0 +1,175 @@
+package org.example.stockitbe.hq.purchaseorder;
+
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.hq.product.model.ProductStatus;
+import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderCatalogDto;
+import org.example.stockitbe.hq.vendor.VendorProductRepository;
+import org.example.stockitbe.hq.vendor.VendorRepository;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorProduct;
+import org.example.stockitbe.hq.vendor.model.VendorProductStatus;
+import org.example.stockitbe.hq.vendor.model.VendorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderCatalogServiceTest {
+
+    @Mock VendorProductRepository vendorProductRepository;
+    @Mock VendorRepository vendorRepository;
+    @Mock ProductMasterRepository productMasterRepository;
+    @Mock ProductSkuRepository productSkuRepository;
+
+    @InjectMocks PurchaseOrderCatalogService service;
+
+    private Vendor vendorA;
+    private Vendor vendorB;
+    private VendorProduct vpA1; // vendorA, productCode=PM-A
+    private VendorProduct vpB1; // vendorB, productCode=PM-B
+    private VendorProduct vpA2; // vendorA, productCode=PM-EMPTY (SKU 0건)
+    private ProductMaster pmA;
+    private ProductMaster pmB;
+    private ProductMaster pmEmpty;
+
+    @BeforeEach
+    void setUp() {
+        vendorA = Vendor.builder().code("VND-A").name("거래처A").contactName("담당A")
+                .status(VendorStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(vendorA, "id", 1L);
+
+        vendorB = Vendor.builder().code("VND-B").name("거래처B").contactName("담당B")
+                .status(VendorStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(vendorB, "id", 2L);
+
+        vpA1 = VendorProduct.builder().code("VP-A-001").vendorId(1L)
+                .productCode("PM-A").productName("티셔츠").unitPrice(6800L)
+                .status(VendorProductStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(vpA1, "id", 11L);
+
+        vpB1 = VendorProduct.builder().code("VP-B-001").vendorId(2L)
+                .productCode("PM-B").productName("니트").unitPrice(15000L)
+                .status(VendorProductStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(vpB1, "id", 21L);
+
+        vpA2 = VendorProduct.builder().code("VP-A-002").vendorId(1L)
+                .productCode("PM-EMPTY").productName("빈제품").unitPrice(9000L)
+                .status(VendorProductStatus.ACTIVE).build();
+        ReflectionTestUtils.setField(vpA2, "id", 12L);
+
+        pmA = ProductMaster.builder().code("PM-A").name("티셔츠").categoryCode("CAT-1")
+                .basePrice(6800L).leadTimeDays(7).mainVendorCode("VND-A")
+                .status(ProductStatus.ACTIVE).build();
+        pmB = ProductMaster.builder().code("PM-B").name("니트").categoryCode("CAT-1")
+                .basePrice(15000L).leadTimeDays(10).mainVendorCode("VND-B")
+                .status(ProductStatus.ACTIVE).build();
+        pmEmpty = ProductMaster.builder().code("PM-EMPTY").name("빈제품").categoryCode("CAT-1")
+                .basePrice(9000L).leadTimeDays(7).mainVendorCode("VND-A")
+                .status(ProductStatus.ACTIVE).build();
+    }
+
+    private ProductSku sku(String skuCode, String productCode, String optionName, String optionValue, long price) {
+        return ProductSku.builder()
+                .skuCode(skuCode)
+                .productCode(productCode)
+                .optionName(optionName)
+                .optionValue(optionValue)
+                .unitPrice(price)
+                .status(ProductStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("vendorCode 미지정 — 모든 ACTIVE 거래처 펼침 + optionFacets axes 통합")
+    void getCatalog_allVendors() {
+        when(vendorProductRepository.findAllByStatusOrderByIdDesc(VendorProductStatus.ACTIVE))
+                .thenReturn(List.of(vpA1, vpB1));
+        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA, vendorB));
+        when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmB));
+        when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
+                sku("SKU-A-1", "PM-A", "색상/사이즈", "화이트/L", 6800L),
+                sku("SKU-A-2", "PM-A", "색상/사이즈", "블랙/M", 7200L),
+                sku("SKU-B-1", "PM-B", "색상", "네이비", 15000L)
+        ));
+
+        PurchaseOrderCatalogDto.CatalogRes res = service.getCatalog(null, null);
+
+        assertThat(res.getMasters()).hasSize(2);
+        PurchaseOrderCatalogDto.MasterRes masterA = res.getMasters().stream()
+                .filter(m -> m.getVendorProductCode().equals("VP-A-001")).findFirst().orElseThrow();
+        assertThat(masterA.getSkus()).hasSize(2);
+        assertThat(masterA.getMinSkuUnitPrice()).isEqualTo(6800L);
+        assertThat(masterA.getMaxSkuUnitPrice()).isEqualTo(7200L);
+        assertThat(masterA.getVendorName()).isEqualTo("거래처A");
+
+        // optionFacets — 색상/사이즈 axes 분리, 색상 axis 한 곳에 통합
+        assertThat(res.getOptionFacets()).extracting(PurchaseOrderCatalogDto.FacetRes::getName)
+                .containsExactlyInAnyOrder("색상", "사이즈");
+        PurchaseOrderCatalogDto.FacetRes color = res.getOptionFacets().stream()
+                .filter(f -> f.getName().equals("색상")).findFirst().orElseThrow();
+        assertThat(color.getValues()).contains("화이트", "블랙", "네이비");
+    }
+
+    @Test
+    @DisplayName("SKU 0건 마스터는 결과에서 제외")
+    void getCatalog_skipMastersWithoutSkus() {
+        when(vendorProductRepository.findAllByStatusOrderByIdDesc(VendorProductStatus.ACTIVE))
+                .thenReturn(List.of(vpA1, vpA2));
+        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
+        when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmEmpty));
+        when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
+                sku("SKU-A-1", "PM-A", "사이즈", "L", 6800L)
+                // PM-EMPTY 의 SKU 는 0건
+        ));
+
+        PurchaseOrderCatalogDto.CatalogRes res = service.getCatalog(null, null);
+
+        assertThat(res.getMasters()).hasSize(1);
+        assertThat(res.getMasters().get(0).getProductCode()).isEqualTo("PM-A");
+    }
+
+    @Test
+    @DisplayName("vendorCode 지정 — 다른 거래처 결과 안 섞임")
+    void getCatalog_filterByVendor() {
+        when(vendorRepository.findByCode("VND-A")).thenReturn(java.util.Optional.of(vendorA));
+        when(vendorProductRepository.findAllByVendorIdAndStatusNotOrderByIdDesc(1L, VendorProductStatus.DELETED))
+                .thenReturn(List.of(vpA1));
+        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
+        when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA));
+        when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
+                sku("SKU-A-1", "PM-A", "사이즈", "L", 6800L)
+        ));
+
+        PurchaseOrderCatalogDto.CatalogRes res = service.getCatalog("VND-A", null);
+
+        assertThat(res.getMasters()).hasSize(1);
+        assertThat(res.getMasters().get(0).getVendorCode()).isEqualTo("VND-A");
+    }
+
+    @Test
+    @DisplayName("vendorCode 미존재 시 VENDOR_NOT_FOUND throw")
+    void getCatalog_vendorNotFound() {
+        when(vendorRepository.findByCode("VND-XYZ")).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> service.getCatalog("VND-XYZ", null))
+                .isInstanceOf(BaseException.class);
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 새 발주 카탈로그가 SKU 단위로 펼쳐짐에 따라 마스터 N건마다 SKU fetch 하던 N+1 회피 위해 **묶음 응답 엔드포인트** 신설
- `vendor_product → ProductMaster → ProductSku` 한 번에 결합, 옵션 axes는 facet으로 분리

<br><br>

## 🎯 작업 내용
- `PurchaseOrderCatalogDto` / `Service` / `Controller` 신설 — 단일 호출로 카탈로그 응답 조립
- `ProductMaster` / `ProductSku` Repository에 declarative 메소드 1개씩만 추가 (타 팀원 도메인 영향 최소화)
- 옵션 axes는 facet으로 분리 노출 (FE 필터 / 표시 대응)

<br><br>

## ✔️ 참고 사항
- `stock` 필드는 인벤토리 BE 합류 후 추가 예정 — 본 사이클 응답에선 자리만 비워둠

<br><br>

## ✔️ 관련 이슈
- Close #153 