### PR TITLE
feat: 본사관리자 제품 마스터 등록 추가 입력 항목 백엔드 확장

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -58,6 +58,7 @@ public enum BaseResponseStatus {
     DUPLICATE_PRODUCT_SKU_OPTION(false, 4217, "이미 등록된 SKU 옵션입니다."),
     INVALID_SKU_PRICE(false, 4218, "SKU 가격은 0 이상이어야 합니다."),
     VENDOR_PRODUCT_VENDOR_MISMATCH(false, 4219, "이 제품의 메인 거래처가 아닙니다."),
+    VENDOR_INACTIVE(false, 4220, "비활성 거래처는 선택할 수 없습니다."),
 
     // 4300번대~ 본사 발주 (CEN-035~040)
     PURCHASE_ORDER_NOT_FOUND(false, 4300, "본사 발주를 찾을 수 없습니다."),

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureController.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureController.java
@@ -23,6 +23,11 @@ public class InfrastructureController {
         return BaseResponse.success(service.findStores(keyword, region, status));
     }
 
+    @GetMapping("/stores/{code}")
+    public BaseResponse<InfrastructureDto.StoreRes> getStore(@PathVariable String code) {
+        return BaseResponse.success(service.findStoreByCode(code));
+    }
+
     @PostMapping("/stores")
     public BaseResponse<InfrastructureDto.StoreRes> createStore(@Valid @RequestBody InfrastructureDto.StoreUpsertReq req) {
         return BaseResponse.success(service.createStore(req));
@@ -39,6 +44,11 @@ public class InfrastructureController {
                                                                              @RequestParam(required = false) String region,
                                                                              @RequestParam(required = false) InfraStatus status) {
         return BaseResponse.success(service.findWarehouses(keyword, region, status));
+    }
+
+    @GetMapping("/warehouses/{code}")
+    public BaseResponse<InfrastructureDto.WarehouseRes> getWarehouse(@PathVariable String code) {
+        return BaseResponse.success(service.findWarehouseByCode(code));
     }
 
     @PostMapping("/warehouses")

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureService.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/InfrastructureService.java
@@ -35,6 +35,13 @@ public class InfrastructureService {
     }
 
     @Transactional(readOnly = true)
+    public InfrastructureDto.StoreRes findStoreByCode(String code) {
+        Store store = storeRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_NOT_FOUND));
+        return InfrastructureDto.StoreRes.from(store);
+    }
+
+    @Transactional(readOnly = true)
     public List<InfrastructureDto.WarehouseRes> findWarehouses(String keyword, String region, InfraStatus status) {
         String safeKeyword = keyword == null ? "" : keyword.trim();
         String safeRegion = region == null ? "" : region.trim();
@@ -49,6 +56,13 @@ public class InfrastructureService {
             warehouses = warehouseRepository.findByNameContainingIgnoreCaseOrderByIdDesc(safeKeyword);
         }
         return warehouses.stream().map(w -> InfrastructureDto.WarehouseRes.from(w, storeRepository.countByWarehouseCode(w.getCode()))).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public InfrastructureDto.WarehouseRes findWarehouseByCode(String code) {
+        Warehouse warehouse = warehouseRepository.findByCode(code)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND));
+        return InfrastructureDto.WarehouseRes.from(warehouse, storeRepository.countByWarehouseCode(warehouse.getCode()));
     }
 
     @Transactional

--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
@@ -7,6 +7,9 @@ import org.example.stockitbe.hq.category.CategoryRepository;
 import org.example.stockitbe.hq.product.model.ProductDto;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.hq.vendor.VendorRepository;
+import org.example.stockitbe.hq.vendor.model.Vendor;
+import org.example.stockitbe.hq.vendor.model.VendorStatus;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +25,7 @@ public class ProductMasterService {
     private final ProductMasterRepository productMasterRepository;
     private final ProductSkuRepository productSkuRepository;
     private final CategoryRepository categoryRepository;
+    private final VendorRepository vendorRepository;
 
     @Transactional(readOnly = true)
     public List<ProductDto.ProductMasterRes> findProducts(String keyword, String categoryCode) {
@@ -53,7 +57,16 @@ public class ProductMasterService {
         ProductMaster product = productMasterRepository.findByCode(code)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
         validateUpdate(req, code);
-        product.update(req.getName().trim(), req.getCategoryCode().trim(), req.getBasePrice(), req.getLeadTimeDays(), req.getMainVendorCode().trim(), req.getStatus());
+        product.update(
+                req.getName().trim(),
+                req.getCategoryCode().trim(),
+                req.getBasePrice(),
+                req.getLeadTimeDays(),
+                req.getWarehouseSafetyStock(),
+                req.getStoreSafetyStock(),
+                req.getMainVendorCode().trim(),
+                req.getStatus()
+        );
         return ProductDto.ProductMasterRes.from(product, productSkuRepository.countByProductCode(product.getCode()));
     }
 
@@ -183,6 +196,7 @@ public class ProductMasterService {
         if (!categoryRepository.findByCode(req.getCategoryCode().trim()).isPresent()) {
             throw BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND);
         }
+        validateMainVendor(req.getMainVendorCode());
         if (productMasterRepository.existsByNameIgnoreCase(req.getName().trim())) {
             throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_MASTER_NAME);
         }
@@ -192,8 +206,17 @@ public class ProductMasterService {
         if (!categoryRepository.findByCode(req.getCategoryCode().trim()).isPresent()) {
             throw BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND);
         }
+        validateMainVendor(req.getMainVendorCode());
         if (productMasterRepository.existsByNameIgnoreCaseAndCodeNot(req.getName().trim(), code)) {
             throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_MASTER_NAME);
+        }
+    }
+
+    private void validateMainVendor(String mainVendorCode) {
+        Vendor vendor = vendorRepository.findByCode(mainVendorCode.trim())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
+        if (vendor.getStatus() != VendorStatus.ACTIVE) {
+            throw BaseException.from(BaseResponseStatus.VENDOR_INACTIVE);
         }
     }
 

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
@@ -19,6 +19,8 @@ public class ProductDto {
         @NotBlank private String categoryCode;
         @NotNull @Min(0) private Long basePrice;
         @NotNull @Min(0) private Integer leadTimeDays;
+        @NotNull @Min(0) private Integer warehouseSafetyStock;
+        @NotNull @Min(0) private Integer storeSafetyStock;
         @NotBlank private String mainVendorCode;
         @NotNull private ProductStatus status;
 
@@ -29,6 +31,8 @@ public class ProductDto {
                     .categoryCode(categoryCode.trim())
                     .basePrice(basePrice)
                     .leadTimeDays(leadTimeDays)
+                    .warehouseSafetyStock(warehouseSafetyStock)
+                    .storeSafetyStock(storeSafetyStock)
                     .mainVendorCode(mainVendorCode.trim())
                     .status(status)
                     .build();
@@ -93,6 +97,8 @@ public class ProductDto {
         private String categoryCode;
         private Long basePrice;
         private Integer leadTimeDays;
+        private Integer warehouseSafetyStock;
+        private Integer storeSafetyStock;
         private String mainVendorCode;
         private ProductStatus status;
         private long skuCount;
@@ -105,6 +111,8 @@ public class ProductDto {
                     .categoryCode(m.getCategoryCode())
                     .basePrice(m.getBasePrice())
                     .leadTimeDays(m.getLeadTimeDays())
+                    .warehouseSafetyStock(m.getWarehouseSafetyStock())
+                    .storeSafetyStock(m.getStoreSafetyStock())
                     .mainVendorCode(m.getMainVendorCode())
                     .status(m.getStatus())
                     .skuCount(skuCount)

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
@@ -33,6 +33,12 @@ public class ProductMaster extends BaseEntity {
     @Column(name = "lead_time_days", nullable = false)
     private Integer leadTimeDays;
 
+    @Column(name = "warehouse_safety_stock", nullable = false)
+    private Integer warehouseSafetyStock;
+
+    @Column(name = "store_safety_stock", nullable = false)
+    private Integer storeSafetyStock;
+
     @Column(name = "main_vendor_code", nullable = false, length = 32)
     private String mainVendorCode;
 
@@ -42,21 +48,26 @@ public class ProductMaster extends BaseEntity {
 
     @Builder
     private ProductMaster(String code, String name, String categoryCode, Long basePrice, Integer leadTimeDays,
-                          String mainVendorCode, ProductStatus status) {
+                          Integer warehouseSafetyStock, Integer storeSafetyStock, String mainVendorCode, ProductStatus status) {
         this.code = code;
         this.name = name;
         this.categoryCode = categoryCode;
         this.basePrice = basePrice;
         this.leadTimeDays = leadTimeDays;
+        this.warehouseSafetyStock = warehouseSafetyStock == null ? 0 : warehouseSafetyStock;
+        this.storeSafetyStock = storeSafetyStock == null ? 0 : storeSafetyStock;
         this.mainVendorCode = mainVendorCode;
         this.status = status == null ? ProductStatus.ACTIVE : status;
     }
 
-    public void update(String name, String categoryCode, Long basePrice, Integer leadTimeDays, String mainVendorCode, ProductStatus status) {
+    public void update(String name, String categoryCode, Long basePrice, Integer leadTimeDays, Integer warehouseSafetyStock,
+                       Integer storeSafetyStock, String mainVendorCode, ProductStatus status) {
         this.name = name;
         this.categoryCode = categoryCode;
         this.basePrice = basePrice;
         this.leadTimeDays = leadTimeDays;
+        this.warehouseSafetyStock = warehouseSafetyStock == null ? 0 : warehouseSafetyStock;
+        this.storeSafetyStock = storeSafetyStock == null ? 0 : storeSafetyStock;
         this.mainVendorCode = mainVendorCode;
         this.status = status;
     }

--- a/src/main/resources/sql/category_two_level_seed.sql
+++ b/src/main/resources/sql/category_two_level_seed.sql
@@ -1,0 +1,115 @@
+-- 2단계 카테고리 시드 데이터
+-- 실행 대상: MariaDB/MySQL
+-- 정책: 중복 실행 가능(코드 기준으로 미존재 시에만 INSERT)
+-- 구성: ROOT(상의/바지/치마/아우터) + CHILD
+
+-- ROOT 카테고리
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9001', '상의', 'ROOT', NULL, 'ACTIVE', 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9001');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9002', '바지', 'ROOT', NULL, 'ACTIVE', 2, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9002');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9003', '치마', 'ROOT', NULL, 'ACTIVE', 3, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9003');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9004', '아우터', 'ROOT', NULL, 'ACTIVE', 4, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9004');
+
+-- 상의 자식: 반팔, 긴팔, 셔츠, 니트, 후드티
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9101', '반팔', 'CHILD', p.id, 'ACTIVE', 1, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9001'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9101');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9102', '긴팔', 'CHILD', p.id, 'ACTIVE', 2, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9001'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9102');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9103', '셔츠', 'CHILD', p.id, 'ACTIVE', 3, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9001'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9103');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9104', '니트', 'CHILD', p.id, 'ACTIVE', 4, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9001'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9104');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9105', '후드티', 'CHILD', p.id, 'ACTIVE', 5, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9001'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9105');
+
+-- 바지 자식: 청바지, 반바지, 긴바지, 츄리닝
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9201', '청바지', 'CHILD', p.id, 'ACTIVE', 1, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9002'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9201');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9202', '반바지', 'CHILD', p.id, 'ACTIVE', 2, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9002'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9202');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9203', '긴바지', 'CHILD', p.id, 'ACTIVE', 3, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9002'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9203');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9204', '츄리닝', 'CHILD', p.id, 'ACTIVE', 4, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9002'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9204');
+
+-- 치마 자식: 미니스커트, 롱스커트
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9301', '미니스커트', 'CHILD', p.id, 'ACTIVE', 1, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9003'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9301');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9302', '롱스커트', 'CHILD', p.id, 'ACTIVE', 2, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9003'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9302');
+
+-- 아우터 자식: 패딩, 후드집업, 자켓, 가디건
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9401', '패딩', 'CHILD', p.id, 'ACTIVE', 1, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9004'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9401');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9402', '후드집업', 'CHILD', p.id, 'ACTIVE', 2, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9004'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9402');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9403', '자켓', 'CHILD', p.id, 'ACTIVE', 3, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9004'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9403');
+
+INSERT INTO category (code, name, level, parent_id, status, sort_order, create_date, update_date)
+SELECT 'CAT-9404', '가디건', 'CHILD', p.id, 'ACTIVE', 4, NOW(), NOW()
+FROM category p
+WHERE p.code = 'CAT-9004'
+  AND NOT EXISTS (SELECT 1 FROM category WHERE code = 'CAT-9404');

--- a/src/main/resources/sql/infrastructure_dummy_data.sql
+++ b/src/main/resources/sql/infrastructure_dummy_data.sql
@@ -1,0 +1,51 @@
+-- HQ 인프라 관리 더미 데이터 (MariaDB/MySQL)
+-- 실행 순서: warehouse -> store
+
+INSERT INTO warehouse
+    (code, name, region, manager_name, contact, address, capacity, status, create_date, update_date)
+VALUES
+    ('WH-0001', '수도권 통합 물류센터', '서울', '박지훈', '02-3011-1001', '서울특별시 강서구 물류로 101', '10,000 PLT / 5,000㎡', 'ACTIVE', NOW(), NOW()),
+    ('WH-0002', '경기 남부 허브 창고', '경기', '최민서', '031-422-2002', '경기도 화성시 산업단지로 88', '8,000 PLT / 4,200㎡', 'ACTIVE', NOW(), NOW()),
+    ('WH-0003', '영남권 거점 창고', '부산', '김도윤', '051-711-3003', '부산광역시 강서구 유통단지 55', '7,500 PLT / 3,900㎡', 'SUSPENDED', NOW(), NOW()),
+    ('WH-0004', '충청권 중계 센터', '대전', '이서연', '042-611-4004', '대전광역시 유성구 물류밸리 12', '6,000 PLT / 3,100㎡', 'INACTIVE', NOW(), NOW()),
+    ('WH-0005', '인천 항만 물류센터', '인천', '문하늘', '032-811-5005', '인천광역시 연수구 송도물류로 77', '9,200 PLT / 4,700㎡', 'ACTIVE', NOW(), NOW()),
+    ('WH-0006', '강원 동부 보관창고', '강원', '남시우', '033-622-6006', '강원특별자치도 강릉시 유통로 19', '4,500 PLT / 2,400㎡', 'ACTIVE', NOW(), NOW()),
+    ('WH-0007', '호남권 메가 허브', '광주', '배유진', '062-933-7007', '광주광역시 광산구 산업대로 244', '8,700 PLT / 4,100㎡', 'SUSPENDED', NOW(), NOW()),
+    ('WH-0008', '제주 저온 복합창고', '제주', '신우람', '064-744-8008', '제주특별자치도 제주시 물류단지길 33', '3,800 PLT / 2,000㎡', 'ACTIVE', NOW(), NOW())
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    region = VALUES(region),
+    manager_name = VALUES(manager_name),
+    contact = VALUES(contact),
+    address = VALUES(address),
+    capacity = VALUES(capacity),
+    status = VALUES(status),
+    update_date = NOW();
+
+INSERT INTO store
+    (code, name, region, type, manager_name, contact, address, warehouse_code, status, create_date, update_date)
+VALUES
+    ('ST-0001', '강남 플래그십점', '서울', 'DIRECT', '정현우', '010-1111-1111', '서울특별시 강남구 테헤란로 201', 'WH-0001', 'ACTIVE', NOW(), NOW()),
+    ('ST-0002', '홍대 라이프스타일점', '서울', 'DIRECT', '오지안', '010-2222-2222', '서울특별시 마포구 양화로 121', 'WH-0001', 'ACTIVE', NOW(), NOW()),
+    ('ST-0003', '수원 광교점', '경기', 'FRANCHISE', '한지민', '010-3333-3333', '경기도 수원시 영통구 광교중앙로 85', 'WH-0002', 'ACTIVE', NOW(), NOW()),
+    ('ST-0004', '분당 서현점', '경기', 'FRANCHISE', '윤태성', '010-4444-4444', '경기도 성남시 분당구 서현로 210', 'WH-0002', 'INACTIVE', NOW(), NOW()),
+    ('ST-0005', '부산 센텀점', '부산', 'DIRECT', '임수빈', '010-5555-5555', '부산광역시 해운대구 센텀동로 45', 'WH-0003', 'SUSPENDED', NOW(), NOW()),
+    ('ST-0006', '대전 둔산점', '대전', 'FRANCHISE', '강민우', '010-6666-6666', '대전광역시 서구 둔산로 77', 'WH-0004', 'ACTIVE', NOW(), NOW()),
+    ('ST-0007', '인천 송도점', '인천', 'DIRECT', '조다인', '010-7777-7777', '인천광역시 연수구 센트럴로 160', 'WH-0005', 'ACTIVE', NOW(), NOW()),
+    ('ST-0008', '인천 부평점', '인천', 'FRANCHISE', '차도현', '010-8888-8888', '인천광역시 부평구 경원대로 1415', 'WH-0005', 'ACTIVE', NOW(), NOW()),
+    ('ST-0009', '강릉 중앙점', '강원', 'FRANCHISE', '표나연', '010-9999-9999', '강원특별자치도 강릉시 금성로 52', 'WH-0006', 'INACTIVE', NOW(), NOW()),
+    ('ST-0010', '원주 혁신점', '강원', 'DIRECT', '구민재', '010-1212-1212', '강원특별자치도 원주시 혁신로 35', 'WH-0006', 'ACTIVE', NOW(), NOW()),
+    ('ST-0011', '광주 상무점', '광주', 'DIRECT', '노아린', '010-3434-3434', '광주광역시 서구 상무중앙로 90', 'WH-0007', 'SUSPENDED', NOW(), NOW()),
+    ('ST-0012', '광주 충장점', '광주', 'FRANCHISE', '도지후', '010-5656-5656', '광주광역시 동구 충장로 102', 'WH-0007', 'ACTIVE', NOW(), NOW()),
+    ('ST-0013', '제주 노형점', '제주', 'DIRECT', '류서하', '010-7878-7878', '제주특별자치도 제주시 노형로 312', 'WH-0008', 'ACTIVE', NOW(), NOW()),
+    ('ST-0014', '제주 서귀포점', '제주', 'FRANCHISE', '마태오', '010-9090-9090', '제주특별자치도 서귀포시 중앙로 65', 'WH-0008', 'ACTIVE', NOW(), NOW())
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    region = VALUES(region),
+    type = VALUES(type),
+    manager_name = VALUES(manager_name),
+    contact = VALUES(contact),
+    address = VALUES(address),
+    warehouse_code = VALUES(warehouse_code),
+    status = VALUES(status),
+    update_date = NOW();

--- a/tools/convert_sheet3_requirements_to_issue_csv.py
+++ b/tools/convert_sheet3_requirements_to_issue_csv.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Convert the provided requirements-definition CSV format into the issue-import CSV
+consumed by tools/create_github_issues_from_csv.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import OrderedDict
+from pathlib import Path
+
+
+OUTPUT_HEADERS = [
+    "type",
+    "title",
+    "summary",
+    "requirement",
+    "todo",
+    "labels",
+    "assignees",
+    "background",
+    "expected_effect",
+    "improvement_type",
+    "bug",
+    "scenario",
+    "expected_result",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert Sheet3-style requirements CSV to issue-import CSV."
+    )
+    parser.add_argument("--input", required=True, help="Source CSV path.")
+    parser.add_argument("--output", required=True, help="Converted CSV path.")
+    return parser.parse_args()
+
+
+def clean_bullet_line(line: str) -> str:
+    return line.strip().strip('"').lstrip("·•・-").strip().strip('"')
+
+
+def split_lines(value: str) -> list[str]:
+    return [clean_bullet_line(line) for line in value.splitlines() if clean_bullet_line(line)]
+
+
+def dedupe_preserve_order(items: list[str]) -> list[str]:
+    return list(OrderedDict.fromkeys(items))
+
+
+def normalize_middle(middle: str) -> str:
+    return middle.strip() or "미분류"
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    with input_path.open("r", encoding="utf-8-sig", newline="") as source_file:
+        rows = list(csv.reader(source_file))
+
+    current_major = ""
+    current_middle = ""
+    grouped_rows: OrderedDict[tuple[str, str], dict[str, list[str] | str]] = OrderedDict()
+
+    for row in rows[8:]:
+        if len(row) < 10:
+            continue
+
+        requirement_id = row[1].strip()
+        if not requirement_id:
+            continue
+
+        if row[2].strip():
+            current_major = row[2].strip()
+        if row[3].strip():
+            current_middle = row[3].strip()
+
+        subcategory = row[4].strip()
+        role = row[5].strip()
+        requirement_text = row[6].strip()
+        detail_text = row[7].strip()
+        _owner = row[8].strip()
+        _priority = row[9].strip()
+
+        major = current_major.strip() or "미분류"
+        middle = normalize_middle(current_middle)
+        group_key = (major, middle)
+        if group_key not in grouped_rows:
+            grouped_rows[group_key] = {
+                "requirement_ids": [],
+                "todo_lines": [],
+            }
+        bucket = grouped_rows[group_key]
+        bucket["requirement_ids"].append(requirement_id)
+
+        todos: list[str] = []
+        if requirement_text:
+            todos.extend(split_lines(requirement_text))
+        if detail_text:
+            todos.extend(split_lines(detail_text))
+        item_title = f"[{requirement_id}] {subcategory}" if subcategory else f"[{requirement_id}]"
+        bucket["todo_lines"].append(item_title)
+        bucket["todo_lines"].extend(todos)
+        if role:
+            bucket["todo_lines"].append(f"권한: {role}")
+
+    converted_rows: list[dict[str, str]] = []
+    for (major, middle), bucket in grouped_rows.items():
+        requirement_ids = bucket["requirement_ids"]
+        todo_lines = dedupe_preserve_order(bucket["todo_lines"])
+
+        converted_rows.append(
+            {
+                "type": "feat",
+                "title": f"[{major}] {middle}",
+                "summary": f"{major} > {middle} 기능 묶음 ({len(requirement_ids)}건)",
+                "requirement": f"{major} | {middle} | {', '.join(requirement_ids)}",
+                "todo": "\n".join(todo_lines),
+                "labels": "기능",
+                "assignees": "",
+                "background": "",
+                "expected_effect": "",
+                "improvement_type": "",
+                "bug": "",
+                "scenario": "",
+                "expected_result": "",
+            }
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8-sig", newline="") as output_file:
+        writer = csv.DictWriter(output_file, fieldnames=OUTPUT_HEADERS)
+        writer.writeheader()
+        writer.writerows(converted_rows)
+
+    print(f"Converted {len(converted_rows)} rows to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/create_github_issues_from_csv.py
+++ b/tools/create_github_issues_from_csv.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+Create GitHub issues from a CSV requirements document.
+
+Example:
+    export GITHUB_TOKEN=ghp_xxx
+    python3 tools/create_github_issues_from_csv.py \
+        --csv docs/requirements/issues.csv \
+        --repo beyond-sw-camp/be24-fin-Stockers-STOCKIT-BE \
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import time
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+DEFAULT_LABELS = {
+    "feat": "기능",
+    "feature": "기능",
+    "refactor": "리팩토링",
+    "fix": "오류 해결",
+    "bug": "오류 해결",
+}
+
+
+@dataclass
+class IssueDraft:
+    title: str
+    body: str
+    labels: list[str]
+    assignees: list[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create GitHub issues from a CSV file."
+    )
+    parser.add_argument("--csv", required=True, help="Path to the input CSV file.")
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="GitHub repository in the form owner/repo.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("GITHUB_TOKEN"),
+        help="GitHub token. Defaults to GITHUB_TOKEN environment variable.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print issue drafts without creating them.",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8-sig",
+        help="CSV encoding. Defaults to utf-8-sig.",
+    )
+    parser.add_argument(
+        "--start-index",
+        type=int,
+        default=1,
+        help="1-based CSV row index to start creating issues from.",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=1.5,
+        help="Delay between issue creations to reduce GitHub secondary rate limits.",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Maximum retries for secondary rate limit errors.",
+    )
+    return parser.parse_args()
+
+
+def require_value(row: dict[str, str], *keys: str) -> str:
+    for key in keys:
+        value = row.get(key, "").strip()
+        if value:
+            return value
+    raise ValueError(f"Missing required column value. Expected one of: {', '.join(keys)}")
+
+
+def split_multiline(value: str) -> list[str]:
+    items = []
+    for raw in value.replace("\\n", "\n").splitlines():
+        item = raw.strip().lstrip("-").strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def list_block(items: list[str], checkbox: bool = False) -> str:
+    if not items:
+        return "- "
+    prefix = "- [ ] " if checkbox else "- "
+    return "\n".join(f"{prefix}{item}" for item in items)
+
+
+def normalize_type(raw_type: str) -> str:
+    issue_type = raw_type.strip().lower()
+    if issue_type in {"feature"}:
+        return "feat"
+    if issue_type in {"bug"}:
+        return "fix"
+    return issue_type
+
+
+def build_issue_body(row: dict[str, str]) -> IssueDraft:
+    issue_type = normalize_type(require_value(row, "type", "issue_type"))
+    title = require_value(row, "title")
+    summary = row.get("summary", "").strip() or row.get("description", "").strip()
+    requirement = require_value(row, "requirement", "requirement_id", "requirement_name")
+    todos = split_multiline(row.get("todo", ""))
+    labels = split_csv_items(row.get("labels", ""))
+    assignees = split_csv_items(row.get("assignees", ""))
+
+    if not labels and issue_type in DEFAULT_LABELS:
+        labels = [DEFAULT_LABELS[issue_type]]
+
+    if issue_type == "feat":
+        body = f"""## 📝 작업 내용
+> 수행해야 할 작업 혹은 구현할 기능에 대해 간략히 설명해주세요.
+{list_block([summary] if summary else [])}
+
+<br><br>
+
+## ✔️ 관련 기능
+> 어떤 기능과 관련되어 있는 작업인가요? (요구사항 명세서)
+{list_block([requirement])}
+
+<br><br>
+
+## 🛠 세부 할 일 (To-Do)
+{list_block(todos, checkbox=True)}
+
+<br><br>
+"""
+        issue_title = f"feat: {title}"
+    elif issue_type == "refactor":
+        background = row.get("background", "").strip()
+        expected = split_multiline(row.get("expected_effect", ""))
+        improvement_flags = split_multiline(row.get("improvement_type", ""))
+        if not improvement_flags:
+            improvement_flags = ["기존 기능 개선"]
+
+        body = f"""## 📝 작업 내용
+> 리팩토링 할 내용에 대해 간략히 설명해주세요. (+ 개선 종류 체크)
+{list_block(improvement_flags, checkbox=True)}
+{f"- {summary}" if summary else "- "}
+
+<br><br>
+
+## ✔️ 관련 기능
+> 어떤 기능과 관련되어 있는 작업인가요? (요구사항 명세서)
+{list_block([requirement])}
+
+<br><br>
+
+## ❓ 리팩토링을 하게 된 이유/배경은 무엇인가요?
+> 어떤 상황에서 문제가 발생했는지, 왜 리팩토링이 필요하게 되었는지 설명해주세요
+{list_block([background] if background else [])}
+
+<br><br>
+
+## 🙆‍♀️ 리팩토링/성능개선 기대 효과
+
+> 리팩토링 후 예상하는 결과가 어떤 것인지 설명해주세요
+{list_block(expected)}
+
+<br><br>
+
+## 🛠 세부 할 일 (To-Do)
+{list_block(todos, checkbox=True)}
+
+<br><br>
+"""
+        issue_title = f"refactor: {title}"
+    elif issue_type == "fix":
+        bug = row.get("bug", "").strip() or summary
+        scenario = row.get("scenario", "").strip()
+        expected_result = row.get("expected_result", "").strip()
+
+        body = f"""## 🐞어떤 버그인가요?
+
+> 어떤 버그/오류 인지 간결하게 설명해주세요
+{list_block([bug] if bug else [])}
+
+<br><br>
+
+## ❓어떤 상황에서 발생한 버그인가요?
+
+> (가능하면) Given-When-Then 형식으로 서술해주세요
+{list_block([scenario] if scenario else [])}
+
+<br><br>
+
+## 🙆‍♀️예상 결과
+
+> 예상했던 정상적인 결과가 어떤 것이었는지 설명해주세요
+{list_block([expected_result] if expected_result else [])}
+
+<br><br>
+"""
+        issue_title = f"fix: {title}"
+    else:
+        raise ValueError(
+            f"Unsupported issue type '{issue_type}'. Use feat, refactor, or fix."
+        )
+
+    return IssueDraft(
+        title=issue_title,
+        body=body,
+        labels=labels,
+        assignees=assignees,
+    )
+
+
+def split_csv_items(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def load_issue_drafts(csv_path: str, encoding: str) -> list[IssueDraft]:
+    with open(csv_path, "r", encoding=encoding, newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        if not reader.fieldnames:
+            raise ValueError("CSV header is missing.")
+        drafts = [build_issue_body(row) for row in reader]
+
+    if not drafts:
+        raise ValueError("CSV does not contain any data rows.")
+    return drafts
+
+
+def create_issue(repo: str, token: str, draft: IssueDraft) -> str:
+    payload = {
+        "title": draft.title,
+        "body": draft.body,
+        "labels": draft.labels,
+        "assignees": draft.assignees,
+    }
+
+    request = urllib.request.Request(
+        url=f"https://api.github.com/repos/{repo}/issues",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "stockit-issue-bulk-creator",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(request) as response:
+        data = json.loads(response.read().decode("utf-8"))
+        return data["html_url"]
+
+
+def is_secondary_rate_limit(error: urllib.error.HTTPError, details: str) -> bool:
+    return error.code == 403 and "secondary rate limit" in details.lower()
+
+
+def create_issue_with_retry(
+    repo: str,
+    token: str,
+    draft: IssueDraft,
+    max_retries: int,
+) -> str:
+    attempt = 0
+    wait_seconds = 30
+
+    while True:
+        try:
+            return create_issue(repo, token, draft)
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            if not is_secondary_rate_limit(error, details) or attempt >= max_retries:
+                raise RuntimeError(f"{error.code} {details}") from error
+
+            attempt += 1
+            print(
+                f"Secondary rate limit hit for '{draft.title}'. "
+                f"Retrying in {wait_seconds:.0f}s "
+                f"(attempt {attempt}/{max_retries})...",
+                file=sys.stderr,
+            )
+            time.sleep(wait_seconds)
+            wait_seconds *= 2
+
+
+def print_draft(index: int, draft: IssueDraft) -> None:
+    print(f"[{index}] {draft.title}")
+    if draft.labels:
+        print(f"labels: {', '.join(draft.labels)}")
+    if draft.assignees:
+        print(f"assignees: {', '.join(draft.assignees)}")
+    print(draft.body)
+    print("=" * 80)
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        drafts = load_issue_drafts(args.csv, args.encoding)
+    except Exception as error:  # noqa: BLE001
+        print(f"Failed to read CSV: {error}", file=sys.stderr)
+        return 1
+
+    if args.start_index < 1 or args.start_index > len(drafts):
+        print(
+            f"--start-index must be between 1 and {len(drafts)}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.dry_run:
+        for index, draft in enumerate(drafts, start=1):
+            if index < args.start_index:
+                continue
+            print_draft(index, draft)
+        return 0
+
+    if not args.token:
+        print(
+            "GitHub token is required. Set GITHUB_TOKEN or pass --token.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for index, draft in enumerate(drafts, start=1):
+        if index < args.start_index:
+            continue
+
+        try:
+            issue_url = create_issue_with_retry(
+                args.repo,
+                args.token,
+                draft,
+                args.max_retries,
+            )
+            print(f"[{index}] Created: {issue_url}")
+            if args.delay_seconds > 0:
+                time.sleep(args.delay_seconds)
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            print(
+                f"[{index}] Failed to create issue '{draft.title}': {error.code} {details}",
+                file=sys.stderr,
+            )
+            return 1
+        except Exception as error:  # noqa: BLE001
+            print(
+                f"[{index}] Failed to create issue '{draft.title}': {error}",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 📌 요약
- 제품 마스터 데이터 모델 확장(안전재고)과 인프라 단건 조회 API를 추가해 FE 화면 요구사항을 안정적으로 지원했습니다.

<br><br>

## 🎯 작업 내용
- 제품 마스터 도메인/DTO/서비스 확장
  - `warehouse_safety_stock`, `store_safety_stock` 필드 반영
  - 생성/수정/조회 시 안전재고 필드 저장·반환 로직 추가
  - 요청값 검증(`@NotNull`, `@Min(0)`) 반영
- 거래처 검증 강화
  - `mainVendorCode` 존재 여부 및 ACTIVE 상태 검증
  - 비활성 거래처 선택 시 저장 차단
- 인프라 단건 조회 API 추가
  - `GET /api/hq/stores/{code}`
  - `GET /api/hq/warehouses/{code}`
  - 코드 기반 조회 실패 시 기존 NOT_FOUND 예외 체계 유지

<br><br>

## ✔️ 참고 사항
- 기존 목록/생성/수정 API 시그니처는 유지하고, 단건 조회만 확장했습니다.
- FE 하위호환을 위해 기존 응답 구조(`StoreRes`, `WarehouseRes`)를 재사용했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #151 

<br><br>
