### PR TITLE
feat: 전사 재고 조회 API 구현 및 SKU 옵션 구조를 color/size로 전환

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
@@ -1,0 +1,43 @@
+package org.example.stockitbe.hq.inventory;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.model.InventoryDto;
+import org.example.stockitbe.hq.inventory.model.InventoryStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq/inventories")
+@RequiredArgsConstructor
+public class InventoryController {
+
+    private final InventoryService inventoryService;
+
+    @GetMapping("/company-wide")
+    public BaseResponse<InventoryDto.CompanyWidePageRes> getCompanyWide(
+            @RequestParam(required = false) LocationType locationType,
+            @RequestParam(required = false) List<Long> locationIds,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) InventoryStatus status,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(inventoryService.findCompanyWide(locationType, locationIds, parentCategory, childCategory, status, keyword));
+    }
+
+    @GetMapping("/company-wide/{itemCode}/skus")
+    public BaseResponse<List<InventoryDto.CompanyWideSkuDetailRes>> getCompanyWideSkus(
+            @PathVariable String itemCode,
+            @RequestParam(required = false) LocationType locationType,
+            @RequestParam(required = false) List<Long> locationIds,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) InventoryStatus status,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(inventoryService.findCompanyWideSkuDetails(itemCode, locationType, locationIds, parentCategory, childCategory, status, keyword));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -1,0 +1,11 @@
+package org.example.stockitbe.hq.inventory;
+
+import org.example.stockitbe.hq.inventory.model.Inventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+    List<Inventory> findAllBySkuIdIn(Collection<Long> skuIds);
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -1,0 +1,256 @@
+package org.example.stockitbe.hq.inventory;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.hq.category.CategoryRepository;
+import org.example.stockitbe.hq.category.model.Category;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.model.Inventory;
+import org.example.stockitbe.hq.inventory.model.InventoryDto;
+import org.example.stockitbe.hq.inventory.model.InventoryStatus;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+
+    private final InventoryRepository inventoryRepository;
+    private final ProductSkuRepository productSkuRepository;
+    private final ProductMasterRepository productMasterRepository;
+    private final CategoryRepository categoryRepository;
+    private final InfrastructureRepository infrastructureRepository;
+
+    @Transactional(readOnly = true)
+    public InventoryDto.CompanyWidePageRes findCompanyWide(LocationType locationType,
+                                                            List<Long> locationIds,
+                                                            String parentCategory,
+                                                            String childCategory,
+                                                            InventoryStatus status,
+                                                            String keyword) {
+        List<Inventory> inventories = inventoryRepository.findAll();
+        List<ProductSku> skus = productSkuRepository.findAll();
+        if (inventories.isEmpty() || skus.isEmpty()) {
+            return InventoryDto.CompanyWidePageRes.builder()
+                    .items(List.of())
+                    .locationOptions(buildLocationOptions(locationType))
+                    .build();
+        }
+
+        Map<Long, ProductSku> skuById = skus.stream().collect(Collectors.toMap(ProductSku::getId, Function.identity()));
+        Set<String> productCodes = skus.stream().map(ProductSku::getProductCode).collect(Collectors.toSet());
+        Map<String, ProductMaster> productByCode = productMasterRepository.findAllByCodeIn(productCodes).stream()
+                .collect(Collectors.toMap(ProductMaster::getCode, Function.identity()));
+
+        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
+        Map<String, Category> categoryByCode = categories.stream().collect(Collectors.toMap(Category::getCode, Function.identity()));
+        Map<Long, Category> categoryById = categories.stream().collect(Collectors.toMap(Category::getId, Function.identity()));
+
+        Map<Long, Infrastructure> locationById = infrastructureRepository.findAll().stream()
+                .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
+
+        String safeParent = parentCategory == null ? "" : parentCategory.trim();
+        String safeChild = childCategory == null ? "" : childCategory.trim();
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        Set<Long> locationIdSet = locationIds == null ? Set.of() : new HashSet<>(locationIds);
+
+        Map<String, Aggregate> aggregateMap = new LinkedHashMap<>();
+
+        for (Inventory inv : inventories) {
+            ProductSku sku = skuById.get(inv.getSkuId());
+            if (sku == null) continue;
+            ProductMaster master = productByCode.get(sku.getProductCode());
+            if (master == null) continue;
+            Infrastructure location = locationById.get(inv.getLocationId());
+            if (location == null) continue;
+            if (locationType != null && location.getLocationType() != locationType) continue;
+            if (!locationIdSet.isEmpty() && !locationIdSet.contains(location.getId())) continue;
+            if (status != null && inv.getInventoryStatus() != status) continue;
+
+            Category child = categoryByCode.get(master.getCategoryCode());
+            if (child == null) continue;
+            Category parent = child.getParentId() == null ? child : categoryById.get(child.getParentId());
+
+            String parentName = parent != null ? parent.getName() : "";
+            String childName = child.getName();
+
+            if (!safeParent.isBlank() && !safeParent.equals(parentName)) continue;
+            if (!safeChild.isBlank() && !safeChild.equals(childName)) continue;
+
+            if (!safeKeyword.isBlank()) {
+                String searchable = String.join(" ",
+                        master.getCode(),
+                        master.getName(),
+                        sku.getSkuCode(),
+                        location.getCode(),
+                        location.getName()
+                ).toLowerCase(Locale.ROOT);
+                if (!searchable.contains(safeKeyword)) continue;
+            }
+
+            Aggregate agg = aggregateMap.computeIfAbsent(master.getCode(), k -> new Aggregate(master, parentName, childName));
+            agg.actualStock += n(inv.getQuantity());
+            agg.availableStock += n(inv.getAvailableQuantity());
+            agg.safetyStock += location.getLocationType() == LocationType.WAREHOUSE
+                    ? n(master.getWarehouseSafetyStock())
+                    : n(master.getStoreSafetyStock());
+            if (agg.updatedAt == null || inv.getUpdatedAt().after(agg.updatedAt)) {
+                agg.updatedAt = inv.getUpdatedAt();
+            }
+            agg.statuses.add(inv.getInventoryStatus());
+        }
+
+        List<InventoryDto.CompanyWideRes> items = aggregateMap.values().stream()
+                .map(agg -> InventoryDto.CompanyWideRes.builder()
+                        .itemCode(agg.master.getCode())
+                        .parentCategory(agg.parentCategory)
+                        .childCategory(agg.childCategory)
+                        .itemName(agg.master.getName())
+                        .actualStock(agg.actualStock)
+                        .availableStock(agg.availableStock)
+                        .safetyStock(agg.safetyStock)
+                        .status(toUiStatus(agg.availableStock, agg.safetyStock))
+                        .updatedAt(agg.updatedAt)
+                        .build())
+                .sorted(Comparator.comparing(InventoryDto.CompanyWideRes::getItemCode))
+                .toList();
+
+        return InventoryDto.CompanyWidePageRes.builder()
+                .items(items)
+                .locationOptions(buildLocationOptions(locationType))
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<InventoryDto.CompanyWideSkuDetailRes> findCompanyWideSkuDetails(String itemCode,
+                                                                                 LocationType locationType,
+                                                                                 List<Long> locationIds,
+                                                                                 String parentCategory,
+                                                                                 String childCategory,
+                                                                                 InventoryStatus status,
+                                                                                 String keyword) {
+        if (itemCode == null || itemCode.isBlank()) return List.of();
+
+        List<ProductSku> productSkus = productSkuRepository.findByProductCodeOrderByIdDesc(itemCode.trim());
+        if (productSkus.isEmpty()) return List.of();
+
+        Set<Long> skuIds = productSkus.stream().map(ProductSku::getId).collect(Collectors.toSet());
+        List<Inventory> inventories = inventoryRepository.findAllBySkuIdIn(skuIds);
+
+        Map<Long, Infrastructure> locationById = infrastructureRepository.findAll().stream()
+                .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
+        Set<Long> locationIdSet = locationIds == null ? Set.of() : new HashSet<>(locationIds);
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+
+        ProductMaster master = productMasterRepository.findByCode(itemCode.trim()).orElse(null);
+        int warehouseSafety = master == null ? 0 : n(master.getWarehouseSafetyStock());
+        int storeSafety = master == null ? 0 : n(master.getStoreSafetyStock());
+
+        Map<Long, SkuAggregate> skuMap = new LinkedHashMap<>();
+        for (ProductSku sku : productSkus) {
+            skuMap.put(sku.getId(), new SkuAggregate(sku));
+        }
+
+        for (Inventory inv : inventories) {
+            Infrastructure location = locationById.get(inv.getLocationId());
+            if (location == null) continue;
+            if (locationType != null && location.getLocationType() != locationType) continue;
+            if (!locationIdSet.isEmpty() && !locationIdSet.contains(location.getId())) continue;
+            if (status != null && inv.getInventoryStatus() != status) continue;
+
+            if (!safeKeyword.isBlank()) {
+                ProductSku sku = skuMap.get(inv.getSkuId()).sku;
+                String searchable = String.join(" ", sku.getSkuCode(), sku.getColor(), sku.getSize(), location.getName())
+                        .toLowerCase(Locale.ROOT);
+                if (!searchable.contains(safeKeyword)) continue;
+            }
+
+            SkuAggregate agg = skuMap.get(inv.getSkuId());
+            if (agg == null) continue;
+            agg.actualStock += n(inv.getQuantity());
+            agg.availableStock += n(inv.getAvailableQuantity());
+            if (agg.locationType == null) agg.locationType = location.getLocationType();
+            if (agg.updatedAt == null || inv.getUpdatedAt().after(agg.updatedAt)) {
+                agg.updatedAt = inv.getUpdatedAt();
+            }
+        }
+
+        return skuMap.values().stream()
+                .filter(agg -> agg.actualStock > 0 || agg.availableStock > 0)
+                .map(agg -> {
+                    int safetyStock = agg.locationType == LocationType.WAREHOUSE ? warehouseSafety : storeSafety;
+                    return InventoryDto.CompanyWideSkuDetailRes.builder()
+                            .skuCode(agg.sku.getSkuCode())
+                            .color(agg.sku.getColor())
+                            .size(agg.sku.getSize())
+                            .actualStock(agg.actualStock)
+                            .availableStock(agg.availableStock)
+                            .safetyStock(safetyStock)
+                            .status(toUiStatus(agg.availableStock, safetyStock))
+                            .updatedAt(agg.updatedAt)
+                            .build();
+                })
+                .sorted(Comparator.comparing(InventoryDto.CompanyWideSkuDetailRes::getSkuCode))
+                .toList();
+    }
+
+    private List<InventoryDto.LocationOptionRes> buildLocationOptions(LocationType locationType) {
+        return infrastructureRepository.findAll().stream()
+                .filter(i -> locationType == null || i.getLocationType() == locationType)
+                .sorted(Comparator.comparing(Infrastructure::getName))
+                .map(i -> InventoryDto.LocationOptionRes.builder()
+                        .id(i.getId())
+                        .code(i.getCode())
+                        .name(i.getName())
+                        .build())
+                .toList();
+    }
+
+    private int n(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private String toUiStatus(int available, int safety) {
+        if (available <= 0) return "품절";
+        if (available < safety) return "부족";
+        return "정상";
+    }
+
+    private static class Aggregate {
+        private final ProductMaster master;
+        private final String parentCategory;
+        private final String childCategory;
+        private int actualStock = 0;
+        private int availableStock = 0;
+        private int safetyStock = 0;
+        private Date updatedAt;
+        private final Set<InventoryStatus> statuses = new HashSet<>();
+
+        private Aggregate(ProductMaster master, String parentCategory, String childCategory) {
+            this.master = master;
+            this.parentCategory = parentCategory;
+            this.childCategory = childCategory;
+        }
+    }
+
+    private static class SkuAggregate {
+        private final ProductSku sku;
+        private int actualStock = 0;
+        private int availableStock = 0;
+        private Date updatedAt;
+        private LocationType locationType;
+
+        private SkuAggregate(ProductSku sku) {
+            this.sku = sku;
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
@@ -1,0 +1,66 @@
+package org.example.stockitbe.hq.inventory.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "inventory", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_inventory_sku_location", columnNames = {"sku_id", "location_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inventory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "sku_id", nullable = false)
+    private Long skuId;
+
+    @Column(name = "location_id", nullable = false)
+    private Long locationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inventory_status", nullable = false, length = 32)
+    private InventoryStatus inventoryStatus;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "reserved_quantity", nullable = false)
+    private Integer reservedQuantity;
+
+    @Column(name = "in_transit_quantity", nullable = false)
+    private Integer inTransitQuantity;
+
+    @Column(name = "available_quantity", nullable = false)
+    private Integer availableQuantity;
+
+    @Column(name = "status_changed_at", nullable = false)
+    private Date statusChangedAt;
+
+    @Column(name = "last_movement_at", nullable = false)
+    private Date lastMovementAt;
+
+    @Builder
+    private Inventory(Long skuId, Long locationId, InventoryStatus inventoryStatus, Integer quantity,
+                      Integer reservedQuantity, Integer inTransitQuantity, Integer availableQuantity,
+                      Date statusChangedAt, Date lastMovementAt) {
+        this.skuId = skuId;
+        this.locationId = locationId;
+        this.inventoryStatus = inventoryStatus == null ? InventoryStatus.NORMAL : inventoryStatus;
+        this.quantity = quantity == null ? 0 : quantity;
+        this.reservedQuantity = reservedQuantity == null ? 0 : reservedQuantity;
+        this.inTransitQuantity = inTransitQuantity == null ? 0 : inTransitQuantity;
+        this.availableQuantity = availableQuantity == null ? 0 : availableQuantity;
+        this.statusChangedAt = statusChangedAt == null ? new Date() : statusChangedAt;
+        this.lastMovementAt = lastMovementAt == null ? new Date() : lastMovementAt;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
@@ -1,0 +1,55 @@
+package org.example.stockitbe.hq.inventory.model;
+
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+
+public class InventoryDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWideRes {
+        private String itemCode;
+        private String parentCategory;
+        private String childCategory;
+        private String itemName;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+        private Date updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWideSkuDetailRes {
+        private String skuCode;
+        private String color;
+        private String size;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+        private Date updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LocationOptionRes {
+        private Long id;
+        private String code;
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWidePageRes {
+        private List<CompanyWideRes> items;
+        private List<LocationOptionRes> locationOptions;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryStatus.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.hq.inventory.model;
+
+public enum InventoryStatus {
+    NORMAL,
+    CIRCULAR_CANDIDATE,
+    CIRCULAR
+}

--- a/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductMasterService.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -127,7 +128,7 @@ public class ProductMasterService {
     public ProductDto.ProductSkuRes createSku(String productCode, ProductDto.ProductSkuUpsertReq req) {
         productMasterRepository.findByCode(productCode)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
-        validateSkuDuplicate(productCode, req.getOptionName().trim(), req.getOptionValue().trim(), null);
+        validateSkuDuplicate(productCode, req.getColor().trim(), req.getSize().trim(), null);
         ProductSku saved = saveSkuWithGeneratedCode(productCode, req);
         return ProductDto.ProductSkuRes.from(saved);
     }
@@ -136,10 +137,10 @@ public class ProductMasterService {
     public ProductDto.ProductSkuRes updateSku(String skuCode, ProductDto.ProductSkuUpsertReq req) {
         ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
-        String optionName = req.getOptionName().trim();
-        String optionValue = req.getOptionValue().trim();
-        validateSkuDuplicate(sku.getProductCode(), optionName, optionValue, skuCode);
-        sku.update(optionName, optionValue, req.getUnitPrice(), req.getStatus());
+        String color = req.getColor().trim();
+        String size = req.getSize().trim();
+        validateSkuDuplicate(sku.getProductCode(), color, size, skuCode);
+        sku.update(color, size, req.getUnitPrice(), req.getStatus());
         return ProductDto.ProductSkuRes.from(sku);
     }
 
@@ -155,32 +156,35 @@ public class ProductMasterService {
         productMasterRepository.findByCode(productCode)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
 
-        String optionName = req.getOptionName().trim();
-        Set<String> uniqueValues = new LinkedHashSet<>();
-        for (String raw : req.getOptionValues()) {
-            if (raw == null) continue;
-            String trimmed = raw.trim();
-            if (!trimmed.isEmpty()) uniqueValues.add(trimmed);
-        }
+        Set<String> colorSet = req.getColors().stream()
+                .filter(v -> v != null && !v.trim().isEmpty())
+                .map(String::trim)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> sizeSet = req.getSizes().stream()
+                .filter(v -> v != null && !v.trim().isEmpty())
+                .map(String::trim)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        int requestedCount = uniqueValues.size();
+        int requestedCount = colorSet.size() * sizeSet.size();
         int createdCount = 0;
         int skippedCount = 0;
 
-        for (String optionValue : uniqueValues) {
-            boolean duplicated = productSkuRepository.existsByProductCodeAndOptionNameAndOptionValue(productCode, optionName, optionValue);
-            if (duplicated) {
-                skippedCount++;
-                continue;
+        for (String color : colorSet) {
+            for (String size : sizeSet) {
+                boolean duplicated = productSkuRepository.existsByProductCodeAndColorAndSize(productCode, color, size);
+                if (duplicated) {
+                    skippedCount++;
+                    continue;
+                }
+                ProductDto.ProductSkuUpsertReq createReq = ProductDto.ProductSkuUpsertReq.builder()
+                        .color(color)
+                        .size(size)
+                        .unitPrice(req.getUnitPrice())
+                        .status(req.getStatus())
+                        .build();
+                saveSkuWithGeneratedCode(productCode, createReq);
+                createdCount++;
             }
-            ProductDto.ProductSkuUpsertReq createReq = ProductDto.ProductSkuUpsertReq.builder()
-                    .optionName(optionName)
-                    .optionValue(optionValue)
-                    .unitPrice(req.getUnitPrice())
-                    .status(req.getStatus())
-                    .build();
-            saveSkuWithGeneratedCode(productCode, createReq);
-            createdCount++;
         }
 
         return ProductDto.ProductSkuBulkCreateRes.builder()
@@ -202,7 +206,7 @@ public class ProductMasterService {
 
         List<ProductSku> targetSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
         for (ProductSku sku : targetSkus) {
-            sku.update(sku.getOptionName(), sku.getOptionValue(), req.getUnitPrice(), sku.getStatus());
+            sku.update(sku.getColor(), sku.getSize(), req.getUnitPrice(), sku.getStatus());
         }
 
         return ProductDto.ProductSkuPriceBulkUpdateRes.builder()
@@ -219,7 +223,7 @@ public class ProductMasterService {
 
         List<ProductSku> targetSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
         for (ProductSku sku : targetSkus) {
-            sku.update(sku.getOptionName(), sku.getOptionValue(), sku.getUnitPrice(), req.getStatus());
+            sku.update(sku.getColor(), sku.getSize(), sku.getUnitPrice(), req.getStatus());
         }
 
         return ProductDto.ProductSkuStatusBulkUpdateRes.builder()
@@ -329,11 +333,11 @@ public class ProductMasterService {
         throw BaseException.from(BaseResponseStatus.FAIL);
     }
 
-    private void validateSkuDuplicate(String productCode, String optionName, String optionValue, String selfSkuCode) {
+    private void validateSkuDuplicate(String productCode, String color, String size, String selfSkuCode) {
         List<ProductSku> sameProductSkus = productSkuRepository.findByProductCodeOrderByIdDesc(productCode);
         boolean duplicated = sameProductSkus.stream()
-                .anyMatch(s -> s.getOptionName().equalsIgnoreCase(optionName)
-                        && s.getOptionValue().equalsIgnoreCase(optionValue)
+                .anyMatch(s -> s.getColor().equalsIgnoreCase(color)
+                        && s.getSize().equalsIgnoreCase(size)
                         && (selfSkuCode == null || !s.getSkuCode().equals(selfSkuCode)));
         if (duplicated) {
             throw BaseException.from(BaseResponseStatus.DUPLICATE_PRODUCT_SKU_OPTION);

--- a/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/product/ProductSkuRepository.java
@@ -12,7 +12,7 @@ public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
     List<ProductSku> findByProductCodeOrderByIdDesc(String productCode);
     long countByProductCode(String productCode);
     List<ProductSku> findAllByOrderByIdDesc();
-    boolean existsByProductCodeAndOptionNameAndOptionValue(String productCode, String optionName, String optionValue);
+    boolean existsByProductCodeAndColorAndSize(String productCode, String color, String size);
     long deleteByProductCode(String productCode);
     List<ProductSku> findAllByProductCodeInOrderByIdAsc(Collection<String> productCodes);
 }

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductDto.java
@@ -72,8 +72,8 @@ public class ProductDto {
     @AllArgsConstructor
     @Builder
     public static class ProductSkuUpsertReq {
-        @NotBlank private String optionName;
-        @NotBlank private String optionValue;
+        @NotBlank private String color;
+        @NotBlank private String size;
         @NotNull @Min(0) private Long unitPrice;
         @NotNull private ProductStatus status;
 
@@ -81,8 +81,8 @@ public class ProductDto {
             return ProductSku.builder()
                     .skuCode(skuCode)
                     .productCode(productCode)
-                    .optionName(optionName.trim())
-                    .optionValue(optionValue.trim())
+                    .color(color.trim())
+                    .size(size.trim())
                     .unitPrice(unitPrice)
                     .status(status)
                     .build();
@@ -94,8 +94,8 @@ public class ProductDto {
     @AllArgsConstructor
     @Builder
     public static class ProductSkuBulkCreateReq {
-        @NotBlank private String optionName;
-        @NotNull private List<String> optionValues;
+        @NotNull private List<String> colors;
+        @NotNull private List<String> sizes;
         @NotNull @Min(0) private Long unitPrice;
         @NotNull private ProductStatus status;
     }
@@ -179,8 +179,9 @@ public class ProductDto {
     public static class ProductSkuRes {
         private String skuCode;
         private String productCode;
-        private String optionName;
-        private String optionValue;
+        private String color;
+        private String size;
+        private String displayOption;
         private Long unitPrice;
         private ProductStatus status;
         private Date updatedAt;
@@ -189,8 +190,9 @@ public class ProductDto {
             return ProductSkuRes.builder()
                     .skuCode(sku.getSkuCode())
                     .productCode(sku.getProductCode())
-                    .optionName(sku.getOptionName())
-                    .optionValue(sku.getOptionValue())
+                    .color(sku.getColor())
+                    .size(sku.getSize())
+                    .displayOption(sku.getColor() + "/" + sku.getSize())
                     .unitPrice(sku.getUnitPrice())
                     .status(sku.getStatus())
                     .updatedAt(sku.getUpdatedAt())

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
@@ -9,7 +9,8 @@ import org.example.stockitbe.common.model.BaseEntity;
 
 @Entity
 @Table(name = "product_sku", uniqueConstraints = {
-        @UniqueConstraint(name = "uk_product_sku_code", columnNames = "sku_code")
+        @UniqueConstraint(name = "uk_product_sku_code", columnNames = "sku_code"),
+        @UniqueConstraint(name = "uk_product_sku_product_color_size", columnNames = {"product_code", "color", "size"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,11 +25,11 @@ public class ProductSku extends BaseEntity {
     @Column(name = "product_code", nullable = false, length = 32)
     private String productCode;
 
-    @Column(name = "option_name", nullable = false, length = 64)
-    private String optionName;
+    @Column(name = "color", nullable = false, length = 32)
+    private String color;
 
-    @Column(name = "option_value", nullable = false, length = 64)
-    private String optionValue;
+    @Column(name = "size", nullable = false, length = 16)
+    private String size;
 
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
@@ -38,19 +39,19 @@ public class ProductSku extends BaseEntity {
     private ProductStatus status;
 
     @Builder
-    private ProductSku(String skuCode, String productCode, String optionName, String optionValue,
+    private ProductSku(String skuCode, String productCode, String color, String size,
                        Long unitPrice, ProductStatus status) {
         this.skuCode = skuCode;
         this.productCode = productCode;
-        this.optionName = optionName;
-        this.optionValue = optionValue;
+        this.color = color;
+        this.size = size;
         this.unitPrice = unitPrice;
         this.status = status == null ? ProductStatus.ACTIVE : status;
     }
 
-    public void update(String optionName, String optionValue, Long unitPrice, ProductStatus status) {
-        this.optionName = optionName;
-        this.optionValue = optionValue;
+    public void update(String color, String size, Long unitPrice, ProductStatus status) {
+        this.color = color;
+        this.size = size;
         this.unitPrice = unitPrice;
         this.status = status;
     }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
@@ -101,8 +101,9 @@ public class PurchaseOrderCatalogService {
             List<PurchaseOrderCatalogDto.SkuRes> skuResList = skus.stream()
                     .map(s -> PurchaseOrderCatalogDto.SkuRes.builder()
                             .skuCode(s.getSkuCode())
-                            .optionName(s.getOptionName())
-                            .optionValue(s.getOptionValue())
+                            .color(s.getColor())
+                            .size(s.getSize())
+                            .displayOption(s.getColor() + "/" + s.getSize())
                             .unitPrice(s.getUnitPrice())
                             .build())
                     .toList();
@@ -122,18 +123,15 @@ public class PurchaseOrderCatalogService {
                     .build());
         }
 
-        // 6) optionFacets 빌드 — axis name 별 unique 값 셋. 슬래시 합성 axis 는 분해
+        // 6) optionFacets 빌드 — color/size 분리
         Map<String, Set<String>> facetMap = new LinkedHashMap<>();
         for (PurchaseOrderCatalogDto.MasterRes m : masters) {
             for (PurchaseOrderCatalogDto.SkuRes s : m.getSkus()) {
-                String[] names = (s.getOptionName() == null ? "" : s.getOptionName()).split("/");
-                String[] values = (s.getOptionValue() == null ? "" : s.getOptionValue()).split("/");
-                int len = Math.min(names.length, values.length);
-                for (int i = 0; i < len; i++) {
-                    String axis = names[i].trim();
-                    String value = values[i].trim();
-                    if (axis.isEmpty() || value.isEmpty()) continue;
-                    facetMap.computeIfAbsent(axis, k -> new TreeSet<>()).add(value);
+                if (s.getColor() != null && !s.getColor().isBlank()) {
+                    facetMap.computeIfAbsent("색상", k -> new TreeSet<>()).add(s.getColor().trim());
+                }
+                if (s.getSize() != null && !s.getSize().isBlank()) {
+                    facetMap.computeIfAbsent("사이즈", k -> new TreeSet<>()).add(s.getSize().trim());
                 }
             }
         }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderCatalogDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderCatalogDto.java
@@ -44,8 +44,9 @@ public class PurchaseOrderCatalogDto {
     @Builder
     public static class SkuRes {
         private String skuCode;
-        private String optionName;           // 슬래시 합성 ("색상/사이즈")
-        private String optionValue;          // 슬래시 합성 ("화이트/L")
+        private String color;
+        private String size;
+        private String displayOption;
         private Long unitPrice;              // SKU 단가 (sku.unit_price 우선)
     }
 

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderDto.java
@@ -72,8 +72,8 @@ public class PurchaseOrderDto {
                     .productCode(vp.getProductCode())
                     .productName(vp.getProductName())
                     .skuCode(sku.getSkuCode())
-                    .optionName(sku.getOptionName())
-                    .optionValue(sku.getOptionValue())
+                    .color(sku.getColor())
+                    .size(sku.getSize())
                     .unitPrice(sku.getUnitPrice())  // sku 단가 우선 (옵션별 차등 가능)
                     .quantity(this.quantity)
                     .build();
@@ -200,8 +200,9 @@ public class PurchaseOrderDto {
         private String productCode;
         private String productName;
         private String skuCode;
-        private String optionName;
-        private String optionValue;
+        private String color;
+        private String size;
+        private String displayOption;
         private Long unitPrice;
         private Integer quantity;
         private Long subtotal;
@@ -213,8 +214,9 @@ public class PurchaseOrderDto {
                     .productCode(item.getProductCode())
                     .productName(item.getProductName())
                     .skuCode(item.getSkuCode())
-                    .optionName(item.getOptionName())
-                    .optionValue(item.getOptionValue())
+                    .color(item.getColor())
+                    .size(item.getSize())
+                    .displayOption(item.getColor() + "/" + item.getSize())
                     .unitPrice(item.getUnitPrice())
                     .quantity(item.getQuantity())
                     .subtotal(item.getSubtotal())

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderItem.java
@@ -30,15 +30,14 @@ public class PurchaseOrderItem {
     private String productName;
 
     // SKU 식별자 + 옵션 스냅샷 (결합 차단 4패턴 #1 — String ID + 시점 복사, @ManyToOne ProductSku 미사용)
-    // 슬래시 합성 컨벤션 — 다차원이면 optionName="색상/사이즈" optionValue="화이트/L", 단일이면 슬래시 없음
     @Column(name = "sku_code", nullable = false, length = 32)
     private String skuCode;
 
-    @Column(name = "option_name", nullable = false, length = 64)
-    private String optionName;
+    @Column(name = "color", nullable = false, length = 32)
+    private String color;
 
-    @Column(name = "option_value", nullable = false, length = 64)
-    private String optionValue;
+    @Column(name = "size", nullable = false, length = 16)
+    private String size;
 
     // 발주 시점 단가 복사 — sku.unitPrice 우선 (옵션별 차등 가능)
     @Column(name = "unit_price", nullable = false)
@@ -53,15 +52,15 @@ public class PurchaseOrderItem {
     @Builder
     private PurchaseOrderItem(Long purchaseOrderId, Long vendorProductId,
                               String productCode, String productName,
-                              String skuCode, String optionName, String optionValue,
+                              String skuCode, String color, String size,
                               Long unitPrice, Integer quantity) {
         this.purchaseOrderId = purchaseOrderId;
         this.vendorProductId = vendorProductId;
         this.productCode = productCode;
         this.productName = productName;
         this.skuCode = skuCode;
-        this.optionName = optionName;
-        this.optionValue = optionValue;
+        this.color = color;
+        this.size = size;
         this.unitPrice = unitPrice;
         this.quantity = quantity;
         this.subtotal = unitPrice * quantity;

--- a/src/main/resources/sql/inventory_dummy_data.sql
+++ b/src/main/resources/sql/inventory_dummy_data.sql
@@ -1,0 +1,37 @@
+-- 재고 더미 데이터
+-- 실행 순서:
+-- 1) category_two_level_seed.sql
+-- 2) infrastructure_dummy_data.sql
+-- 3) product_master_dummy_data.sql
+
+INSERT INTO inventory
+(sku_id, location_id, inventory_status, quantity, reserved_quantity, in_transit_quantity, available_quantity, status_changed_at, last_movement_at, create_date, update_date)
+SELECT
+    s.id AS sku_id,
+    i.id AS location_id,
+    CASE
+      WHEN MOD(s.id + i.id, 11) IN (0,1) THEN 'CIRCULAR'
+      WHEN MOD(s.id + i.id, 11) IN (2,3,4) THEN 'CIRCULAR_CANDIDATE'
+      ELSE 'NORMAL'
+    END AS inventory_status,
+    (20 + MOD(s.id * 13 + i.id * 7, 260)) AS quantity,
+    MOD(s.id * 5 + i.id * 3, 30) AS reserved_quantity,
+    MOD(s.id * 3 + i.id * 2, 18) AS in_transit_quantity,
+    GREATEST((20 + MOD(s.id * 13 + i.id * 7, 260)) - MOD(s.id * 5 + i.id * 3, 30), 0) AS available_quantity,
+    DATE_SUB(NOW(), INTERVAL MOD(s.id + i.id, 45) DAY) AS status_changed_at,
+    DATE_SUB(NOW(), INTERVAL MOD(s.id * 2 + i.id, 30) DAY) AS last_movement_at,
+    NOW(),
+    NOW()
+FROM product_sku s
+CROSS JOIN infrastructure i
+WHERE i.status = 'ACTIVE'
+  AND MOD(s.id + i.id, 4) <> 0
+ON DUPLICATE KEY UPDATE
+inventory_status = VALUES(inventory_status),
+quantity = VALUES(quantity),
+reserved_quantity = VALUES(reserved_quantity),
+in_transit_quantity = VALUES(in_transit_quantity),
+available_quantity = VALUES(available_quantity),
+status_changed_at = VALUES(status_changed_at),
+last_movement_at = VALUES(last_movement_at),
+update_date = NOW();

--- a/src/main/resources/sql/product_master_dummy_data.sql
+++ b/src/main/resources/sql/product_master_dummy_data.sql
@@ -1,0 +1,44 @@
+-- 제품 마스터/SKU 더미 데이터 (color/size 구조)
+-- 실행 순서: category_two_level_seed.sql + vendor + infrastructure 이후
+-- 주의:
+-- 1) product_sku 는 option_name/option_value 를 사용하지 않습니다.
+-- 2) product_sku 유니크 키는 (product_code, color, size) 기준입니다.
+
+INSERT INTO product_master
+(code, name, category_code, base_price, lead_time_days, warehouse_safety_stock, store_safety_stock, main_vendor_code, material_spec, status, create_date, update_date)
+VALUES
+('PM-2001','코튼 베이직 반팔 티셔츠','CAT-9101',19900,5,120,60,'VND-001','{"materialType":"NATURAL_SINGLE","compositions":[{"materialCode":"COTTON","ratio":100}]}','ACTIVE',NOW(),NOW()),
+('PM-2002','슬림핏 긴팔 티셔츠','CAT-9102',22900,5,110,55,'VND-001','{"materialType":"BLEND","compositions":[{"materialCode":"COTTON","ratio":80},{"materialCode":"ELASTANE","ratio":20}]}','ACTIVE',NOW(),NOW()),
+('PM-2003','오버핏 옥스포드 셔츠','CAT-9103',39900,7,100,45,'VND-002','{"materialType":"NATURAL_SINGLE","compositions":[{"materialCode":"COTTON","ratio":100}]}','ACTIVE',NOW(),NOW()),
+('PM-2004','라운드넥 소프트 니트','CAT-9104',49900,8,90,40,'VND-005','{"materialType":"BLEND","compositions":[{"materialCode":"WOOL","ratio":60},{"materialCode":"ACRYLIC","ratio":40}]}','ACTIVE',NOW(),NOW()),
+('PM-2005','헤비웨이트 로고 후드티','CAT-9105',45900,6,100,50,'VND-006','{"materialType":"BLEND","compositions":[{"materialCode":"COTTON","ratio":70},{"materialCode":"POLYESTER","ratio":30}]}','ACTIVE',NOW(),NOW()),
+('PM-2006','스트레이트 워싱 데님','CAT-9201',55900,9,95,35,'VND-003','{"materialType":"BLEND","compositions":[{"materialCode":"COTTON","ratio":98},{"materialCode":"ELASTANE","ratio":2}]}','ACTIVE',NOW(),NOW()),
+('PM-2007','라이트 코튼 쇼츠','CAT-9202',32900,6,85,30,'VND-004','{"materialType":"NATURAL_SINGLE","compositions":[{"materialCode":"COTTON","ratio":100}]}','ACTIVE',NOW(),NOW()),
+('PM-2008','와이드 밴딩 팬츠','CAT-9203',37900,6,90,30,'VND-004','{"materialType":"BLEND","compositions":[{"materialCode":"POLYESTER","ratio":65},{"materialCode":"RAYON","ratio":35}]}','ACTIVE',NOW(),NOW()),
+('PM-2009','A라인 데님 미니스커트','CAT-9301',34900,7,70,30,'VND-008','{"materialType":"BLEND","compositions":[{"materialCode":"COTTON","ratio":99},{"materialCode":"ELASTANE","ratio":1}]}','ACTIVE',NOW(),NOW()),
+('PM-2010','플리츠 롱스커트','CAT-9302',42900,7,75,28,'VND-008','{"materialType":"SYNTHETIC","compositions":[{"materialCode":"POLYESTER","ratio":100}]}','ACTIVE',NOW(),NOW()),
+('PM-2011','라이트 숏 패딩','CAT-9401',89900,12,80,25,'VND-007','{"materialType":"SYNTHETIC","compositions":[{"materialCode":"POLYESTER","ratio":100}]}','ACTIVE',NOW(),NOW()),
+('PM-2012','싱글 브레스트 자켓','CAT-9403',79900,10,65,22,'VND-006','{"materialType":"BLEND","compositions":[{"materialCode":"WOOL","ratio":50},{"materialCode":"POLYESTER","ratio":50}]}','ACTIVE',NOW(),NOW())
+ON DUPLICATE KEY UPDATE
+name=VALUES(name), category_code=VALUES(category_code), base_price=VALUES(base_price), lead_time_days=VALUES(lead_time_days),
+warehouse_safety_stock=VALUES(warehouse_safety_stock), store_safety_stock=VALUES(store_safety_stock), main_vendor_code=VALUES(main_vendor_code),
+material_spec=VALUES(material_spec), status=VALUES(status), update_date=NOW();
+
+INSERT INTO product_sku
+(sku_code, product_code, color, size, unit_price, status, create_date, update_date)
+VALUES
+('PS-3001','PM-2001','검정','S',19900,'ACTIVE',NOW(),NOW()),('PS-3002','PM-2001','검정','M',19900,'ACTIVE',NOW(),NOW()),('PS-3003','PM-2001','검정','L',19900,'ACTIVE',NOW(),NOW()),
+('PS-3004','PM-2001','흰색','S',19900,'ACTIVE',NOW(),NOW()),('PS-3005','PM-2001','흰색','M',19900,'ACTIVE',NOW(),NOW()),('PS-3006','PM-2001','흰색','L',19900,'ACTIVE',NOW(),NOW()),
+('PS-3007','PM-2002','검정','M',22900,'ACTIVE',NOW(),NOW()),('PS-3008','PM-2002','검정','L',22900,'ACTIVE',NOW(),NOW()),('PS-3009','PM-2002','아이보리','M',22900,'ACTIVE',NOW(),NOW()),
+('PS-3010','PM-2003','흰색','M',39900,'ACTIVE',NOW(),NOW()),('PS-3011','PM-2003','흰색','L',39900,'ACTIVE',NOW(),NOW()),('PS-3012','PM-2003','블루','L',39900,'ACTIVE',NOW(),NOW()),
+('PS-3013','PM-2004','그레이','M',49900,'ACTIVE',NOW(),NOW()),('PS-3014','PM-2004','그레이','L',49900,'ACTIVE',NOW(),NOW()),('PS-3015','PM-2004','네이비','L',49900,'ACTIVE',NOW(),NOW()),
+('PS-3016','PM-2005','검정','M',45900,'ACTIVE',NOW(),NOW()),('PS-3017','PM-2005','검정','L',45900,'ACTIVE',NOW(),NOW()),('PS-3018','PM-2005','그레이','L',45900,'ACTIVE',NOW(),NOW()),
+('PS-3019','PM-2006','인디고','30',55900,'ACTIVE',NOW(),NOW()),('PS-3020','PM-2006','인디고','32',55900,'ACTIVE',NOW(),NOW()),('PS-3021','PM-2006','블랙','32',55900,'ACTIVE',NOW(),NOW()),
+('PS-3022','PM-2007','베이지','M',32900,'ACTIVE',NOW(),NOW()),('PS-3023','PM-2007','베이지','L',32900,'ACTIVE',NOW(),NOW()),('PS-3024','PM-2007','카키','L',32900,'ACTIVE',NOW(),NOW()),
+('PS-3025','PM-2008','블랙','M',37900,'ACTIVE',NOW(),NOW()),('PS-3026','PM-2008','블랙','L',37900,'ACTIVE',NOW(),NOW()),('PS-3027','PM-2008','차콜','L',37900,'ACTIVE',NOW(),NOW()),
+('PS-3028','PM-2009','데님','S',34900,'ACTIVE',NOW(),NOW()),('PS-3029','PM-2009','데님','M',34900,'ACTIVE',NOW(),NOW()),('PS-3030','PM-2009','데님','L',34900,'ACTIVE',NOW(),NOW()),
+('PS-3031','PM-2010','블랙','S',42900,'ACTIVE',NOW(),NOW()),('PS-3032','PM-2010','블랙','M',42900,'ACTIVE',NOW(),NOW()),('PS-3033','PM-2010','아이보리','M',42900,'ACTIVE',NOW(),NOW()),
+('PS-3034','PM-2011','블랙','M',89900,'ACTIVE',NOW(),NOW()),('PS-3035','PM-2011','블랙','L',89900,'ACTIVE',NOW(),NOW()),('PS-3036','PM-2011','카키','L',89900,'ACTIVE',NOW(),NOW()),
+('PS-3037','PM-2012','그레이','M',79900,'ACTIVE',NOW(),NOW()),('PS-3038','PM-2012','그레이','L',79900,'ACTIVE',NOW(),NOW()),('PS-3039','PM-2012','네이비','L',79900,'ACTIVE',NOW(),NOW())
+ON DUPLICATE KEY UPDATE
+product_code=VALUES(product_code), color=VALUES(color), size=VALUES(size), unit_price=VALUES(unit_price), status=VALUES(status), update_date=NOW();

--- a/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
+++ b/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
@@ -86,12 +86,12 @@ class PurchaseOrderCatalogServiceTest {
                 .status(ProductStatus.ACTIVE).build();
     }
 
-    private ProductSku sku(String skuCode, String productCode, String optionName, String optionValue, long price) {
+    private ProductSku sku(String skuCode, String productCode, String color, String size, long price) {
         return ProductSku.builder()
                 .skuCode(skuCode)
                 .productCode(productCode)
-                .optionName(optionName)
-                .optionValue(optionValue)
+                .color(color)
+                .size(size)
                 .unitPrice(price)
                 .status(ProductStatus.ACTIVE)
                 .build();
@@ -105,9 +105,9 @@ class PurchaseOrderCatalogServiceTest {
         when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA, vendorB));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmB));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
-                sku("SKU-A-1", "PM-A", "색상/사이즈", "화이트/L", 6800L),
-                sku("SKU-A-2", "PM-A", "색상/사이즈", "블랙/M", 7200L),
-                sku("SKU-B-1", "PM-B", "색상", "네이비", 15000L)
+                sku("SKU-A-1", "PM-A", "화이트", "L", 6800L),
+                sku("SKU-A-2", "PM-A", "블랙", "M", 7200L),
+                sku("SKU-B-1", "PM-B", "네이비", "FREE", 15000L)
         ));
 
         PurchaseOrderCatalogDto.CatalogRes res = service.getCatalog(null, null);
@@ -136,7 +136,7 @@ class PurchaseOrderCatalogServiceTest {
         when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmEmpty));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
-                sku("SKU-A-1", "PM-A", "사이즈", "L", 6800L)
+                sku("SKU-A-1", "PM-A", "화이트", "L", 6800L)
                 // PM-EMPTY 의 SKU 는 0건
         ));
 
@@ -155,7 +155,7 @@ class PurchaseOrderCatalogServiceTest {
         when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
-                sku("SKU-A-1", "PM-A", "사이즈", "L", 6800L)
+                sku("SKU-A-1", "PM-A", "화이트", "L", 6800L)
         ));
 
         PurchaseOrderCatalogDto.CatalogRes res = service.getCatalog("VND-A", null);


### PR DESCRIPTION
## 📌 요약
- HQ 전사 재고 조회 기능을 백엔드 실데이터 API로 구현하고, SKU 옵션 구조를 `color/size` 기준으로 전환했습니다.

<br><br>

## 🎯 작업 내용
- `inventory` 도메인 및 전사 재고 조회 API 추가  
  - `GET /api/hq/inventories/company-wide`  
  - `GET /api/hq/inventories/company-wide/{itemCode}/skus`
- `product_sku`를 `option_name/option_value`에서 `color/size` 구조로 전환하고, 관련 서비스/DTO/조회 로직 정리
- 더미 SQL 추가 및 정비  
  - `product_master_dummy_data.sql`, `inventory_dummy_data.sql`  

<br><br>

## ✔️ 참고 사항
- `compileJava` 기준 빌드 통과

<br><br>

## ✔️ 관련 이슈

- Close #163 

<br><br>
