### PR TITLE
refactor(vendor,purchase-order): 사용자 노출 거래처 표기를 공급처로 통일

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -38,9 +38,9 @@ public enum BaseResponseStatus {
     PAYMENT_DEFAULT_BILLING_REQUIRED(false, 4106, "기본 결제 수단이 존재하지 않습니다."),
 
     // 4200번대~ 공급처별 제품 (CEN-027~031, 033)
-    VENDOR_NOT_FOUND(false, 4200, "거래처를 찾을 수 없습니다."),
+    VENDOR_NOT_FOUND(false, 4200, "공급처를 찾을 수 없습니다."),
     VENDOR_PRODUCT_NOT_FOUND(false, 4201, "공급처별 제품 계약을 찾을 수 없습니다."),
-    DUPLICATE_VENDOR_PRODUCT_CODE(false, 4202, "이미 등록된 거래처-제품 코드 조합입니다."),
+    DUPLICATE_VENDOR_PRODUCT_CODE(false, 4202, "이미 등록된 공급처-제품 코드 조합입니다."),
     CATEGORY_NOT_FOUND(false, 4203, "카테고리를 찾을 수 없습니다."),
     DUPLICATE_CATEGORY_NAME(false, 4204, "동일한 범위에 같은 카테고리명이 이미 존재합니다."),
     CATEGORY_PARENT_REQUIRED(false, 4205, "소분류 등록 시 상위 카테고리가 필요합니다."),
@@ -57,17 +57,17 @@ public enum BaseResponseStatus {
     DUPLICATE_PRODUCT_MASTER_NAME(false, 4216, "이미 등록된 제품명입니다."),
     DUPLICATE_PRODUCT_SKU_OPTION(false, 4217, "이미 등록된 SKU 옵션입니다."),
     INVALID_SKU_PRICE(false, 4218, "SKU 가격은 0 이상이어야 합니다."),
-    VENDOR_PRODUCT_VENDOR_MISMATCH(false, 4219, "이 제품의 메인 거래처가 아닙니다."),
-    VENDOR_INACTIVE(false, 4220, "비활성 거래처는 선택할 수 없습니다."),
+    VENDOR_PRODUCT_VENDOR_MISMATCH(false, 4219, "이 제품의 메인 공급처가 아닙니다."),
+    VENDOR_INACTIVE(false, 4220, "비활성 공급처는 선택할 수 없습니다."),
     INVALID_PRODUCT_MATERIAL_SPEC(false, 4221, "제품 소재 정보가 올바르지 않습니다."),
 
     // 4300번대~ 본사 발주 (CEN-035~040)
     PURCHASE_ORDER_NOT_FOUND(false, 4300, "본사 발주를 찾을 수 없습니다."),
     PURCHASE_ORDER_INVALID_STATUS_TRANSITION(false, 4301, "허용되지 않는 발주 상태 전환입니다."),
     PURCHASE_ORDER_EMPTY_ITEMS(false, 4302, "발주 품목이 비어 있습니다."),
-    PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH(false, 4303, "발주 거래처와 품목의 거래처가 일치하지 않습니다."),
+    PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH(false, 4303, "발주 공급처와 품목의 공급처가 일치하지 않습니다."),
     PURCHASE_ORDER_CANCEL_REASON_REQUIRED(false, 4304, "발주 취소 사유는 필수입니다."),
-    PURCHASE_ORDER_SKU_PRODUCT_MISMATCH(false, 4305, "발주 품목의 SKU가 거래처 계약 제품의 옵션이 아닙니다."),
+    PURCHASE_ORDER_SKU_PRODUCT_MISMATCH(false, 4305, "발주 품목의 SKU가 공급처 계약 제품의 옵션이 아닙니다."),
 
     // 4400번대~ 순환재고 거래처 (ADR-020 / ADR-021)
     CIRCULAR_BUYER_NOT_FOUND(false, 4400, "순환재고 거래처를 찾을 수 없습니다."),

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
@@ -38,8 +38,8 @@ public class PurchaseOrderBatchService {
      * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 모든 PENDING/APPROVED/SHIPPING 즉시 처리.
      *              false 면 {@code updatedAt < now - waitMinutes} 인 건만.
      *
-     * 거래처 책임 단계 3개 모두 SYS-001 자동 전환 (ADR-013/019).
-     * SHIPPING → DELIVERED 도 같은 패턴 — 배송 도착 시점도 거래처 책임이라 자동화.
+     * 공급처 책임 단계 3개 모두 SYS-001 자동 전환 (ADR-013/019).
+     * SHIPPING → DELIVERED 도 같은 패턴 — 배송 도착 시점도 공급처 책임이라 자동화.
      * DELIVERED → COMPLETED 는 창고 [입고 확정] 매뉴얼 트리거(WHS-007) — 배치 처리 안 함.
      */
     public BatchResult run(boolean force) {

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
@@ -44,13 +44,13 @@ public class PurchaseOrderCatalogService {
     private final ProductSkuRepository productSkuRepository;
 
     /**
-     * vendorCode 미지정 → 모든 ACTIVE 거래처의 ACTIVE 계약 펼침.
-     * 지정 시 그 거래처만.
+     * vendorCode 미지정 → 모든 ACTIVE 공급처의 ACTIVE 계약 펼침.
+     * 지정 시 그 공급처만.
      *
      * warehouseId 는 본 사이클에선 사용 X (인벤토리 합류 후 stock 필터링용 placeholder).
      *
      * 응답 룰:
-     *  - vendor.status != ACTIVE 거래처는 제외
+     *  - vendor.status != ACTIVE 공급처는 제외
      *  - vendor_product.status != ACTIVE 계약은 제외
      *  - product_master.status != ACTIVE 마스터는 제외
      *  - product_sku.status != ACTIVE SKU 는 제외

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -303,7 +303,7 @@ public class PurchaseOrderService {
 
     /**
      * 진행 이력 한 행 추가. changedByName 은 도메인 책임자 기준 분기:
-     *   - APPROVED / SHIPPING / DELIVERED : "담당자명 (회사명)" 형식 — 발주 시점 거래처 스냅샷
+     *   - APPROVED / SHIPPING / DELIVERED : "담당자명 (회사명)" 형식 — 발주 시점 공급처 스냅샷
      *     (실제 트리거는 SYS-001 배치지만 자동화는 구현 디테일이라 도메인 이력에 노출하지 않음, ADR-013/019)
      *     실무 ERP 표준 — 법적 주체(회사) + 실무 처리자(담당자) 둘 다 노출.
      *   - COMPLETED            : 입고 확정은 창고 관리자 책임

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
@@ -29,11 +29,11 @@ public class PurchaseOrder extends BaseEntity {
     @Column(name = "vendor_id", nullable = false)
     private Long vendorId;
 
-    // vendor.name 시점 복사 — 발주 시점의 거래처명 스냅샷 (warehouseName/memberName 패턴과 동일).
+    // vendor.name 시점 복사 — 발주 시점의 공급처명 스냅샷 (warehouseName/memberName 패턴과 동일).
     @Column(name = "vendor_name", nullable = false, length = 128)
     private String vendorName;
 
-    // vendor.contactName 시점 복사 — 거래처 담당자명. statusHistory.changedByName 에
+    // vendor.contactName 시점 복사 — 공급처 담당자명. statusHistory.changedByName 에
     // APPROVED/SHIPPING/DELIVERED 단계 주체로 박힘 (회사명보다 사람 이름이 자연).
     @Column(name = "vendor_contact_name", nullable = false, length = 64)
     private String vendorContactName;
@@ -95,7 +95,7 @@ public class PurchaseOrder extends BaseEntity {
 
     /**
      * 배송 완료 — SHIPPING → DELIVERED. SYS-001 배치 자동 (30분 경과) 또는 force 트리거.
-     * 거래처 책임 단계 (운송 도착) — ADR-013 / ADR-019 일관.
+     * 공급처 책임 단계 (운송 도착) — ADR-013 / ADR-019 일관.
      */
     public void markDelivered() {
         if (this.status != PurchaseOrderStatus.SHIPPING) {

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorController.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorController.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 /**
  * Vendor read-only Controller — 등록/수정/삭제는 SQL 로 직접 처리.
- * 거래처 계약 표(E 안)는 vendorProductService.findContractRows 로 mainVendorCode 매칭 ProductMaster + VendorProduct join.
+ * 공급처 계약 표(E 안)는 vendorProductService.findContractRows 로 mainVendorCode 매칭 ProductMaster + VendorProduct join.
  */
 @RestController
 @RequestMapping("/api/vendors")
@@ -34,7 +34,7 @@ public class VendorController {
     }
 
     /**
-     * 거래처 계약 표 — ProductMaster(mainVendorCode 매칭) 행 + VendorProduct 매칭 join.
+     * 공급처 계약 표 — ProductMaster(mainVendorCode 매칭) 행 + VendorProduct 매칭 join.
      * VendorProduct 가 없으면 contracted=false (미정) 행으로 반환.
      */
     @GetMapping("/{code}/contracts")

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
@@ -36,7 +36,7 @@ public class VendorProductService {
     }
 
     /**
-     * 전체 거래처의 제품 일괄 조회 (CEN-035 발주 작성 페이지 카탈로그용).
+     * 전체 공급처의 제품 일괄 조회 (CEN-035 발주 작성 페이지 카탈로그용).
      * statusFilter == null → DELETED 만 제외한 전체.
      * statusFilter != null → 정확히 그 status 만 (DELETED 도 호출자가 의도하면 그대로 통과).
      */
@@ -81,7 +81,7 @@ public class VendorProductService {
         ProductMaster product = productMasterRepository.findByCode(req.getProductCode())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
 
-        // 한 제품 = 한 거래처 검증 — ProductMaster.mainVendorCode 와 요청 vendor 일치해야 함
+        // 한 제품 = 한 공급처 검증 — ProductMaster.mainVendorCode 와 요청 vendor 일치해야 함
         if (!vendor.getCode().equals(product.getMainVendorCode())) {
             throw BaseException.from(BaseResponseStatus.VENDOR_PRODUCT_VENDOR_MISMATCH);
         }
@@ -114,7 +114,7 @@ public class VendorProductService {
     }
 
     /**
-     * 거래처 계약 표 (E 안 — UX 친화 inline edit).
+     * 공급처 계약 표 (E 안 — UX 친화 inline edit).
      * mainVendorCode 매칭 ProductMaster 전체를 행으로 보여주고, 매칭되는 VendorProduct 가 있으면 계약 디테일 채움.
      * VendorProduct 0건이면 모두 contracted=false ("미정") 상태로 반환.
      */
@@ -122,7 +122,7 @@ public class VendorProductService {
     public List<VendorProductDto.ContractRowRes> findContractRows(String vendorCode) {
         Vendor vendor = lookupVendor(vendorCode);
 
-        // 이 거래처를 메인으로 둔 ProductMaster (in-memory 필터 — ProductMasterRepository 메소드 추가 회피, 팀원 코드 보호)
+        // 이 공급처를 메인으로 둔 ProductMaster (in-memory 필터 — ProductMasterRepository 메소드 추가 회피, 팀원 코드 보호)
         List<ProductMaster> products = productMasterRepository.findAllByOrderByIdDesc().stream()
                 .filter(p -> vendor.getCode().equals(p.getMainVendorCode()))
                 .toList();
@@ -130,7 +130,7 @@ public class VendorProductService {
             return List.of();
         }
 
-        // 해당 거래처의 active VendorProduct (DELETED 제외)
+        // 해당 공급처의 active VendorProduct (DELETED 제외)
         List<VendorProduct> vps = vendorProductRepository
                 .findAllByVendorIdAndStatusNotOrderByIdDesc(vendor.getId(), VendorProductStatus.DELETED);
         Map<String, VendorProduct> vpByProductCode = vps.stream()

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorSeedRunner.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * dev 프로파일 부팅 시 vendor 테이블이 비어 있으면 거래처 12개를 자동 INSERT.
- * 운영(prod) 에선 동작하지 않음 — 운영 거래처 데이터는 운영자가 별도 관리.
+ * dev 프로파일 부팅 시 vendor 테이블이 비어 있으면 공급처 12개를 자동 INSERT.
+ * 운영(prod) 에선 동작하지 않음 — 운영 공급처 데이터는 운영자가 별도 관리.
  *
  * 빈 테이블 조건(count == 0) — 이미 데이터 있으면 건너뜀.
  */

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
@@ -109,7 +109,7 @@ public class VendorProductDto {
     }
 
     /**
-     * 거래처 계약 표 한 행 (E 안 — UX 친화 inline edit).
+     * 공급처 계약 표 한 행 (E 안 — UX 친화 inline edit).
      * ProductMaster 가 mainVendorCode 매칭으로 무조건 노출되고, VendorProduct 매칭이 있으면 계약 디테일을 채워서 반환.
      * contracted=false 인 행 = "미정" 상태 (마스터 제품은 있지만 계약 정보 없음).
      */

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -24,7 +24,7 @@ public class InboundService {
 
     /**
      * 입고 목록 — 창고 관심사는 DELIVERED(도착됨)/COMPLETED(입고완료) 만.
-     * SHIPPING 은 거래처 단계(운송중)라 창고 화면에서 안 보임 — 본사 발주 화면에서 진행 상황만 확인.
+     * SHIPPING 은 공급처 단계(운송중)라 창고 화면에서 안 보임 — 본사 발주 화면에서 진행 상황만 확인.
      * status 미지정 시 두 상태 모두, 지정 시 그 status 만 (DELIVERED/COMPLETED 외엔 빈 결과).
      */
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 요약
- 본사 발주 영역의 사용자 노출 한국어 표기를 "거래처" → "공급처" 로 통일. vendor 도메인 의미(SPA 의류 공급처) 와 일치시키고 순환재고 거래처(`circular_buyer`) 와의 혼동을 차단.

<br><br>

## 🎯 작업 내용
- `BaseResponseStatus.java` 의 vendor 관련 사용자 노출 메시지 6곳 변경 (`VENDOR_NOT_FOUND`/`DUPLICATE_VENDOR_PRODUCT_CODE`/`VENDOR_PRODUCT_VENDOR_MISMATCH`/`VENDOR_INACTIVE`/`PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH`/`PURCHASE_ORDER_SKU_PRODUCT_MISMATCH` — 4200/4202/4219/4220/4303/4305).
- `hq/vendor/**`, `hq/purchaseorder/**`, `warehouse/inbound/**` 패키지의 한국어 코드 주석 통일 (10파일).
- 4400 번대 `CIRCULAR_BUYER_*` 의 "순환재고 거래처" 메시지는 별 도메인이라 그대로 보존.
- 코드 식별자(`vendor`, `vendorCode`, `vendorName`, `vendorContactName` 등)는 변경하지 않음 — 한국어 라벨/메시지/주석만 손댐.

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #166

<br><br>
