### PR TITLE
refactor(circular-buyer): 거래처 코드 자동 부여 (RCV-{NNN}) 로 전환

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -73,6 +73,8 @@ public enum BaseResponseStatus {
     CIRCULAR_BUYER_NOT_FOUND(false, 4400, "순환재고 거래처를 찾을 수 없습니다."),
     DUPLICATE_CIRCULAR_BUYER_CODE(false, 4401, "이미 등록된 순환재고 거래처 코드입니다."),
     INVALID_MATERIAL_FIT(false, 4402, "유효하지 않은 소재 적합도입니다."),
+    CIRCULAR_BUYER_CODE_EXHAUSTED(false, 4403, "순환재고 거래처 코드(RCV-999)가 모두 소진되었습니다."),
+    CONCURRENT_CIRCULAR_BUYER_REGISTRATION(false, 4404, "동시 등록 충돌이 발생했습니다. 다시 시도해주세요."),
 
     // 4500번대~ 매장 판매
     STORE_SALE_NOT_FOUND(false, 4500, "판매 내역을 찾을 수 없습니다."),

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRepository.java
@@ -1,9 +1,14 @@
 package org.example.stockitbe.hq.circularbuyer;
 
+import jakarta.persistence.LockModeType;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CircularBuyerRepository
@@ -11,5 +16,12 @@ public interface CircularBuyerRepository
 
     Optional<CircularBuyer> findByCode(String code);
 
-    boolean existsByCode(String code);
+    /**
+     * 자동 코드 부여 시 동시성 제어 — 마지막(max code) row 에 PESSIMISTIC_WRITE 락.
+     * 두 트랜잭션이 동시에 호출하면 한 쪽은 락 대기 → 깨어나면 새 max 다시 조회 → 충돌 회피.
+     * Pageable 로 top 1 만 조회. 빈 테이블이면 빈 리스트 (시드 30건이 있어 정상 운영 시 항상 1건 이상).
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select b from CircularBuyer b order by b.code desc")
+    List<CircularBuyer> findAllOrderByCodeDescForUpdate(Pageable pageable);
 }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
@@ -6,6 +6,8 @@ import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerDto;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,10 @@ public class CircularBuyerService {
     private static final Set<String> ALLOWED_MATERIAL_FITS = Set.of(
             "natural-single", "synthetic", "blended"
     );
+
+    private static final String CODE_PREFIX = "RCV-";
+    private static final int CODE_NUMBER_WIDTH = 3;
+    private static final int CODE_NUMBER_MAX = 999;
 
     private final CircularBuyerRepository circularBuyerRepository;
     private final CircularBuyerEmbeddingService embeddingService;
@@ -46,13 +52,39 @@ public class CircularBuyerService {
     @Transactional
     public CircularBuyerDto.DetailRes create(CircularBuyerDto.CreateReq req) {
         validateMaterialFit(req.getPrimaryMaterialFit());
-        if (circularBuyerRepository.existsByCode(req.getCode())) {
-            throw BaseException.from(BaseResponseStatus.DUPLICATE_CIRCULAR_BUYER_CODE);
+        String nextCode = nextCircularBuyerCode();
+        CircularBuyer saved;
+        try {
+            saved = circularBuyerRepository.save(req.toEntity(nextCode));
+        } catch (DataIntegrityViolationException e) {
+            // PESSIMISTIC_WRITE 가 잡지 못한 가장자리 케이스(빈 테이블 동시 호출 등) 안전망.
+            throw BaseException.from(BaseResponseStatus.CONCURRENT_CIRCULAR_BUYER_REGISTRATION);
         }
-        CircularBuyer saved = circularBuyerRepository.save(req.toEntity());
         // ADR-021 — 등록 시 항상 임베딩 생성. 실패해도 등록은 성공.
         embeddingService.embedAndApply(saved);
         return CircularBuyerDto.DetailRes.from(saved);
+    }
+
+    /**
+     * 자동 코드 부여 — RCV-{NNN} 3자리 zero-padded.
+     * PESSIMISTIC_WRITE 로 마지막 row 락을 잡아 동시 등록 시 한 트랜잭션이 끝날 때까지 다른 트랜잭션 대기.
+     */
+    private String nextCircularBuyerCode() {
+        List<CircularBuyer> top = circularBuyerRepository.findAllOrderByCodeDescForUpdate(PageRequest.of(0, 1));
+        int next = top.isEmpty() ? 1 : parseCodeNumber(top.get(0).getCode()) + 1;
+        if (next > CODE_NUMBER_MAX) {
+            throw BaseException.from(BaseResponseStatus.CIRCULAR_BUYER_CODE_EXHAUSTED);
+        }
+        return String.format("%s%0" + CODE_NUMBER_WIDTH + "d", CODE_PREFIX, next);
+    }
+
+    private static int parseCodeNumber(String code) {
+        if (code == null || !code.startsWith(CODE_PREFIX)) return 0;
+        try {
+            return Integer.parseInt(code.substring(CODE_PREFIX.length()));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     @Transactional

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
@@ -17,8 +17,6 @@ public class CircularBuyerDto {
     @Builder
     public static class CreateReq {
         @NotBlank
-        private String code;
-        @NotBlank
         private String companyName;
         @NotBlank
         private String industryGroup;
@@ -32,9 +30,9 @@ public class CircularBuyerDto {
         @NotBlank
         private String phone;
 
-        public CircularBuyer toEntity() {
+        public CircularBuyer toEntity(String code) {
             return CircularBuyer.builder()
-                    .code(this.code)
+                    .code(code)
                     .companyName(this.companyName)
                     .industryGroup(this.industryGroup)
                     .productTypes(this.productTypes)


### PR DESCRIPTION
## 📌 요약
- 순환재고 거래처 등록 시 코드를 사용자가 직접 입력하던 방식에서 BE 가 `RCV-{NNN}` 3자리 zero-padded 로 자동 부여하는 방식으로 전환

<br><br>

## 🎯 작업 내용
- `CircularBuyerService.create()` 안에서 `nextCircularBuyerCode()` 헬퍼로 다음 번호 산출 후 부여 — 시드 RCV-030 다음은 RCV-031 부여
- 동시 등록 시 충돌 방지를 위해 `findAllOrderByCodeDescForUpdate(Pageable)` 에 `@Lock(PESSIMISTIC_WRITE)` 적용 — 마지막 row 락으로 두 트랜잭션 직렬화
- 락이 닿지 않는 가장자리 케이스 안전망으로 `DataIntegrityViolationException` 을 catch 하여 `CONCURRENT_CIRCULAR_BUYER_REGISTRATION(4404)` 한국어 메시지로 변환
- `RCV-999` 초과 시 `CIRCULAR_BUYER_CODE_EXHAUSTED(4403)` 으로 차단
- DTO `CircularBuyerDto.CreateReq` 의 `code` 필드 + `@NotBlank` 제거, `toEntity(String code)` 시그니처 변경
- 미사용 `existsByCode` Repository 메소드 제거

<br><br>

## ✔️ 참고 사항
- 본사 발주 `PO-{YYYYMMDD}-{NNN}` 자동 부여 패턴과 일관성을 맞춘 변경
- FE 측 등록 폼 코드 입력 칸 제거 작업은 별도 PR (이슈 #376)
- 시드 30건이 RCV-001~030 으로 박혀 있는 상태에서 첫 자동 부여는 RCV-031 (테스트 검증 완료)

<br><br>

## ✔️ 관련 이슈

- Close #174

<br><br>
