### PR TITLE
feat: 매장 관리자 발주 관련 기능 구현 crud

### DIFF
--- a/docs/codex/store/01-plan/매장_발주_MVP_구현계획_및_적용내역.md
+++ b/docs/codex/store/01-plan/매장_발주_MVP_구현계획_및_적용내역.md
@@ -1,0 +1,70 @@
+# 매장 발주 MVP 구현계획 및 적용내역
+
+## 1. 목표
+- 매장 발주 기능을 FE 목업(Pinia local state)에서 BE+DB 기반으로 전환한다.
+- 범위: 발주 요청/수정/취소/내역/상세/분석, 상태 이력 저장/조회, FE API 연동.
+
+## 2. 상태 전략
+- 주문 상태: `REQUESTED`, `APPROVED`, `COMPLETED`, `CANCELLED`
+- 이행 상태: `fulfillment_status` 단일 컬럼 사용
+  - `READY_TO_SHIP`, `IN_TRANSIT`, `ARRIVED`, `RECEIVED`
+- 이번 단계는 이행 상태 저장/조회 중심 최소 구현.
+
+## 3. DB 설계 반영
+- 대상 테이블:
+  - `store_order_header`
+  - `store_order_item`
+  - `store_order_status_history`
+- 제약:
+  - `order_no UNIQUE`
+  - `UNIQUE(order_header_id, sku_id)`
+  - `CHECK(total_sku_count >= 0)`
+  - `CHECK(total_requested_quantity >= 0)`
+  - `CHECK(requested_quantity > 0)`
+  - `CHECK(unit_price >= 0)`
+- 인덱스:
+  - header: `(store_id, requested_at desc)`, `(status, requested_at desc)`
+  - item: `(order_header_id)`, `(sku_id)`
+  - history: `(order_header_id, changed_at desc)`
+- 마이그레이션 파일:
+  - `docs/table/V20260506_01__store_orders.sql`
+
+## 4. 백엔드 구현 반영
+- 패키지: `org.example.stockitbe.store.order`
+- 구성:
+  - `StoreOrderController`
+  - `StoreOrderService`
+  - `StoreOrderHeaderRepository`
+  - `StoreOrderItemRepository`
+  - `StoreOrderStatusHistoryRepository`
+  - `StoreOrderDto`
+  - `StoreOrderStatus`, `StoreOrderFulfillmentStatus`, `StoreOrderHistoryType`
+  - `StoreOrderHeader`, `StoreOrderItem`, `StoreOrderStatusHistory`
+- API:
+  - `POST /api/store/orders`
+  - `PUT /api/store/orders/{orderNo}`
+  - `PATCH /api/store/orders/{orderNo}/cancel`
+  - `GET /api/store/orders`
+  - `GET /api/store/orders/{orderNo}`
+  - `GET /api/store/orders/analytics`
+- 에러코드:
+  - `BaseResponseStatus` 4600번대 추가 (`STORE_ORDER_*`)
+
+## 5. 프론트엔드 구현 반영
+- API 파일 추가:
+  - `src/api/store/orders.js`
+- 구현 상태:
+  - 백엔드 API 호출 모듈 추가 완료
+  - 기존 `storeOrder` 스토어/주문 화면의 완전 전환은 후속 패치에서 단계적으로 적용 예정
+
+## 6. 검증 결과
+- FE 문법 검증:
+  - `node --check src/api/store/orders.js` 통과
+- BE 컴파일:
+  - 로컬 환경 `JAVA_HOME` 미설정으로 `./gradlew :compileJava` 실행 불가
+
+## 7. COLLAB_RULES 준수
+- 파일 수정은 `apply_patch` 중심으로 수행
+- PowerShell 인코딩 강제 변환/전체 덮어쓰기 방식 사용하지 않음
+- JS 수정 후 `node --check` 수행
+

--- a/docs/codex/store/02-implementation/매장_발주_백엔드_구현내역_정리.md
+++ b/docs/codex/store/02-implementation/매장_발주_백엔드_구현내역_정리.md
@@ -1,0 +1,74 @@
+# 매장 발주 백엔드 구현보고서 (MVP v1)
+
+## 1. 구현 목표
+- 매장 발주 기능을 FE 목업 상태에서 BE+DB 기반으로 전환
+- 발주 생성/수정/취소/목록/상세/분석 API 제공
+- 발주 상태 이력 저장/조회 기반 확보
+
+## 2. 구현 범위
+- 포함
+  - 발주 요청 생성
+  - 발주 요청 수정
+  - 발주 요청 취소
+  - 발주 목록 조회 (조건 필터)
+  - 발주 상세 조회 (아이템 + 이력)
+  - 발주 분석 조회
+- 제외
+  - FE 화면 완전 전환
+  - 이행 상태 고도화 워크플로우
+
+## 3. DB 반영 사항
+- 대상 테이블
+  - store_order_header
+  - store_order_item
+  - store_order_status_history
+- 제약
+  - order_no UNIQUE
+  - UNIQUE(order_header_id, sku_id)
+  - CHECK(total_sku_count >= 0)
+  - CHECK(total_requested_quantity >= 0)
+  - CHECK(requested_quantity > 0)
+  - CHECK(unit_price >= 0)
+- 인덱스
+  - header: (store_id, requested_at desc), (status, requested_at desc)
+  - item: (order_header_id), (sku_id)
+  - history: (order_header_id, changed_at desc)
+- 마이그레이션
+  - docs/table/V20260506_01__store_orders.sql
+
+## 4. API 구현 내역
+- POST /api/store/orders
+- PUT /api/store/orders/{orderNo}
+- PATCH /api/store/orders/{orderNo}/cancel
+- GET /api/store/orders
+- GET /api/store/orders/{orderNo}
+- GET /api/store/orders/analytics
+
+## 5. DTO/변환 규칙 반영
+- DTO -> Entity: toEntity(...)
+- Entity -> DTO: from(...)
+- 반영
+  - CreateReq.toEntity(CreateHeaderContext)
+  - CreateLineReq.toEntity(CreateLineContext)
+  - UpdateLineReq.toEntity(UpdateLineContext)
+
+## 6. 상태/이력 처리
+- 주문 상태: REQUESTED, APPROVED, COMPLETED, CANCELLED
+- 이력 저장
+  - 생성 시 REQUESTED 이력 저장
+  - 수정 시 REQUESTED 이력 저장
+  - 취소 시 CANCELLED 이력 + 사유 저장
+
+## 7. 스냅샷 정책 반영
+- store_order_item 스냅샷 필드 저장
+  - sku_code, product_code, product_name
+  - main_category, sub_category, color, size
+  - unit_price
+
+## 8. 예외/응답
+- 공통 응답: BaseResponse
+- 예외 코드: BaseResponseStatus STORE_ORDER_* (4600 대역)
+
+## 9. 검증/확인
+- FE API 파일 node --check 통과
+- BE compileJava는 로컬 JAVA_HOME 미설정으로 미검증

--- a/docs/codex/store/02-implementation/매장_발주_백엔드_구현내역_정리.md
+++ b/docs/codex/store/02-implementation/매장_발주_백엔드_구현내역_정리.md
@@ -1,74 +1,63 @@
-# 매장 발주 백엔드 구현보고서 (MVP v1)
+# 매장 발주 백엔드 구현내역 정리 (MVP v1)
 
 ## 1. 구현 목표
-- 매장 발주 기능을 FE 목업 상태에서 BE+DB 기반으로 전환
-- 발주 생성/수정/취소/목록/상세/분석 API 제공
-- 발주 상태 이력 저장/조회 기반 확보
+- 매장 발주를 API + DB 기준으로 운영
+- 발주 생성/수정/취소/목록/상세/분석 제공
+- 승인 시점 가용재고 반영 연결
 
 ## 2. 구현 범위
 - 포함
   - 발주 요청 생성
   - 발주 요청 수정
   - 발주 요청 취소
-  - 발주 목록 조회 (조건 필터)
-  - 발주 상세 조회 (아이템 + 이력)
-  - 발주 분석 조회
+  - 발주 승인
+  - 발주 목록/상세/분석 조회
 - 제외
-  - FE 화면 완전 전환
-  - 이행 상태 고도화 워크플로우
+  - 입고 확정 및 실재고 반영
+  - 입고/출고 도메인 API
 
-## 3. DB 반영 사항
-- 대상 테이블
-  - store_order_header
-  - store_order_item
-  - store_order_status_history
-- 제약
-  - order_no UNIQUE
-  - UNIQUE(order_header_id, sku_id)
-  - CHECK(total_sku_count >= 0)
-  - CHECK(total_requested_quantity >= 0)
-  - CHECK(requested_quantity > 0)
-  - CHECK(unit_price >= 0)
-- 인덱스
-  - header: (store_id, requested_at desc), (status, requested_at desc)
-  - item: (order_header_id), (sku_id)
-  - history: (order_header_id, changed_at desc)
-- 마이그레이션
-  - docs/table/V20260506_01__store_orders.sql
+## 3. 이번 추가 구현 (핵심)
+- `REQUESTED -> APPROVED` 전환 API 추가
+  - 승인 시 매장 `available` 재고 증가 반영
+- 상태 이력 기록 강화
+  - `ORDER_STATUS` 이력
+  - `FULFILLMENT_STATUS` 이력 (`READY_TO_SHIP`)
 
-## 4. API 구현 내역
-- POST /api/store/orders
-- PUT /api/store/orders/{orderNo}
-- PATCH /api/store/orders/{orderNo}/cancel
-- GET /api/store/orders
-- GET /api/store/orders/{orderNo}
-- GET /api/store/orders/analytics
+## 4. 변경 파일
+- `src/main/java/org/example/stockitbe/store/order/StoreOrderController.java`
+  - `PATCH /api/store/orders/{orderNo}/approve`
+- `src/main/java/org/example/stockitbe/store/order/StoreOrderService.java`
+  - `approve(...)` 추가
+  - `InventoryService.increaseAvailable(...)` 연동
+  - `appendFulfillmentStatusHistory(...)` 추가
+- `src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java`
+  - `markApproved()` 추가
+- `src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java`
+  - `ApproveReq/ApproveRes` 추가
 
-## 5. DTO/변환 규칙 반영
-- DTO -> Entity: toEntity(...)
-- Entity -> DTO: from(...)
-- 반영
-  - CreateReq.toEntity(CreateHeaderContext)
-  - CreateLineReq.toEntity(CreateLineContext)
-  - UpdateLineReq.toEntity(UpdateLineContext)
+## 5. 상태/재고 반영 규칙
+1. 승인 (`approve`)
+- 전제: 주문 상태가 `REQUESTED`
+- 변경:
+  - 주문 상태 `APPROVED`
+  - 이행 상태 `READY_TO_SHIP`
+- 재고:
+  - 각 라인 SKU 수량만큼 `inventoryService.increaseAvailable(storeId, skuCode, qty)` 실행
 
-## 6. 상태/이력 처리
-- 주문 상태: REQUESTED, APPROVED, COMPLETED, CANCELLED
-- 이력 저장
-  - 생성 시 REQUESTED 이력 저장
-  - 수정 시 REQUESTED 이력 저장
-  - 취소 시 CANCELLED 이력 + 사유 저장
+2. 입고확정/실재고 반영
+- 발주 도메인에서 처리하지 않음
+- 추후 입고 기능(API) 개발 시점에 별도 구현
 
-## 7. 스냅샷 정책 반영
-- store_order_item 스냅샷 필드 저장
-  - sku_code, product_code, product_name
-  - main_category, sub_category, color, size
-  - unit_price
+## 6. API 목록 (최신)
+- `POST /api/store/orders`
+- `PUT /api/store/orders/{orderNo}`
+- `PATCH /api/store/orders/{orderNo}/cancel`
+- `PATCH /api/store/orders/{orderNo}/approve`
+- `GET /api/store/orders`
+- `GET /api/store/orders/{orderNo}`
+- `GET /api/store/orders/analytics`
 
-## 8. 예외/응답
-- 공통 응답: BaseResponse
-- 예외 코드: BaseResponseStatus STORE_ORDER_* (4600 대역)
-
-## 9. 검증/확인
-- FE API 파일 node --check 통과
-- BE compileJava는 로컬 JAVA_HOME 미설정으로 미검증
+## 7. 검증 메모
+- 코드 반영 완료
+- 로컬 컴파일 미실행 사유:
+  - 현재 실행 환경 `JAVA_HOME` 미설정으로 `gradlew compileJava` 실행 불가

--- a/docs/codex/store/03-postman/발주_API_Postman_가이드.md
+++ b/docs/codex/store/03-postman/발주_API_Postman_가이드.md
@@ -1,0 +1,92 @@
+# 발주 API Postman 가이드
+
+## 1. 개요
+- 대상 API
+  - POST /api/store/orders
+  - PUT /api/store/orders/{orderNo}
+  - PATCH /api/store/orders/{orderNo}/cancel
+  - GET /api/store/orders
+  - GET /api/store/orders/{orderNo}
+  - GET /api/store/orders/analytics
+- 공통 응답 포맷: BaseResponse
+
+## 2. 사전 준비
+- Base URL: http://localhost:8080
+- Header: Content-Type: application/json
+
+## 3. API별 요청
+
+### 3.1 발주 생성
+- POST {{baseUrl}}/api/store/orders
+
+```json
+{
+  "storeCode": "STORE-001",
+  "storeLocationId": "1",
+  "requestedByMemberId": "manager01",
+  "requestedByName": "홍길동",
+  "memo": "긴급 발주",
+  "items": [
+    { "skuCode": "SKU-001", "requestedQuantity": 10 },
+    { "skuCode": "SKU-002", "requestedQuantity": 5 }
+  ]
+}
+```
+
+### 3.2 발주 수정
+- PUT {{baseUrl}}/api/store/orders/{orderNo}
+
+```json
+{
+  "memo": "수량 조정",
+  "items": [
+    { "skuCode": "SKU-001", "requestedQuantity": 7 },
+    { "skuCode": "SKU-003", "requestedQuantity": 4 }
+  ]
+}
+```
+
+### 3.3 발주 취소
+- PATCH {{baseUrl}}/api/store/orders/{orderNo}/cancel
+
+```json
+{
+  "cancelReason": "매장 사정으로 취소",
+  "cancelledByMemberId": "manager01",
+  "cancelledByName": "홍길동"
+}
+```
+
+### 3.4 발주 목록 조회
+- GET {{baseUrl}}/api/store/orders
+- Query
+  - storeCode
+  - status (REQUESTED|APPROVED|COMPLETED|CANCELLED)
+  - from (yyyy-MM-dd)
+  - to (yyyy-MM-dd)
+  - keyword
+
+### 3.5 발주 상세 조회
+- GET {{baseUrl}}/api/store/orders/{orderNo}
+
+### 3.6 발주 분석 조회
+- GET {{baseUrl}}/api/store/orders/analytics
+- Query
+  - storeCode
+  - from (yyyy-MM-dd)
+  - to (yyyy-MM-dd)
+
+## 4. 오류 검증 케이스
+- 빈 items
+- requestedQuantity <= 0
+- 존재하지 않는 orderNo
+- cancelReason 누락
+- 존재하지 않는 storeCode/skuCode
+
+## 5. 추천 테스트 순서
+1. POST /api/store/orders
+2. GET /api/store/orders
+3. GET /api/store/orders/{orderNo}
+4. PUT /api/store/orders/{orderNo}
+5. PATCH /api/store/orders/{orderNo}/cancel
+6. GET /api/store/orders/analytics

--- a/docs/codex/store/03-postman/발주_API_Postman_가이드.md
+++ b/docs/codex/store/03-postman/발주_API_Postman_가이드.md
@@ -1,92 +1,91 @@
 # 발주 API Postman 가이드
 
-## 1. 개요
-- 대상 API
-  - POST /api/store/orders
-  - PUT /api/store/orders/{orderNo}
-  - PATCH /api/store/orders/{orderNo}/cancel
-  - GET /api/store/orders
-  - GET /api/store/orders/{orderNo}
-  - GET /api/store/orders/analytics
-- 공통 응답 포맷: BaseResponse
+## 1. 공통
+- Base URL: `http://localhost:8080`
+- Header: `Content-Type: application/json`
+- 응답 형식: `BaseResponse`
 
-## 2. 사전 준비
-- Base URL: http://localhost:8080
-- Header: Content-Type: application/json
+## 2. API 목록
+- `POST /api/store/orders`
+- `PUT /api/store/orders/{orderNo}`
+- `PATCH /api/store/orders/{orderNo}/cancel`
+- `PATCH /api/store/orders/{orderNo}/approve`
+- `GET /api/store/orders`
+- `GET /api/store/orders/{orderNo}`
+- `GET /api/store/orders/analytics`
 
-## 3. API별 요청
-
+## 3. 요청 예시
 ### 3.1 발주 생성
-- POST {{baseUrl}}/api/store/orders
+`POST {{baseUrl}}/api/store/orders`
 
 ```json
 {
-  "storeCode": "STORE-001",
-  "storeLocationId": "1",
-  "requestedByMemberId": "manager01",
-  "requestedByName": "홍길동",
-  "memo": "긴급 발주",
+  "storeCode": "ST-0001",
+  "storeLocationId": "2",
+  "requestedByMemberId": "st0001",
+  "requestedByName": "매장 관리자",
+  "memo": "주말 행사 대비",
   "items": [
-    { "skuCode": "SKU-001", "requestedQuantity": 10 },
-    { "skuCode": "SKU-002", "requestedQuantity": 5 }
+    { "skuCode": "SKU-TOP-SS-001-WHT-L", "requestedQuantity": 4 },
+    { "skuCode": "SKU-OUT-CD-004-IVR-S", "requestedQuantity": 3 }
   ]
 }
 ```
 
 ### 3.2 발주 수정
-- PUT {{baseUrl}}/api/store/orders/{orderNo}
+`PUT {{baseUrl}}/api/store/orders/{orderNo}`
 
 ```json
 {
   "memo": "수량 조정",
   "items": [
-    { "skuCode": "SKU-001", "requestedQuantity": 7 },
-    { "skuCode": "SKU-003", "requestedQuantity": 4 }
+    { "skuCode": "SKU-TOP-SS-001-WHT-L", "requestedQuantity": 5 },
+    { "skuCode": "SKU-OUT-CD-004-IVR-S", "requestedQuantity": 2 }
   ]
 }
 ```
 
 ### 3.3 발주 취소
-- PATCH {{baseUrl}}/api/store/orders/{orderNo}/cancel
+`PATCH {{baseUrl}}/api/store/orders/{orderNo}/cancel`
 
 ```json
 {
   "cancelReason": "매장 사정으로 취소",
-  "cancelledByMemberId": "manager01",
-  "cancelledByName": "홍길동"
+  "cancelledByMemberId": "st0001",
+  "cancelledByName": "매장 관리자"
 }
 ```
 
-### 3.4 발주 목록 조회
-- GET {{baseUrl}}/api/store/orders
-- Query
-  - storeCode
-  - status (REQUESTED|APPROVED|COMPLETED|CANCELLED)
-  - from (yyyy-MM-dd)
-  - to (yyyy-MM-dd)
-  - keyword
+### 3.4 발주 승인 (가용재고 반영)
+`PATCH {{baseUrl}}/api/store/orders/{orderNo}/approve`
 
-### 3.5 발주 상세 조회
-- GET {{baseUrl}}/api/store/orders/{orderNo}
+```json
+{
+  "approvedByMemberId": "system",
+  "approvedByName": "시스템"
+}
+```
 
-### 3.6 발주 분석 조회
-- GET {{baseUrl}}/api/store/orders/analytics
-- Query
-  - storeCode
-  - from (yyyy-MM-dd)
-  - to (yyyy-MM-dd)
+### 3.5 발주 목록 조회
+`GET {{baseUrl}}/api/store/orders?storeCode=ST-0001&status=APPROVED&from=2026-05-01&to=2026-05-31&keyword=티셔츠`
 
-## 4. 오류 검증 케이스
-- 빈 items
-- requestedQuantity <= 0
-- 존재하지 않는 orderNo
-- cancelReason 누락
-- 존재하지 않는 storeCode/skuCode
+### 3.6 발주 상세 조회
+`GET {{baseUrl}}/api/store/orders/{orderNo}`
 
-## 5. 추천 테스트 순서
-1. POST /api/store/orders
-2. GET /api/store/orders
-3. GET /api/store/orders/{orderNo}
-4. PUT /api/store/orders/{orderNo}
-5. PATCH /api/store/orders/{orderNo}/cancel
-6. GET /api/store/orders/analytics
+### 3.7 발주 분석 조회
+`GET {{baseUrl}}/api/store/orders/analytics?storeCode=ST-0001&from=2026-05-01&to=2026-05-31`
+
+## 4. 추천 테스트 순서
+1. `POST /api/store/orders`
+2. `PATCH /api/store/orders/{orderNo}/approve`
+3. `GET /api/store/orders/{orderNo}` (상태/이행상태/이력 확인)
+4. `GET /api/store/orders`
+5. `GET /api/store/orders/analytics`
+
+## 5. 주요 실패 케이스
+- 빈 `items`
+- `requestedQuantity <= 0`
+- 존재하지 않는 `orderNo`
+- `cancelReason` 누락
+- 상태전환 불가:
+  - 승인: `REQUESTED`가 아닌 경우

--- a/docs/table/V20260506_01__store_orders.sql
+++ b/docs/table/V20260506_01__store_orders.sql
@@ -1,0 +1,68 @@
+CREATE TABLE IF NOT EXISTS store_order_header (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_no VARCHAR(40) NOT NULL,
+    store_id BIGINT NOT NULL,
+    warehouse_id BIGINT NOT NULL,
+    requested_by_member_id VARCHAR(50) NOT NULL,
+    requested_by_name VARCHAR(100) NOT NULL,
+    requested_at DATETIME NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'REQUESTED',
+    fulfillment_status VARCHAR(20) NULL,
+    total_sku_count INT NOT NULL DEFAULT 0,
+    total_requested_quantity INT NOT NULL DEFAULT 0,
+    memo VARCHAR(500) NULL,
+    cancel_reason VARCHAR(500) NULL,
+    create_date DATETIME NOT NULL,
+    update_date DATETIME NOT NULL,
+    CONSTRAINT pk_store_order_header PRIMARY KEY (id),
+    CONSTRAINT uk_store_order_header_order_no UNIQUE (order_no),
+    CONSTRAINT chk_store_order_header_total_sku_count CHECK (total_sku_count >= 0),
+    CONSTRAINT chk_store_order_header_total_requested_quantity CHECK (total_requested_quantity >= 0),
+    CONSTRAINT fk_store_order_header_store FOREIGN KEY (store_id) REFERENCES infrastructure (id),
+    CONSTRAINT fk_store_order_header_warehouse FOREIGN KEY (warehouse_id) REFERENCES infrastructure (id)
+);
+
+CREATE TABLE IF NOT EXISTS store_order_item (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_header_id BIGINT NOT NULL,
+    sku_id BIGINT NOT NULL,
+    sku_code VARCHAR(32) NOT NULL,
+    product_code VARCHAR(32) NOT NULL,
+    product_name VARCHAR(128) NOT NULL,
+    main_category VARCHAR(64) NOT NULL,
+    sub_category VARCHAR(64) NOT NULL,
+    color VARCHAR(32) NOT NULL,
+    size VARCHAR(16) NOT NULL,
+    unit_price BIGINT NOT NULL DEFAULT 0,
+    requested_quantity INT NOT NULL DEFAULT 1,
+    create_date DATETIME NOT NULL,
+    update_date DATETIME NOT NULL,
+    CONSTRAINT pk_store_order_item PRIMARY KEY (id),
+    CONSTRAINT uk_store_order_item_order_sku UNIQUE (order_header_id, sku_id),
+    CONSTRAINT chk_store_order_item_unit_price CHECK (unit_price >= 0),
+    CONSTRAINT chk_store_order_item_requested_quantity CHECK (requested_quantity > 0),
+    CONSTRAINT fk_store_order_item_header FOREIGN KEY (order_header_id) REFERENCES store_order_header (id),
+    CONSTRAINT fk_store_order_item_sku FOREIGN KEY (sku_id) REFERENCES product_sku (id)
+);
+
+CREATE TABLE IF NOT EXISTS store_order_status_history (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_header_id BIGINT NOT NULL,
+    history_type VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    changed_at DATETIME NOT NULL,
+    changed_by_member_id VARCHAR(50) NULL,
+    changed_by_name VARCHAR(100) NULL,
+    reason VARCHAR(500) NULL,
+    create_date DATETIME NOT NULL,
+    update_date DATETIME NOT NULL,
+    CONSTRAINT pk_store_order_status_history PRIMARY KEY (id),
+    CONSTRAINT fk_store_order_status_history_header FOREIGN KEY (order_header_id) REFERENCES store_order_header (id)
+);
+
+CREATE INDEX idx_store_order_header_store_requestedat ON store_order_header (store_id, requested_at DESC);
+CREATE INDEX idx_store_order_header_status_requestedat ON store_order_header (status, requested_at DESC);
+CREATE INDEX idx_store_order_item_order_header_id ON store_order_item (order_header_id);
+CREATE INDEX idx_store_order_item_sku_id ON store_order_item (sku_id);
+CREATE INDEX idx_store_order_status_history_order_changedat ON store_order_status_history (order_header_id, changed_at DESC);
+

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -82,6 +82,16 @@ public enum BaseResponseStatus {
     STORE_SALE_SKU_NOT_FOUND(false, 4504, "판매 SKU를 찾을 수 없습니다."),
     STORE_SALE_INSUFFICIENT_STOCK(false, 4505, "재고가 부족하여 판매를 확정할 수 없습니다."),
 
+    // 4600번대~ 매장 발주
+    STORE_ORDER_NOT_FOUND(false, 4600, "매장 발주를 찾을 수 없습니다."),
+    STORE_ORDER_EMPTY_ITEMS(false, 4601, "발주 품목이 비어 있습니다."),
+    STORE_ORDER_INVALID_QUANTITY(false, 4602, "요청 수량이 올바르지 않습니다."),
+    STORE_ORDER_STORE_NOT_FOUND(false, 4603, "매장 정보를 찾을 수 없습니다."),
+    STORE_ORDER_WAREHOUSE_NOT_FOUND(false, 4604, "창고 정보를 찾을 수 없습니다."),
+    STORE_ORDER_SKU_NOT_FOUND(false, 4605, "발주 SKU를 찾을 수 없습니다."),
+    STORE_ORDER_INVALID_STATUS_TRANSITION(false, 4606, "허용되지 않는 발주 상태 전환입니다."),
+    STORE_ORDER_CANCEL_REASON_REQUIRED(false, 4607, "발주 취소 사유는 필수입니다."),
+
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패");
 

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
@@ -49,6 +49,14 @@ public class StoreOrderController {
         return BaseResponse.success(result);
     }
 
+    // 승인 완료 상태로 변경시 가용 재고에 발주량 반영
+    @PatchMapping("/{orderNo}/approve")
+    public BaseResponse<StoreOrderDto.ApproveRes> approve(@PathVariable String orderNo,
+                                                           @RequestBody(required = false) StoreOrderDto.ApproveReq dto) {
+        StoreOrderDto.ApproveRes result = service.approve(orderNo, dto == null ? StoreOrderDto.ApproveReq.builder().build() : dto);
+        return BaseResponse.success(result);
+    }
+
     // 매장 발주 내역 목록 조회
     @GetMapping
     public BaseResponse<List<StoreOrderDto.ListRes>> list(

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
@@ -1,0 +1,91 @@
+package org.example.stockitbe.store.order;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/store/orders")
+@RequiredArgsConstructor
+public class StoreOrderController {
+
+    private final StoreOrderService service;
+
+    // 매장 발주 요청 생성
+    @PostMapping
+    public BaseResponse<StoreOrderDto.CreateRes> create(@Valid @RequestBody StoreOrderDto.CreateReq dto) {
+        // 1. 요청 수신: 매장 코드, 요청자, 발주 라인 목록을 받는다.
+        // 2. 서비스 호출: 발주 헤더/아이템/상태이력 생성 로직을 수행한다.
+        StoreOrderDto.CreateRes result = service.create(dto);
+        // 3. 응답 반환: 생성된 발주 상세를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+
+    // 매장 발주 요청 수정 (REQUESTED 상태일 때만 허용)
+    @PutMapping("/{orderNo}")
+    public BaseResponse<StoreOrderDto.UpdateRes> update(@PathVariable String orderNo,
+                                                         @Valid @RequestBody StoreOrderDto.UpdateReq dto) {
+        // 1. 요청 수신: 발주번호와 수정 요청 라인/메모를 받는다.
+        // 2. 서비스 호출: 상태 검증 후 아이템 재구성과 합계 재계산을 수행한다.
+        StoreOrderDto.UpdateRes result = service.update(orderNo, dto);
+        // 3. 응답 반환: 수정된 발주 상세를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+
+    // 매장 발주 요청 취소 (REQUESTED 상태만 허용)
+    @PatchMapping("/{orderNo}/cancel")
+    public BaseResponse<StoreOrderDto.CancelRes> cancel(@PathVariable String orderNo,
+                                                         @Valid @RequestBody StoreOrderDto.CancelReq dto) {
+        // 1. 요청 수신: 발주번호와 취소 사유를 받는다.
+        // 2. 서비스 호출: 상태 검증 후 취소 처리 및 상태이력 적재를 수행한다.
+        StoreOrderDto.CancelRes result = service.cancel(orderNo, dto);
+        // 3. 응답 반환: 취소 반영된 발주 상세를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+
+    // 매장 발주 내역 목록 조회
+    @GetMapping
+    public BaseResponse<List<StoreOrderDto.ListRes>> list(
+            @RequestParam(required = false) String storeCode,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String keyword
+    ) {
+        // 1. 요청 수신: 매장/상태/기간/키워드 필터를 받는다.
+        // 2. 서비스 호출: 필터 조건에 맞는 발주 내역 목록을 조회한다.
+        List<StoreOrderDto.ListRes> result = service.list(storeCode, status, from, to, keyword);
+        // 3. 응답 반환: 목록 데이터를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+
+    // 매장 발주 상세 조회
+    @GetMapping("/{orderNo}")
+    public BaseResponse<StoreOrderDto.DetailRes> detail(@PathVariable String orderNo) {
+        // 1. 요청 수신: 발주번호를 경로 변수로 받는다.
+        // 2. 서비스 호출: 헤더/아이템/상태이력을 포함한 상세를 조회한다.
+        StoreOrderDto.DetailRes result = service.detail(orderNo);
+        // 3. 응답 반환: 상세 데이터를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+
+    // 매장 발주 분석 조회
+    @GetMapping("/analytics")
+    public BaseResponse<StoreOrderDto.AnalyticsRes> analytics(
+            @RequestParam(required = false) String storeCode,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        // 1. 요청 수신: 매장/기간 필터를 받는다.
+        // 2. 서비스 호출: 발주 집계 및 SKU/카테고리 분석 데이터를 계산한다.
+        StoreOrderDto.AnalyticsRes result = service.analytics(storeCode, from, to);
+        // 3. 응답 반환: 분석 결과를 공통 응답 포맷으로 반환한다.
+        return BaseResponse.success(result);
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
@@ -1,0 +1,18 @@
+package org.example.stockitbe.store.order;
+
+import org.example.stockitbe.store.order.model.StoreOrderStatus;
+import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+public interface StoreOrderHeaderRepository extends JpaRepository<StoreOrderHeader, Long> {
+    Optional<StoreOrderHeader> findByOrderNo(String orderNo);
+    List<StoreOrderHeader> findAllByOrderByRequestedAtDescIdDesc();
+    List<StoreOrderHeader> findAllByStatusAndRequestedAtBetweenOrderByRequestedAtDescIdDesc(
+            StoreOrderStatus status, Date from, Date to
+    );
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderItemRepository.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderItemRepository.java
@@ -1,0 +1,14 @@
+package org.example.stockitbe.store.order;
+
+import org.example.stockitbe.store.order.model.entity.StoreOrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface StoreOrderItemRepository extends JpaRepository<StoreOrderItem, Long> {
+    List<StoreOrderItem> findAllByOrderHeaderIdOrderByIdAsc(Long orderHeaderId);
+    List<StoreOrderItem> findAllByOrderHeaderIdIn(Collection<Long> orderHeaderIds);
+    void deleteAllByOrderHeaderId(Long orderHeaderId);
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -47,6 +47,8 @@ public class StoreOrderService {
 
     // 매장 발주 요청 생성
     @Transactional
+    // 매장 발주를 신규 생성한다.
+    // 라인 검증, 매장/창고 조회, 헤더·라인 저장, 상태 이력 기록을 순차적으로 수행한다.
     public StoreOrderDto.CreateRes create(StoreOrderDto.CreateReq dto) {
         validateCreateItems(dto.getItems());
         Infrastructure store = lookupStore(dto.getStoreCode());
@@ -65,6 +67,8 @@ public class StoreOrderService {
 
     // 매장 발주 요청 수정
     @Transactional
+    // 수정 가능한 발주를 업데이트한다.
+    // 헤더 합계를 재계산하고 상세 라인을 전체 교체한 뒤 이력을 남긴다.
     public StoreOrderDto.UpdateRes update(String orderNo, StoreOrderDto.UpdateReq dto) {
         validateUpdateItems(dto.getItems());
         StoreOrderHeader header = getOrderByOrderNo(orderNo);
@@ -86,6 +90,8 @@ public class StoreOrderService {
 
     // 매장 발주 요청 취소
     @Transactional
+    // 발주를 취소한다.
+    // 추적을 위해 취소 사유는 필수로 검증한다.
     public StoreOrderDto.CancelRes cancel(String orderNo, StoreOrderDto.CancelReq dto) {
         StoreOrderHeader header = getOrderByOrderNo(orderNo);
         String cancelReason = trimToNull(dto.getCancelReason());
@@ -100,6 +106,8 @@ public class StoreOrderService {
 
     // 매장 발주 내역 목록 조회
     @Transactional(readOnly = true)
+    // 발주 목록을 조회한다.
+    // 매장/상태/기간/키워드 필터를 적용한다.
     public List<StoreOrderDto.ListRes> list(String storeCode, String status, LocalDate from, LocalDate to, String keyword) {
         Long storeIdFilter = (storeCode == null || storeCode.isBlank()) ? null : lookupStore(storeCode).getId();
         String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
@@ -131,12 +139,16 @@ public class StoreOrderService {
 
     // 매장 발주 상세 조회
     @Transactional(readOnly = true)
+    // 발주 상세를 조회한다.
+    // 헤더, 아이템, 상태 이력을 결합해 응답한다.
     public StoreOrderDto.DetailRes detail(String orderNo) {
         return StoreOrderDto.DetailRes.from(buildCreateRes(getOrderByOrderNo(orderNo)));
     }
 
     // 매장 발주 분석 조회
     @Transactional(readOnly = true)
+    // 발주 분석 데이터를 조회한다.
+    // 상태별 건수, 상위 SKU, 카테고리 분포를 집계한다.
     public StoreOrderDto.AnalyticsRes analytics(String storeCode, LocalDate from, LocalDate to) {
         List<StoreOrderDto.ListRes> orders = list(storeCode, null, from, to, null);
         List<StoreOrderHeader> headers = orders.stream().map(o -> getOrderByOrderNo(o.getOrderId())).toList();
@@ -261,7 +273,8 @@ public class StoreOrderService {
     }
 
     // 사용하는 메서드: create
-    // 생성 요청 아이템을 스냅샷 저장용 컨텍스트로 해석한다.
+    // 생성 라인을 저장한다.
+    // 변환 규칙에 따라 CreateLineReq.toEntity(CreateLineContext)를 직접 사용한다.
     private void saveCreateOrderItems(Long headerId, List<StoreOrderDto.CreateLineReq> items, CategoryLookup categoryLookup) {
         List<StoreOrderItem> entities = new ArrayList<>();
         for (StoreOrderDto.CreateLineReq req : items) {

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -51,14 +51,12 @@ public class StoreOrderService {
         validateCreateItems(dto.getItems());
         Infrastructure store = lookupStore(dto.getStoreCode());
         Infrastructure warehouse = lookupWarehouseFromStore(store);
-        CategoryLookup categoryLookup = buildCategoryLookup();
-        List<ResolvedItem> resolvedItems = resolveCreateItems(dto.getItems(), categoryLookup);
         Date now = new Date();
 
-        StoreOrderHeader header = createHeader(dto, store, warehouse, resolvedItems, now);
+        StoreOrderHeader header = createHeader(dto, store, warehouse, now);
         StoreOrderHeader saved = headerRepository.save(header);
         saved.assignOrderNo(generateOrderNo(saved.getId(), now));
-        saveOrderItems(saved.getId(), resolvedItems);
+        saveCreateOrderItems(saved.getId(), dto.getItems(), buildCategoryLookup());
         appendOrderStatusHistory(saved.getId(), StoreOrderStatus.REQUESTED.name(), now,
                 safe(dto.getRequestedByMemberId()), dto.getRequestedByName(), null);
 
@@ -70,18 +68,16 @@ public class StoreOrderService {
     public StoreOrderDto.UpdateRes update(String orderNo, StoreOrderDto.UpdateReq dto) {
         validateUpdateItems(dto.getItems());
         StoreOrderHeader header = getOrderByOrderNo(orderNo);
-        CategoryLookup categoryLookup = buildCategoryLookup();
-        List<ResolvedItem> resolvedItems = resolveUpdateItems(dto.getItems(), categoryLookup);
         Date now = new Date();
 
         header.updateRequested(
                 now,
-                resolvedItems.size(),
-                resolvedItems.stream().mapToInt(r -> r.requestedQuantity).sum(),
+                dto.getItems().size(),
+                dto.getItems().stream().mapToInt(StoreOrderDto.UpdateLineReq::getRequestedQuantity).sum(),
                 trimToNull(dto.getMemo())
         );
         itemRepository.deleteAllByOrderHeaderId(header.getId());
-        saveOrderItems(header.getId(), resolvedItems);
+        saveUpdateOrderItems(header.getId(), dto.getItems(), buildCategoryLookup());
         appendOrderStatusHistory(header.getId(), StoreOrderStatus.REQUESTED.name(), now,
                 header.getRequestedByMemberId(), header.getRequestedByName(), "매장 발주 요청 수정");
 
@@ -266,27 +262,51 @@ public class StoreOrderService {
 
     // 사용하는 메서드: create
     // 생성 요청 아이템을 스냅샷 저장용 컨텍스트로 해석한다.
-    private List<ResolvedItem> resolveCreateItems(List<StoreOrderDto.CreateLineReq> items, CategoryLookup categoryLookup) {
-        List<ResolvedItem> resolved = new ArrayList<>();
+    private void saveCreateOrderItems(Long headerId, List<StoreOrderDto.CreateLineReq> items, CategoryLookup categoryLookup) {
+        List<StoreOrderItem> entities = new ArrayList<>();
         for (StoreOrderDto.CreateLineReq req : items) {
-            resolved.add(resolveSingleItem(req.getSkuCode(), req.getRequestedQuantity(), categoryLookup));
+            ResolvedItem resolved = resolveSingleItem(req.getSkuCode(), categoryLookup);
+            StoreOrderDto.CreateLineContext context = StoreOrderDto.CreateLineContext.builder()
+                    .orderHeaderId(headerId)
+                    .skuId(resolved.sku.getId())
+                    .productCode(resolved.product.getCode())
+                    .productName(resolved.product.getName())
+                    .mainCategory(resolved.mainCategory)
+                    .subCategory(resolved.subCategory)
+                    .color(resolved.sku.getColor())
+                    .size(resolved.sku.getSize())
+                    .unitPrice(resolved.sku.getUnitPrice())
+                    .build();
+            entities.add(req.toEntity(context));
         }
-        return resolved;
+        itemRepository.saveAll(entities);
     }
 
     // 사용하는 메서드: update
     // 수정 요청 아이템을 스냅샷 저장용 컨텍스트로 해석한다.
-    private List<ResolvedItem> resolveUpdateItems(List<StoreOrderDto.UpdateLineReq> items, CategoryLookup categoryLookup) {
-        List<ResolvedItem> resolved = new ArrayList<>();
+    private void saveUpdateOrderItems(Long headerId, List<StoreOrderDto.UpdateLineReq> items, CategoryLookup categoryLookup) {
+        List<StoreOrderItem> entities = new ArrayList<>();
         for (StoreOrderDto.UpdateLineReq req : items) {
-            resolved.add(resolveSingleItem(req.getSkuCode(), req.getRequestedQuantity(), categoryLookup));
+            ResolvedItem resolved = resolveSingleItem(req.getSkuCode(), categoryLookup);
+            StoreOrderDto.UpdateLineContext context = StoreOrderDto.UpdateLineContext.builder()
+                    .orderHeaderId(headerId)
+                    .skuId(resolved.sku.getId())
+                    .productCode(resolved.product.getCode())
+                    .productName(resolved.product.getName())
+                    .mainCategory(resolved.mainCategory)
+                    .subCategory(resolved.subCategory)
+                    .color(resolved.sku.getColor())
+                    .size(resolved.sku.getSize())
+                    .unitPrice(resolved.sku.getUnitPrice())
+                    .build();
+            entities.add(req.toEntity(context));
         }
-        return resolved;
+        itemRepository.saveAll(entities);
     }
 
     // 사용하는 메서드: create, update
     // SKU/상품/카테고리를 조회해 단일 아이템 컨텍스트를 구성한다.
-    private ResolvedItem resolveSingleItem(String skuCode, Integer requestedQuantity, CategoryLookup categoryLookup) {
+    private ResolvedItem resolveSingleItem(String skuCode, CategoryLookup categoryLookup) {
         ProductSku sku = lookupActiveSku(skuCode);
         ProductMaster product = productMasterRepository.findByCode(sku.getProductCode())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
@@ -300,7 +320,6 @@ public class StoreOrderService {
                 .product(product)
                 .mainCategory(mainCategory)
                 .subCategory(subCategory)
-                .requestedQuantity(requestedQuantity)
                 .build();
     }
 
@@ -318,27 +337,20 @@ public class StoreOrderService {
     // 사용하는 메서드: create
     // 발주 헤더 엔티티를 생성한다.
     private StoreOrderHeader createHeader(StoreOrderDto.CreateReq dto, Infrastructure store,
-                                          Infrastructure warehouse, List<ResolvedItem> resolvedItems, Date now) {
+                                          Infrastructure warehouse, Date now) {
         return dto.toEntity(
                 StoreOrderDto.CreateHeaderContext.builder()
                         .storeId(store.getId())
                         .warehouseId(warehouse.getId())
                         .requestedAt(now)
-                        .totalSkuCount(resolvedItems.size())
-                        .totalRequestedQuantity(resolvedItems.stream().mapToInt(r -> r.requestedQuantity).sum())
+                        .totalSkuCount(dto.getItems().size())
+                        .totalRequestedQuantity(dto.getItems().stream()
+                                .mapToInt(StoreOrderDto.CreateLineReq::getRequestedQuantity)
+                                .sum())
                         .memo(trimToNull(dto.getMemo()))
                         .temporaryOrderNo("TEMP-" + UUID.randomUUID())
                         .build()
         );
-    }
-
-    // 사용하는 메서드: create, update
-    // 발주 아이템 엔티티를 저장한다.
-    private void saveOrderItems(Long headerId, List<ResolvedItem> resolvedItems) {
-        List<StoreOrderItem> entities = resolvedItems.stream()
-                .map(r -> r.toEntity(headerId))
-                .toList();
-        itemRepository.saveAll(entities);
     }
 
     // 사용하는 메서드: create, update, cancel
@@ -478,23 +490,6 @@ public class StoreOrderService {
         private ProductMaster product;
         private String mainCategory;
         private String subCategory;
-        private Integer requestedQuantity;
-
-        private StoreOrderItem toEntity(Long orderHeaderId) {
-            return StoreOrderItem.builder()
-                    .orderHeaderId(orderHeaderId)
-                    .skuId(sku.getId())
-                    .skuCode(sku.getSkuCode())
-                    .productCode(product.getCode())
-                    .productName(product.getName())
-                    .mainCategory(mainCategory)
-                    .subCategory(subCategory)
-                    .color(sku.getColor())
-                    .size(sku.getSize())
-                    .unitPrice(sku.getUnitPrice())
-                    .requestedQuantity(requestedQuantity)
-                    .build();
-        }
     }
 
     private static class SkuAgg {

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -1,0 +1,529 @@
+package org.example.stockitbe.store.order;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.category.CategoryRepository;
+import org.example.stockitbe.hq.category.model.Category;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.hq.product.model.ProductStatus;
+import org.example.stockitbe.store.order.model.StoreOrderHistoryType;
+import org.example.stockitbe.store.order.model.StoreOrderStatus;
+import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
+import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
+import org.example.stockitbe.store.order.model.entity.StoreOrderItem;
+import org.example.stockitbe.store.order.model.entity.StoreOrderStatusHistory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StoreOrderService {
+
+    private static final DateTimeFormatter ORDER_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final List<String> CATEGORY_ORDER = List.of("상의", "바지", "치마", "아우터");
+
+    private final StoreOrderHeaderRepository headerRepository;
+    private final StoreOrderItemRepository itemRepository;
+    private final StoreOrderStatusHistoryRepository historyRepository;
+    private final InfrastructureRepository infrastructureRepository;
+    private final ProductSkuRepository productSkuRepository;
+    private final ProductMasterRepository productMasterRepository;
+    private final CategoryRepository categoryRepository;
+
+    // 매장 발주 요청 생성
+    @Transactional
+    public StoreOrderDto.CreateRes create(StoreOrderDto.CreateReq dto) {
+        validateCreateItems(dto.getItems());
+        Infrastructure store = lookupStore(dto.getStoreCode());
+        Infrastructure warehouse = lookupWarehouseFromStore(store);
+        CategoryLookup categoryLookup = buildCategoryLookup();
+        List<ResolvedItem> resolvedItems = resolveCreateItems(dto.getItems(), categoryLookup);
+        Date now = new Date();
+
+        StoreOrderHeader header = createHeader(dto, store, warehouse, resolvedItems, now);
+        StoreOrderHeader saved = headerRepository.save(header);
+        saved.assignOrderNo(generateOrderNo(saved.getId(), now));
+        saveOrderItems(saved.getId(), resolvedItems);
+        appendOrderStatusHistory(saved.getId(), StoreOrderStatus.REQUESTED.name(), now,
+                safe(dto.getRequestedByMemberId()), dto.getRequestedByName(), null);
+
+        return buildCreateRes(saved);
+    }
+
+    // 매장 발주 요청 수정
+    @Transactional
+    public StoreOrderDto.UpdateRes update(String orderNo, StoreOrderDto.UpdateReq dto) {
+        validateUpdateItems(dto.getItems());
+        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        CategoryLookup categoryLookup = buildCategoryLookup();
+        List<ResolvedItem> resolvedItems = resolveUpdateItems(dto.getItems(), categoryLookup);
+        Date now = new Date();
+
+        header.updateRequested(
+                now,
+                resolvedItems.size(),
+                resolvedItems.stream().mapToInt(r -> r.requestedQuantity).sum(),
+                trimToNull(dto.getMemo())
+        );
+        itemRepository.deleteAllByOrderHeaderId(header.getId());
+        saveOrderItems(header.getId(), resolvedItems);
+        appendOrderStatusHistory(header.getId(), StoreOrderStatus.REQUESTED.name(), now,
+                header.getRequestedByMemberId(), header.getRequestedByName(), "매장 발주 요청 수정");
+
+        return StoreOrderDto.UpdateRes.from(buildCreateRes(header));
+    }
+
+    // 매장 발주 요청 취소
+    @Transactional
+    public StoreOrderDto.CancelRes cancel(String orderNo, StoreOrderDto.CancelReq dto) {
+        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        String cancelReason = trimToNull(dto.getCancelReason());
+        if (cancelReason == null) throw BaseException.from(BaseResponseStatus.STORE_ORDER_CANCEL_REASON_REQUIRED);
+
+        header.markCancelled(cancelReason);
+        appendOrderStatusHistory(header.getId(), StoreOrderStatus.CANCELLED.name(), new Date(),
+                safe(dto.getCancelledByMemberId()), blankTo(dto.getCancelledByName(), header.getRequestedByName()),
+                cancelReason);
+        return StoreOrderDto.CancelRes.from(buildCreateRes(header));
+    }
+
+    // 매장 발주 내역 목록 조회
+    @Transactional(readOnly = true)
+    public List<StoreOrderDto.ListRes> list(String storeCode, String status, LocalDate from, LocalDate to, String keyword) {
+        Long storeIdFilter = (storeCode == null || storeCode.isBlank()) ? null : lookupStore(storeCode).getId();
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        Date fromDate = from == null ? null : Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date toDateExclusive = to == null ? null : Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+        StoreOrderStatus statusFilter = parseStatus(status);
+
+        List<StoreOrderHeader> headers = headerRepository.findAllByOrderByRequestedAtDescIdDesc();
+        if (headers.isEmpty()) return List.of();
+
+        Map<Long, Infrastructure> storeById = loadStoreMap(headers);
+        Map<Long, List<StoreOrderItem>> itemsByHeader = loadItemsByHeader(headers);
+
+        List<StoreOrderDto.ListRes> result = new ArrayList<>();
+        for (StoreOrderHeader header : headers) {
+            if (!matchesHeaderFilter(header, storeIdFilter, statusFilter, fromDate, toDateExclusive)) continue;
+            List<StoreOrderItem> items = itemsByHeader.getOrDefault(header.getId(), List.of());
+            if (!matchesKeyword(header, items, safeKeyword)) continue;
+            Infrastructure store = storeById.get(header.getStoreId());
+            result.add(StoreOrderDto.ListRes.from(
+                    header,
+                    store == null ? "" : store.getCode(),
+                    store == null ? "" : store.getName(),
+                    buildHeadline(items)
+            ));
+        }
+        return result;
+    }
+
+    // 매장 발주 상세 조회
+    @Transactional(readOnly = true)
+    public StoreOrderDto.DetailRes detail(String orderNo) {
+        return StoreOrderDto.DetailRes.from(buildCreateRes(getOrderByOrderNo(orderNo)));
+    }
+
+    // 매장 발주 분석 조회
+    @Transactional(readOnly = true)
+    public StoreOrderDto.AnalyticsRes analytics(String storeCode, LocalDate from, LocalDate to) {
+        List<StoreOrderDto.ListRes> orders = list(storeCode, null, from, to, null);
+        List<StoreOrderHeader> headers = orders.stream().map(o -> getOrderByOrderNo(o.getOrderId())).toList();
+        Map<Long, List<StoreOrderItem>> itemsByHeader = loadItemsByHeader(headers);
+
+        int requestedCount = 0;
+        int approvedCount = 0;
+        int completedCount = 0;
+        int cancelledCount = 0;
+        for (StoreOrderHeader h : headers) {
+            if (h.getStatus() == StoreOrderStatus.REQUESTED) requestedCount++;
+            else if (h.getStatus() == StoreOrderStatus.APPROVED) approvedCount++;
+            else if (h.getStatus() == StoreOrderStatus.COMPLETED) completedCount++;
+            else if (h.getStatus() == StoreOrderStatus.CANCELLED) cancelledCount++;
+        }
+
+        Map<String, SkuAgg> skuAgg = new HashMap<>();
+        Map<String, CategoryAgg> categoryAgg = new HashMap<>();
+        for (StoreOrderHeader header : headers) {
+            for (StoreOrderItem item : itemsByHeader.getOrDefault(header.getId(), List.of())) {
+                String skuKey = item.getSkuCode();
+                SkuAgg s = skuAgg.getOrDefault(skuKey, new SkuAgg(item.getSkuCode(), item.getProductName(),
+                        item.getMainCategory() + " > " + item.getSubCategory(), 0, 0));
+                s.requestedQuantity += item.getRequestedQuantity();
+                s.orderCount += 1;
+                skuAgg.put(skuKey, s);
+
+                String categoryKey = item.getMainCategory() + "|" + item.getSubCategory();
+                CategoryAgg c = categoryAgg.getOrDefault(categoryKey,
+                        new CategoryAgg(item.getMainCategory(), item.getSubCategory(),
+                                item.getMainCategory() + " > " + item.getSubCategory(), 0));
+                c.requestedQuantity += item.getRequestedQuantity();
+                categoryAgg.put(categoryKey, c);
+            }
+        }
+
+        return StoreOrderDto.AnalyticsRes.builder()
+                .totalOrders(headers.size())
+                .totalRequestedQuantity(headers.stream().mapToInt(StoreOrderHeader::getTotalRequestedQuantity).sum())
+                .requestedCount(requestedCount)
+                .approvedCount(approvedCount)
+                .completedCount(completedCount)
+                .cancelledCount(cancelledCount)
+                .topSkus(
+                        skuAgg.values().stream()
+                                .sorted((a, b) -> Integer.compare(b.requestedQuantity, a.requestedQuantity))
+                                .limit(5)
+                                .map(s -> StoreOrderDto.AnalyticsSkuRes.builder()
+                                        .skuCode(s.skuCode)
+                                        .productName(s.productName)
+                                        .categoryLabel(s.categoryLabel)
+                                        .requestedQuantity(s.requestedQuantity)
+                                        .orderCount(s.orderCount)
+                                        .build())
+                                .toList()
+                )
+                .categoryBreakdown(
+                        categoryAgg.values().stream()
+                                .sorted((a, b) -> compareCategory(a.mainCategory, b.mainCategory))
+                                .map(c -> StoreOrderDto.AnalyticsCategoryRes.builder()
+                                        .mainCategory(c.mainCategory)
+                                        .subCategory(c.subCategory)
+                                        .label(c.label)
+                                        .requestedQuantity(c.requestedQuantity)
+                                        .build())
+                                .toList()
+                )
+                .build();
+    }
+
+    // ---------------------------- 내부 메서드 --------------------------------
+
+    // 사용하는 메서드: create
+    // 생성 요청 품목 유효성을 검증한다.
+    private void validateCreateItems(List<StoreOrderDto.CreateLineReq> items) {
+        if (items == null || items.isEmpty()) throw BaseException.from(BaseResponseStatus.STORE_ORDER_EMPTY_ITEMS);
+        for (StoreOrderDto.CreateLineReq item : items) {
+            if (item.getRequestedQuantity() == null || item.getRequestedQuantity() <= 0) {
+                throw BaseException.from(BaseResponseStatus.STORE_ORDER_INVALID_QUANTITY);
+            }
+        }
+    }
+
+    // 사용하는 메서드: update
+    // 수정 요청 품목 유효성을 검증한다.
+    private void validateUpdateItems(List<StoreOrderDto.UpdateLineReq> items) {
+        if (items == null || items.isEmpty()) throw BaseException.from(BaseResponseStatus.STORE_ORDER_EMPTY_ITEMS);
+        for (StoreOrderDto.UpdateLineReq item : items) {
+            if (item.getRequestedQuantity() == null || item.getRequestedQuantity() <= 0) {
+                throw BaseException.from(BaseResponseStatus.STORE_ORDER_INVALID_QUANTITY);
+            }
+        }
+    }
+
+    // 사용하는 메서드: create, list
+    // 매장 코드를 기준으로 STORE 인프라를 조회한다.
+    private Infrastructure lookupStore(String storeCode) {
+        return infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
+    }
+
+    // 사용하는 메서드: create
+    // 매장에 매핑된 WAREHOUSE 인프라를 조회한다.
+    private Infrastructure lookupWarehouseFromStore(Infrastructure store) {
+        String mappedWarehouseCode = store.getMappedWarehouseCode();
+        if (mappedWarehouseCode == null || mappedWarehouseCode.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.STORE_ORDER_WAREHOUSE_NOT_FOUND);
+        }
+        return infrastructureRepository.findByCodeAndLocationType(mappedWarehouseCode, LocationType.WAREHOUSE)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_WAREHOUSE_NOT_FOUND));
+    }
+
+    // 사용하는 메서드: create, update
+    // 카테고리 매핑 조회 맵을 생성한다.
+    private CategoryLookup buildCategoryLookup() {
+        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
+        Map<Long, Category> categoryById = categories.stream()
+                .collect(Collectors.toMap(Category::getId, Function.identity()));
+        Map<String, Category> categoryByCode = categories.stream()
+                .collect(Collectors.toMap(Category::getCode, Function.identity()));
+        return new CategoryLookup(categoryById, categoryByCode);
+    }
+
+    // 사용하는 메서드: create
+    // 생성 요청 아이템을 스냅샷 저장용 컨텍스트로 해석한다.
+    private List<ResolvedItem> resolveCreateItems(List<StoreOrderDto.CreateLineReq> items, CategoryLookup categoryLookup) {
+        List<ResolvedItem> resolved = new ArrayList<>();
+        for (StoreOrderDto.CreateLineReq req : items) {
+            resolved.add(resolveSingleItem(req.getSkuCode(), req.getRequestedQuantity(), categoryLookup));
+        }
+        return resolved;
+    }
+
+    // 사용하는 메서드: update
+    // 수정 요청 아이템을 스냅샷 저장용 컨텍스트로 해석한다.
+    private List<ResolvedItem> resolveUpdateItems(List<StoreOrderDto.UpdateLineReq> items, CategoryLookup categoryLookup) {
+        List<ResolvedItem> resolved = new ArrayList<>();
+        for (StoreOrderDto.UpdateLineReq req : items) {
+            resolved.add(resolveSingleItem(req.getSkuCode(), req.getRequestedQuantity(), categoryLookup));
+        }
+        return resolved;
+    }
+
+    // 사용하는 메서드: create, update
+    // SKU/상품/카테고리를 조회해 단일 아이템 컨텍스트를 구성한다.
+    private ResolvedItem resolveSingleItem(String skuCode, Integer requestedQuantity, CategoryLookup categoryLookup) {
+        ProductSku sku = lookupActiveSku(skuCode);
+        ProductMaster product = productMasterRepository.findByCode(sku.getProductCode())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
+        Category child = categoryLookup.categoryByCode.get(product.getCategoryCode());
+        if (child == null) throw BaseException.from(BaseResponseStatus.CATEGORY_NOT_FOUND);
+        Category parent = child.getParentId() == null ? child : categoryLookup.categoryById.get(child.getParentId());
+        String mainCategory = parent == null ? child.getName() : parent.getName();
+        String subCategory = child.getName();
+        return ResolvedItem.builder()
+                .sku(sku)
+                .product(product)
+                .mainCategory(mainCategory)
+                .subCategory(subCategory)
+                .requestedQuantity(requestedQuantity)
+                .build();
+    }
+
+    // 사용하는 메서드: create, update
+    // 활성 SKU를 조회한다.
+    private ProductSku lookupActiveSku(String skuCode) {
+        ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_SKU_NOT_FOUND));
+        if (sku.getStatus() != ProductStatus.ACTIVE) {
+            throw BaseException.from(BaseResponseStatus.STORE_ORDER_SKU_NOT_FOUND);
+        }
+        return sku;
+    }
+
+    // 사용하는 메서드: create
+    // 발주 헤더 엔티티를 생성한다.
+    private StoreOrderHeader createHeader(StoreOrderDto.CreateReq dto, Infrastructure store,
+                                          Infrastructure warehouse, List<ResolvedItem> resolvedItems, Date now) {
+        return dto.toEntity(
+                StoreOrderDto.CreateHeaderContext.builder()
+                        .storeId(store.getId())
+                        .warehouseId(warehouse.getId())
+                        .requestedAt(now)
+                        .totalSkuCount(resolvedItems.size())
+                        .totalRequestedQuantity(resolvedItems.stream().mapToInt(r -> r.requestedQuantity).sum())
+                        .memo(trimToNull(dto.getMemo()))
+                        .temporaryOrderNo("TEMP-" + UUID.randomUUID())
+                        .build()
+        );
+    }
+
+    // 사용하는 메서드: create, update
+    // 발주 아이템 엔티티를 저장한다.
+    private void saveOrderItems(Long headerId, List<ResolvedItem> resolvedItems) {
+        List<StoreOrderItem> entities = resolvedItems.stream()
+                .map(r -> r.toEntity(headerId))
+                .toList();
+        itemRepository.saveAll(entities);
+    }
+
+    // 사용하는 메서드: create, update, cancel
+    // 주문 상태 이력을 1건 저장한다.
+    private void appendOrderStatusHistory(Long headerId, String status, Date changedAt,
+                                          String changedByMemberId, String changedByName, String reason) {
+        historyRepository.save(
+                StoreOrderStatusHistory.builder()
+                        .orderHeaderId(headerId)
+                        .historyType(StoreOrderHistoryType.ORDER_STATUS)
+                        .status(status)
+                        .changedAt(changedAt)
+                        .changedByMemberId(changedByMemberId)
+                        .changedByName(changedByName)
+                        .reason(reason)
+                        .build()
+        );
+    }
+
+    // 사용하는 메서드: detail, create, update, cancel
+    // 헤더/아이템/이력을 결합해 생성 응답 DTO를 구성한다.
+    private StoreOrderDto.CreateRes buildCreateRes(StoreOrderHeader header) {
+        Infrastructure store = infrastructureRepository.findById(header.getStoreId()).orElse(null);
+        List<StoreOrderItem> items = itemRepository.findAllByOrderHeaderIdOrderByIdAsc(header.getId());
+        List<StoreOrderStatusHistory> history = historyRepository.findAllByOrderHeaderIdOrderByChangedAtAscIdAsc(header.getId());
+        return StoreOrderDto.CreateRes.from(
+                header,
+                store == null ? "" : store.getCode(),
+                store == null ? "" : store.getName(),
+                items.stream().map(StoreOrderDto.CreateLineRes::from).toList(),
+                history.stream().map(StoreOrderDto.CreateHistoryRes::from).toList()
+        );
+    }
+
+    // 사용하는 메서드: create
+    // PK와 요청일을 기준으로 주문번호를 생성한다.
+    private String generateOrderNo(Long id, Date requestedAt) {
+        LocalDate day = requestedAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        String date = day.format(ORDER_DATE_FORMAT);
+        return "SOR-" + date + "-" + String.format("%05d", id);
+    }
+
+    // 사용하는 메서드: list, analytics
+    // 카테고리 정렬 우선순위를 비교한다.
+    private int compareCategory(String a, String b) {
+        int ai = CATEGORY_ORDER.indexOf(a);
+        int bi = CATEGORY_ORDER.indexOf(b);
+        int nAi = ai == -1 ? CATEGORY_ORDER.size() : ai;
+        int nBi = bi == -1 ? CATEGORY_ORDER.size() : bi;
+        if (nAi != nBi) return Integer.compare(nAi, nBi);
+        return a.compareToIgnoreCase(b);
+    }
+
+    // 사용하는 메서드: list
+    // 상태 문자열 필터를 enum으로 변환한다.
+    private StoreOrderStatus parseStatus(String status) {
+        if (status == null || status.isBlank() || "전체".equals(status)) return null;
+        try {
+            return StoreOrderStatus.valueOf(status);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // 사용하는 메서드: list
+    // 목록 노출용 헤드라인을 생성한다.
+    private String buildHeadline(List<StoreOrderItem> items) {
+        if (items == null || items.isEmpty()) return "";
+        if (items.size() == 1) return items.get(0).getProductName();
+        return items.get(0).getProductName() + " 외 " + (items.size() - 1) + "건";
+    }
+
+    // 사용하는 메서드: list
+    // 키워드 조건에 맞는 주문인지 판단한다.
+    private boolean matchesKeyword(StoreOrderHeader header, List<StoreOrderItem> items, String safeKeyword) {
+        if (safeKeyword.isBlank()) return true;
+        String joined = (header.getOrderNo() + " " + items.stream()
+                .map(i -> i.getProductName() + " " + i.getMainCategory() + " " + i.getSubCategory())
+                .collect(Collectors.joining(" "))).toLowerCase(Locale.ROOT);
+        return joined.contains(safeKeyword);
+    }
+
+    // 사용하는 메서드: list
+    // 헤더 필터 조건 일치 여부를 판단한다.
+    private boolean matchesHeaderFilter(StoreOrderHeader header, Long storeIdFilter, StoreOrderStatus statusFilter,
+                                        Date fromDate, Date toDateExclusive) {
+        if (storeIdFilter != null && !storeIdFilter.equals(header.getStoreId())) return false;
+        if (statusFilter != null && statusFilter != header.getStatus()) return false;
+        if (fromDate != null && header.getRequestedAt().before(fromDate)) return false;
+        return toDateExclusive == null || header.getRequestedAt().before(toDateExclusive);
+    }
+
+    // 사용하는 메서드: list
+    // 헤더 목록 기준 매장 조회 맵을 구성한다.
+    private Map<Long, Infrastructure> loadStoreMap(List<StoreOrderHeader> headers) {
+        Set<Long> storeIds = headers.stream().map(StoreOrderHeader::getStoreId).collect(Collectors.toSet());
+        return infrastructureRepository.findAllById(storeIds).stream()
+                .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
+    }
+
+    // 사용하는 메서드: list, analytics
+    // 헤더 목록 기준 아이템 그룹 맵을 구성한다.
+    private Map<Long, List<StoreOrderItem>> loadItemsByHeader(List<StoreOrderHeader> headers) {
+        Set<Long> headerIds = headers.stream().map(StoreOrderHeader::getId).collect(Collectors.toSet());
+        if (headerIds.isEmpty()) return Map.of();
+        return itemRepository.findAllByOrderHeaderIdIn(headerIds).stream()
+                .collect(Collectors.groupingBy(StoreOrderItem::getOrderHeaderId));
+    }
+
+    // 사용하는 메서드: update, cancel, detail, analytics
+    // 주문번호 기준 헤더를 조회한다.
+    private StoreOrderHeader getOrderByOrderNo(String orderNo) {
+        return headerRepository.findByOrderNo(orderNo)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_NOT_FOUND));
+    }
+
+    private String trimToNull(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+    private String safe(String s) {
+        return s == null ? "" : s;
+    }
+
+    private String blankTo(String s, String fallback) {
+        if (s == null || s.isBlank()) return fallback;
+        return s;
+    }
+
+    private record CategoryLookup(Map<Long, Category> categoryById, Map<String, Category> categoryByCode) {}
+
+    @Builder
+    private static class ResolvedItem {
+        private ProductSku sku;
+        private ProductMaster product;
+        private String mainCategory;
+        private String subCategory;
+        private Integer requestedQuantity;
+
+        private StoreOrderItem toEntity(Long orderHeaderId) {
+            return StoreOrderItem.builder()
+                    .orderHeaderId(orderHeaderId)
+                    .skuId(sku.getId())
+                    .skuCode(sku.getSkuCode())
+                    .productCode(product.getCode())
+                    .productName(product.getName())
+                    .mainCategory(mainCategory)
+                    .subCategory(subCategory)
+                    .color(sku.getColor())
+                    .size(sku.getSize())
+                    .unitPrice(sku.getUnitPrice())
+                    .requestedQuantity(requestedQuantity)
+                    .build();
+        }
+    }
+
+    private static class SkuAgg {
+        private final String skuCode;
+        private final String productName;
+        private final String categoryLabel;
+        private int requestedQuantity;
+        private int orderCount;
+
+        private SkuAgg(String skuCode, String productName, String categoryLabel, int requestedQuantity, int orderCount) {
+            this.skuCode = skuCode;
+            this.productName = productName;
+            this.categoryLabel = categoryLabel;
+            this.requestedQuantity = requestedQuantity;
+            this.orderCount = orderCount;
+        }
+    }
+
+    private static class CategoryAgg {
+        private final String mainCategory;
+        private final String subCategory;
+        private final String label;
+        private int requestedQuantity;
+
+        private CategoryAgg(String mainCategory, String subCategory, String label, int requestedQuantity) {
+            this.mainCategory = mainCategory;
+            this.subCategory = subCategory;
+            this.label = label;
+            this.requestedQuantity = requestedQuantity;
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -9,11 +9,13 @@ import org.example.stockitbe.hq.category.model.Category;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.InventoryService;
 import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.ProductSkuRepository;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
 import org.example.stockitbe.hq.product.model.ProductStatus;
+import org.example.stockitbe.store.order.model.StoreOrderFulfillmentStatus;
 import org.example.stockitbe.store.order.model.StoreOrderHistoryType;
 import org.example.stockitbe.store.order.model.StoreOrderStatus;
 import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
@@ -41,6 +43,7 @@ public class StoreOrderService {
     private final StoreOrderItemRepository itemRepository;
     private final StoreOrderStatusHistoryRepository historyRepository;
     private final InfrastructureRepository infrastructureRepository;
+    private final InventoryService inventoryService;
     private final ProductSkuRepository productSkuRepository;
     private final ProductMasterRepository productMasterRepository;
     private final CategoryRepository categoryRepository;
@@ -102,6 +105,29 @@ public class StoreOrderService {
                 safe(dto.getCancelledByMemberId()), blankTo(dto.getCancelledByName(), header.getRequestedByName()),
                 cancelReason);
         return StoreOrderDto.CancelRes.from(buildCreateRes(header));
+    }
+
+    @Transactional
+    public StoreOrderDto.ApproveRes approve(String orderNo, StoreOrderDto.ApproveReq dto) {
+        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        Date now = new Date();
+
+        header.markApproved();
+        header.markFulfillment(StoreOrderFulfillmentStatus.READY_TO_SHIP);
+
+        List<StoreOrderItem> items = itemRepository.findAllByOrderHeaderIdOrderByIdAsc(header.getId());
+        for (StoreOrderItem item : items) {
+            inventoryService.increaseAvailable(header.getStoreId(), item.getSkuCode(), item.getRequestedQuantity());
+        }
+
+        String actorMemberId = safe(dto == null ? null : dto.getApprovedByMemberId());
+        String actorName = blankTo(dto == null ? null : dto.getApprovedByName(), "시스템");
+        appendOrderStatusHistory(header.getId(), StoreOrderStatus.APPROVED.name(), now,
+                actorMemberId, actorName, "발주 승인 처리");
+        appendFulfillmentStatusHistory(header.getId(), StoreOrderFulfillmentStatus.READY_TO_SHIP.name(), now,
+                actorMemberId, actorName, "가용재고 반영");
+
+        return StoreOrderDto.ApproveRes.from(buildCreateRes(header));
     }
 
     // 매장 발주 내역 목록 조회
@@ -374,6 +400,21 @@ public class StoreOrderService {
                 StoreOrderStatusHistory.builder()
                         .orderHeaderId(headerId)
                         .historyType(StoreOrderHistoryType.ORDER_STATUS)
+                        .status(status)
+                        .changedAt(changedAt)
+                        .changedByMemberId(changedByMemberId)
+                        .changedByName(changedByName)
+                        .reason(reason)
+                        .build()
+        );
+    }
+
+    private void appendFulfillmentStatusHistory(Long headerId, String status, Date changedAt,
+                                                String changedByMemberId, String changedByName, String reason) {
+        historyRepository.save(
+                StoreOrderStatusHistory.builder()
+                        .orderHeaderId(headerId)
+                        .historyType(StoreOrderHistoryType.FULFILLMENT_STATUS)
                         .status(status)
                         .changedAt(changedAt)
                         .changedByMemberId(changedByMemberId)

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderStatusHistoryRepository.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderStatusHistoryRepository.java
@@ -1,0 +1,11 @@
+package org.example.stockitbe.store.order;
+
+import org.example.stockitbe.store.order.model.entity.StoreOrderStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StoreOrderStatusHistoryRepository extends JpaRepository<StoreOrderStatusHistory, Long> {
+    List<StoreOrderStatusHistory> findAllByOrderHeaderIdOrderByChangedAtAscIdAsc(Long orderHeaderId);
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/StoreOrderFulfillmentStatus.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/StoreOrderFulfillmentStatus.java
@@ -1,0 +1,9 @@
+package org.example.stockitbe.store.order.model;
+
+public enum StoreOrderFulfillmentStatus {
+    READY_TO_SHIP,  // 배송 준비 중
+    IN_TRANSIT,     // 배송 중
+    ARRIVED,        // 매장 도착
+    RECEIVED        // 입고 완료
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/StoreOrderHistoryType.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/StoreOrderHistoryType.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.store.order.model;
+
+public enum StoreOrderHistoryType {
+    ORDER_STATUS,
+    FULFILLMENT_STATUS
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/StoreOrderStatus.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/StoreOrderStatus.java
@@ -1,0 +1,9 @@
+package org.example.stockitbe.store.order.model;
+
+public enum StoreOrderStatus {
+    REQUESTED,  // 승인 대기
+    APPROVED,   // 승인 완료
+    COMPLETED,  // 완료 (입고까지 완료 후 해당 발주 건 종료)
+    CANCELLED   // 취소
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
@@ -265,6 +265,26 @@ public class StoreOrderDto {
         }
     }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ApproveReq {
+        private String approvedByMemberId;
+        private String approvedByName;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ApproveRes {
+        private CreateRes order;
+
+        public static ApproveRes from(CreateRes order) {
+            return ApproveRes.builder().order(order).build();
+        }
+    }
+
     // 발주 목록 조회 응답 DTO
     // 목록 조회용 요약 정보와 헤드라인을 반환
     @Getter

--- a/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
@@ -1,0 +1,401 @@
+package org.example.stockitbe.store.order.model.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.store.order.model.StoreOrderFulfillmentStatus;
+import org.example.stockitbe.store.order.model.StoreOrderHistoryType;
+import org.example.stockitbe.store.order.model.StoreOrderStatus;
+import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
+import org.example.stockitbe.store.order.model.entity.StoreOrderItem;
+import org.example.stockitbe.store.order.model.entity.StoreOrderStatusHistory;
+
+import java.util.Date;
+import java.util.List;
+
+public class StoreOrderDto {
+
+    // 발주 생성 요청 DTO
+    // 매장 코드, 요청자 정보, 발주 SKU 라인 목록을 전달
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateReq {
+        @NotBlank
+        private String storeCode;
+        private String storeLocationId;
+        private String requestedByMemberId;
+        @NotBlank
+        private String requestedByName;
+        private String memo;
+        @Valid
+        @NotEmpty
+        private List<CreateLineReq> items;
+
+        public StoreOrderHeader toEntity(CreateHeaderContext context) {
+            return StoreOrderHeader.builder()
+                    .orderNo(context.getTemporaryOrderNo())
+                    .storeId(context.getStoreId())
+                    .warehouseId(context.getWarehouseId())
+                    .requestedByMemberId(this.requestedByMemberId == null ? "" : this.requestedByMemberId)
+                    .requestedByName(this.requestedByName)
+                    .requestedAt(context.getRequestedAt())
+                    .status(StoreOrderStatus.REQUESTED)
+                    .totalSkuCount(context.getTotalSkuCount())
+                    .totalRequestedQuantity(context.getTotalRequestedQuantity())
+                    .memo(context.getMemo())
+                    .cancelReason(null)
+                    .build();
+        }
+    }
+
+    // 발주 생성 응답 DTO
+    // 생성된 발주 헤더/라인/상태 이력을 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CreateRes {
+        private String orderId;
+        private String storeCode;
+        private String storeName;
+        private Date requestedAt;
+        private String requestedByMemberId;
+        private String requestedBy;
+        private StoreOrderStatus status;
+        private StoreOrderFulfillmentStatus inboundStatus;
+        private Integer totalSkuCount;
+        private Integer totalRequestedQuantity;
+        private String memo;
+        private String cancelReason;
+        private List<CreateLineRes> items;
+        private List<CreateHistoryRes> statusHistory;
+
+        public static CreateRes from(StoreOrderHeader header, String storeCode, String storeName,
+                                     List<CreateLineRes> items, List<CreateHistoryRes> history) {
+            return CreateRes.builder()
+                    .orderId(header.getOrderNo())
+                    .storeCode(storeCode)
+                    .storeName(storeName)
+                    .requestedAt(header.getRequestedAt())
+                    .requestedByMemberId(header.getRequestedByMemberId())
+                    .requestedBy(header.getRequestedByName())
+                    .status(header.getStatus())
+                    .inboundStatus(header.getFulfillmentStatus())
+                    .totalSkuCount(header.getTotalSkuCount())
+                    .totalRequestedQuantity(header.getTotalRequestedQuantity())
+                    .memo(header.getMemo())
+                    .cancelReason(header.getCancelReason())
+                    .items(items)
+                    .statusHistory(history)
+                    .build();
+        }
+    }
+
+    // 발주 생성 라인 요청 DTO
+    // SKU 코드와 요청 수량을 전달
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateLineReq {
+        @NotBlank
+        private String skuCode;
+        @Min(1)
+        private Integer requestedQuantity;
+
+        public StoreOrderItem toEntity(CreateLineContext context) {
+            return StoreOrderItem.builder()
+                    .orderHeaderId(context.getOrderHeaderId())
+                    .skuId(context.getSkuId())
+                    .skuCode(this.skuCode)
+                    .productCode(context.getProductCode())
+                    .productName(context.getProductName())
+                    .mainCategory(context.getMainCategory())
+                    .subCategory(context.getSubCategory())
+                    .color(context.getColor())
+                    .size(context.getSize())
+                    .unitPrice(context.getUnitPrice())
+                    .requestedQuantity(this.requestedQuantity)
+                    .build();
+        }
+    }
+
+    // 발주 생성 라인 응답 DTO
+    // SKU/상품/옵션 스냅샷과 수량/단가를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CreateLineRes {
+        private Long skuId;
+        private String skuCode;
+        private String productCode;
+        private String productName;
+        private String mainCategory;
+        private String subCategory;
+        private String color;
+        private String size;
+        private Long unitPrice;
+        private Integer requestedQuantity;
+
+        public static CreateLineRes from(StoreOrderItem item) {
+            return CreateLineRes.builder()
+                    .skuId(item.getSkuId())
+                    .skuCode(item.getSkuCode())
+                    .productCode(item.getProductCode())
+                    .productName(item.getProductName())
+                    .mainCategory(item.getMainCategory())
+                    .subCategory(item.getSubCategory())
+                    .color(item.getColor())
+                    .size(item.getSize())
+                    .unitPrice(item.getUnitPrice())
+                    .requestedQuantity(item.getRequestedQuantity())
+                    .build();
+        }
+    }
+
+    // 발주 생성 상태이력 응답 DTO
+    // 상태 전환 이력과 변경 주체/사유를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CreateHistoryRes {
+        private StoreOrderHistoryType historyType;
+        private String status;
+        private Date changedAt;
+        private String changedByMemberId;
+        private String changedByName;
+        private String reason;
+
+        public static CreateHistoryRes from(StoreOrderStatusHistory history) {
+            return CreateHistoryRes.builder()
+                    .historyType(history.getHistoryType())
+                    .status(history.getStatus())
+                    .changedAt(history.getChangedAt())
+                    .changedByMemberId(history.getChangedByMemberId())
+                    .changedByName(history.getChangedByName())
+                    .reason(history.getReason())
+                    .build();
+        }
+    }
+
+    // 발주 수정 요청 DTO
+    // 발주 메모와 수정 라인 목록을 전달
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateReq {
+        private String memo;
+        @Valid
+        @NotEmpty
+        private List<UpdateLineReq> items;
+    }
+
+    // 발주 수정 응답 DTO
+    // 수정 반영된 발주 상세를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateRes {
+        private CreateRes order;
+
+        public static UpdateRes from(CreateRes order) {
+            return UpdateRes.builder().order(order).build();
+        }
+    }
+
+    // 발주 수정 라인 요청 DTO
+    // SKU 코드와 요청 수량을 전달
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateLineReq {
+        @NotBlank
+        private String skuCode;
+        @Min(1)
+        private Integer requestedQuantity;
+
+        public StoreOrderItem toEntity(UpdateLineContext context) {
+            return StoreOrderItem.builder()
+                    .orderHeaderId(context.getOrderHeaderId())
+                    .skuId(context.getSkuId())
+                    .skuCode(this.skuCode)
+                    .productCode(context.getProductCode())
+                    .productName(context.getProductName())
+                    .mainCategory(context.getMainCategory())
+                    .subCategory(context.getSubCategory())
+                    .color(context.getColor())
+                    .size(context.getSize())
+                    .unitPrice(context.getUnitPrice())
+                    .requestedQuantity(this.requestedQuantity)
+                    .build();
+        }
+    }
+
+    // 발주 취소 요청 DTO
+    // 취소 사유와 취소자 정보를 전달
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CancelReq {
+        @NotBlank
+        private String cancelReason;
+        private String cancelledByMemberId;
+        private String cancelledByName;
+    }
+
+    // 발주 취소 응답 DTO
+    // 취소 반영된 발주 상세를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CancelRes {
+        private CreateRes order;
+
+        public static CancelRes from(CreateRes order) {
+            return CancelRes.builder().order(order).build();
+        }
+    }
+
+    // 발주 목록 조회 응답 DTO
+    // 목록 조회용 요약 정보와 헤드라인을 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ListRes {
+        private String orderId;
+        private String storeCode;
+        private String storeName;
+        private Date requestedAt;
+        private String requestedBy;
+        private StoreOrderStatus status;
+        private StoreOrderFulfillmentStatus inboundStatus;
+        private Integer totalSkuCount;
+        private Integer totalRequestedQuantity;
+        private String memo;
+        private String cancelReason;
+        private String headline;
+
+        public static ListRes from(StoreOrderHeader header, String storeCode, String storeName, String headline) {
+            return ListRes.builder()
+                    .orderId(header.getOrderNo())
+                    .storeCode(storeCode)
+                    .storeName(storeName)
+                    .requestedAt(header.getRequestedAt())
+                    .requestedBy(header.getRequestedByName())
+                    .status(header.getStatus())
+                    .inboundStatus(header.getFulfillmentStatus())
+                    .totalSkuCount(header.getTotalSkuCount())
+                    .totalRequestedQuantity(header.getTotalRequestedQuantity())
+                    .memo(header.getMemo())
+                    .cancelReason(header.getCancelReason())
+                    .headline(headline)
+                    .build();
+        }
+    }
+
+    // 발주 상세 조회 응답 DTO
+    // 단건 발주 상세를 래핑해 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class DetailRes {
+        private CreateRes order;
+
+        public static DetailRes from(CreateRes order) {
+            return DetailRes.builder().order(order).build();
+        }
+    }
+
+    // 발주 분석 응답 DTO
+    // 상태별 집계 및 SKU/카테고리 분석 결과를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class AnalyticsRes {
+        private Integer totalOrders;
+        private Integer totalRequestedQuantity;
+        private Integer requestedCount;
+        private Integer approvedCount;
+        private Integer completedCount;
+        private Integer cancelledCount;
+        private List<AnalyticsSkuRes> topSkus;
+        private List<AnalyticsCategoryRes> categoryBreakdown;
+    }
+
+    // 발주 SKU 분석 응답 DTO
+    // SKU별 누적 요청 수량/건수를 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class AnalyticsSkuRes {
+        private String skuCode;
+        private String productName;
+        private String categoryLabel;
+        private Integer requestedQuantity;
+        private Integer orderCount;
+    }
+
+    // 발주 카테고리 분석 응답 DTO
+    // 카테고리별 누적 요청 수량을 반환
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class AnalyticsCategoryRes {
+        private String mainCategory;
+        private String subCategory;
+        private String label;
+        private Integer requestedQuantity;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CreateHeaderContext {
+        private Long storeId;
+        private Long warehouseId;
+        private Date requestedAt;
+        private Integer totalSkuCount;
+        private Integer totalRequestedQuantity;
+        private String memo;
+        private String temporaryOrderNo;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class CreateLineContext {
+        private Long orderHeaderId;
+        private Long skuId;
+        private String productCode;
+        private String productName;
+        private String mainCategory;
+        private String subCategory;
+        private String color;
+        private String size;
+        private Long unitPrice;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateLineContext {
+        private Long orderHeaderId;
+        private Long skuId;
+        private String productCode;
+        private String productName;
+        private String mainCategory;
+        private String subCategory;
+        private String color;
+        private String size;
+        private Long unitPrice;
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
@@ -100,6 +100,11 @@ public class StoreOrderHeader extends BaseEntity {
         this.fulfillmentStatus = null;
     }
 
+    public void markApproved() {
+        validateRequestedOnly();
+        this.status = StoreOrderStatus.APPROVED;
+    }
+
     public void markFulfillment(StoreOrderFulfillmentStatus fulfillmentStatus) {
         this.fulfillmentStatus = fulfillmentStatus;
     }

--- a/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
@@ -23,7 +23,7 @@ public class StoreOrderHeader extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "order_no", nullable = false, length = 40)
+    @Column(name = "order_no", nullable = false, length = 50)
     private String orderNo;
 
     @Column(name = "store_id", nullable = false)

--- a/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderHeader.java
@@ -1,0 +1,112 @@
+package org.example.stockitbe.store.order.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseEntity;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.store.order.model.StoreOrderFulfillmentStatus;
+import org.example.stockitbe.store.order.model.StoreOrderStatus;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "store_order_header")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreOrderHeader extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_no", nullable = false, length = 40)
+    private String orderNo;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "warehouse_id", nullable = false)
+    private Long warehouseId;
+
+    @Column(name = "requested_by_member_id", nullable = false, length = 50)
+    private String requestedByMemberId;
+
+    @Column(name = "requested_by_name", nullable = false, length = 100)
+    private String requestedByName;
+
+    @Column(name = "requested_at", nullable = false)
+    private Date requestedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private StoreOrderStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fulfillment_status", length = 20)
+    private StoreOrderFulfillmentStatus fulfillmentStatus;
+
+    @Column(name = "total_sku_count", nullable = false)
+    private Integer totalSkuCount;
+
+    @Column(name = "total_requested_quantity", nullable = false)
+    private Integer totalRequestedQuantity;
+
+    @Column(name = "memo", length = 500)
+    private String memo;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    @Builder
+    private StoreOrderHeader(String orderNo, Long storeId, Long warehouseId, String requestedByMemberId,
+                             String requestedByName, Date requestedAt, StoreOrderStatus status,
+                             StoreOrderFulfillmentStatus fulfillmentStatus,
+                             Integer totalSkuCount, Integer totalRequestedQuantity,
+                             String memo, String cancelReason) {
+        this.orderNo = orderNo;
+        this.storeId = storeId;
+        this.warehouseId = warehouseId;
+        this.requestedByMemberId = requestedByMemberId;
+        this.requestedByName = requestedByName;
+        this.requestedAt = requestedAt;
+        this.status = status == null ? StoreOrderStatus.REQUESTED : status;
+        this.fulfillmentStatus = fulfillmentStatus;
+        this.totalSkuCount = totalSkuCount == null ? 0 : totalSkuCount;
+        this.totalRequestedQuantity = totalRequestedQuantity == null ? 0 : totalRequestedQuantity;
+        this.memo = memo;
+        this.cancelReason = cancelReason;
+    }
+
+    public void assignOrderNo(String orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public void updateRequested(Date requestedAt, Integer totalSkuCount, Integer totalRequestedQuantity, String memo) {
+        validateRequestedOnly();
+        this.requestedAt = requestedAt == null ? this.requestedAt : requestedAt;
+        this.totalSkuCount = totalSkuCount;
+        this.totalRequestedQuantity = totalRequestedQuantity;
+        this.memo = memo;
+    }
+
+    public void markCancelled(String cancelReason) {
+        validateRequestedOnly();
+        this.status = StoreOrderStatus.CANCELLED;
+        this.cancelReason = cancelReason;
+        this.fulfillmentStatus = null;
+    }
+
+    public void markFulfillment(StoreOrderFulfillmentStatus fulfillmentStatus) {
+        this.fulfillmentStatus = fulfillmentStatus;
+    }
+
+    private void validateRequestedOnly() {
+        if (this.status != StoreOrderStatus.REQUESTED) {
+            throw BaseException.from(BaseResponseStatus.STORE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderItem.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderItem.java
@@ -1,0 +1,70 @@
+package org.example.stockitbe.store.order.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+
+@Entity
+@Table(name = "store_order_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreOrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_header_id", nullable = false)
+    private Long orderHeaderId;
+
+    @Column(name = "sku_id", nullable = false)
+    private Long skuId;
+
+    @Column(name = "sku_code", nullable = false, length = 32)
+    private String skuCode;
+
+    @Column(name = "product_code", nullable = false, length = 32)
+    private String productCode;
+
+    @Column(name = "product_name", nullable = false, length = 128)
+    private String productName;
+
+    @Column(name = "main_category", nullable = false, length = 64)
+    private String mainCategory;
+
+    @Column(name = "sub_category", nullable = false, length = 64)
+    private String subCategory;
+
+    @Column(name = "color", nullable = false, length = 32)
+    private String color;
+
+    @Column(name = "size", nullable = false, length = 16)
+    private String size;
+
+    @Column(name = "unit_price", nullable = false)
+    private Long unitPrice;
+
+    @Column(name = "requested_quantity", nullable = false)
+    private Integer requestedQuantity;
+
+    @Builder
+    private StoreOrderItem(Long orderHeaderId, Long skuId, String skuCode,
+                           String productCode, String productName,
+                           String mainCategory, String subCategory,
+                           String color, String size, Long unitPrice, Integer requestedQuantity) {
+        this.orderHeaderId = orderHeaderId;
+        this.skuId = skuId;
+        this.skuCode = skuCode;
+        this.productCode = productCode;
+        this.productName = productName;
+        this.mainCategory = mainCategory;
+        this.subCategory = subCategory;
+        this.color = color;
+        this.size = size;
+        this.unitPrice = unitPrice;
+        this.requestedQuantity = requestedQuantity;
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderStatusHistory.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/entity/StoreOrderStatusHistory.java
@@ -1,0 +1,56 @@
+package org.example.stockitbe.store.order.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.common.model.BaseEntity;
+import org.example.stockitbe.store.order.model.StoreOrderHistoryType;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "store_order_status_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreOrderStatusHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_header_id", nullable = false)
+    private Long orderHeaderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "history_type", nullable = false, length = 20)
+    private StoreOrderHistoryType historyType;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "changed_at", nullable = false)
+    private Date changedAt;
+
+    @Column(name = "changed_by_member_id", length = 50)
+    private String changedByMemberId;
+
+    @Column(name = "changed_by_name", length = 100)
+    private String changedByName;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Builder
+    private StoreOrderStatusHistory(Long orderHeaderId, StoreOrderHistoryType historyType, String status,
+                                    Date changedAt, String changedByMemberId, String changedByName, String reason) {
+        this.orderHeaderId = orderHeaderId;
+        this.historyType = historyType;
+        this.status = status;
+        this.changedAt = changedAt == null ? new Date() : changedAt;
+        this.changedByMemberId = changedByMemberId;
+        this.changedByName = changedByName;
+        this.reason = reason;
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 매장 발주 백엔드 MVP(v1) 구현을 완료했습니다.
- 발주 도메인(헤더/아이템/상태이력) 기반으로 생성/수정/취소/목록/상세/분석 API를 제공하도록 반영했습니다.

<br><br>

## 🎯 작업 내용
- `store_order_header`, `store_order_item`, `store_order_status_history` 기반 발주 도메인 모델/리포지토리/서비스/컨트롤러 구현
- 발주 API 구현
  - `POST /api/store/orders`
  - `PUT /api/store/orders/{orderNo}`
  - `PATCH /api/store/orders/{orderNo}/cancel`
  - `GET /api/store/orders`
  - `GET /api/store/orders/{orderNo}`
  - `GET /api/store/orders/analytics`
- 상태 전이 검증, 예외 코드 분리, BaseResponse 표준 응답 정합화 및 DTO 컨벤션(Req/Res 인접, `toEntity`/`from`) 정리

<br><br>

## ✔️ 참고 사항
- `requested_at`(비즈니스 요청 시각)과 `create_date/update_date`(시스템 시각)를 분리해 운영합니다.
- 아이템은 `skuCode/productCode/productName/category/color/size/unitPrice` 스냅샷을 저장하도록 설계했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #109 

<br><br>
