### PR TITLE
refactor: 로그인 응답에 매장코드/지점명 추가 + 창고 prefix 정리

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/LoginSuccessHandler.java
+++ b/src/main/java/org/example/stockitbe/common/config/LoginSuccessHandler.java
@@ -78,6 +78,8 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .employeeCode(employeeCode)
                 .name(userDetails.getName())
                 .role(userDetails.getRole())
+                .locationCode(userDetails.getLocationCode())
+                .locationName(userDetails.getLocationName())
                 .build();
 
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/org/example/stockitbe/user/model/AuthUserDetails.java
+++ b/src/main/java/org/example/stockitbe/user/model/AuthUserDetails.java
@@ -19,6 +19,8 @@ public class AuthUserDetails implements UserDetails {
     private String name;
     private UserStatus status;
     private UserRole role;
+    private String locationCode;
+    private String locationName;
 
     public static AuthUserDetails from(User entity) {
         return AuthUserDetails.builder()
@@ -27,6 +29,8 @@ public class AuthUserDetails implements UserDetails {
                 .name(entity.getName())
                 .role(entity.getRole())
                 .status(entity.getStatus())
+                .locationCode(entity.getLocationCode())
+                .locationName(entity.getLocationName())
                 .build();
     }
 

--- a/src/main/java/org/example/stockitbe/user/model/UserDto.java
+++ b/src/main/java/org/example/stockitbe/user/model/UserDto.java
@@ -84,6 +84,8 @@ public class UserDto {
         private String employeeCode;
         private String name;
         private UserRole role;
+        private String locationCode;
+        private String locationName;
     }
 
     //  마이페이지

--- a/src/main/java/org/example/stockitbe/user/model/UserRole.java
+++ b/src/main/java/org/example/stockitbe/user/model/UserRole.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserRole {
     HQ("hq"),
     STORE("st"),
-    WAREHOUSE("wa");
+    WAREHOUSE("wh");
 
     private final String codePrefix;
 }


### PR DESCRIPTION
## 📌 요약
- 로그인 응답에 매장코드/지점명 추가 + 창고 prefix 정리

<br><br>

## 🎯 작업 내용
- LoginRes 에 locationCode, locationName 필드 추가
- AuthUserDetails 에 두 필드 + from() 매핑 추가
- LoginSuccessHandler builder 에 두 필드 매핑 추가 → POST /api/user/login 응답에 사용자가 속한 지점 정보가 포함됨
- UserRole.WAREHOUSE prefix 'wa' → 'wh' 로 변경

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #183 

<br><br>
