### PR TITLE
refactor(purchase-order): 발주 코드 5자리 + 상태머신 7단계 확장

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -330,8 +330,8 @@ public class InventoryService {
     }
 
     /**
-     * 발주 SHIPPING 진입 시 해당 창고 SKU 의 가용재고 증가 (이슈 #169 — 발주 ↔ 인벤토리 연결 룰).
-     * row 부재 시 신규 INSERT 분기. 동일 트랜잭션에서 호출자(PurchaseOrderService.startShipping)
+     * 발주 IN_TRANSIT 진입 시 해당 창고 SKU 의 가용재고 증가 (이슈 #169 — 발주 ↔ 인벤토리 연결 룰).
+     * row 부재 시 신규 INSERT 분기. 동일 트랜잭션에서 호출자(PurchaseOrderService.startInTransit)
      * 가 실패하면 함께 롤백된다.
      */
     @Transactional

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderAutoTransitionScheduler.java
@@ -21,7 +21,7 @@ public class PurchaseOrderAutoTransitionScheduler {
     public void run() {
         log.info("[SYS-001] 배치 시작");
         PurchaseOrderBatchService.BatchResult result = batchService.run(false);
-        log.info("[SYS-001] 배치 완료 — approved={}, shipping={}, delivered={}",
-                result.approved(), result.shipping(), result.delivered());
+        log.info("[SYS-001] 배치 완료 — approved={}, readyToShip={}, inTransit={}, arrived={}",
+                result.approved(), result.readyToShip(), result.inTransit(), result.arrived());
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchController.java
@@ -9,7 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * SYS-001 강제 트리거 — 시연·QA·장애 대응용.
  *
- * 시간 조건(wait-minutes)을 무시하고 모든 PENDING/APPROVED 발주를 즉시 다음 단계로 전환한다.
+ * 시간 조건(wait-minutes)을 무시하고 거래처 책임 4단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT)
+ * 발주를 즉시 다음 단계로 전환한다.
  * 운영 환경에서는 {@link PurchaseOrderAutoTransitionScheduler} 가 5분마다 자동 호출.
  */
 @RestController

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderBatchService.java
@@ -19,9 +19,13 @@ import java.util.function.Consumer;
  * 5분 주기 스케줄러({@link PurchaseOrderAutoTransitionScheduler}) 와 시연용 강제 트리거
  * 컨트롤러({@link PurchaseOrderBatchController}) 모두 이 서비스의 {@link #run(boolean)} 을 호출한다.
  *
- * 1건 1트랜잭션 — {@link PurchaseOrderService#approve(String)} / {@link PurchaseOrderService#startShipping(String)}
- * 가 자체 {@code @Transactional} 이므로 이 클래스에는 트랜잭션 어노테이션을 절대 달지 않는다.
+ * 1건 1트랜잭션 — PurchaseOrderService 의 각 단계 메소드가 자체 {@code @Transactional} 이므로
+ * 이 클래스에는 트랜잭션 어노테이션을 절대 달지 않는다.
  * 한 건 실패는 try/catch 로 격리하고 다음 건을 계속 처리한다.
+ *
+ * 거래처 책임 4단계 모두 자동 전환:
+ *   REQUESTED → APPROVED → READY_TO_SHIP → IN_TRANSIT → ARRIVED
+ * ARRIVED → COMPLETED 는 창고 [입고 확정] 매뉴얼 트리거(WHS-007) — 배치 처리 안 함.
  */
 @Service
 @RequiredArgsConstructor
@@ -35,18 +39,15 @@ public class PurchaseOrderBatchService {
     private long waitMinutes;
 
     /**
-     * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 모든 PENDING/APPROVED/SHIPPING 즉시 처리.
+     * @param force true 면 시간 조건 무시 (시연·QA·장애 대응) — 거래처 책임 4단계 모두 즉시 처리.
      *              false 면 {@code updatedAt < now - waitMinutes} 인 건만.
-     *
-     * 공급처 책임 단계 3개 모두 SYS-001 자동 전환 (ADR-013/019).
-     * SHIPPING → DELIVERED 도 같은 패턴 — 배송 도착 시점도 공급처 책임이라 자동화.
-     * DELIVERED → COMPLETED 는 창고 [입고 확정] 매뉴얼 트리거(WHS-007) — 배치 처리 안 함.
      */
     public BatchResult run(boolean force) {
-        int approved  = autoTransition(PurchaseOrderStatus.PENDING,  force, code -> service.approve(code));
-        int shipping  = autoTransition(PurchaseOrderStatus.APPROVED, force, code -> service.startShipping(code));
-        int delivered = autoTransition(PurchaseOrderStatus.SHIPPING, force, code -> service.deliver(code));
-        return new BatchResult(approved, shipping, delivered);
+        int approved     = autoTransition(PurchaseOrderStatus.REQUESTED,     force, code -> service.approve(code));
+        int readyToShip  = autoTransition(PurchaseOrderStatus.APPROVED,      force, code -> service.readyToShip(code));
+        int inTransit    = autoTransition(PurchaseOrderStatus.READY_TO_SHIP, force, code -> service.startInTransit(code));
+        int arrived      = autoTransition(PurchaseOrderStatus.IN_TRANSIT,    force, code -> service.arrive(code));
+        return new BatchResult(approved, readyToShip, inTransit, arrived);
     }
 
     private int autoTransition(PurchaseOrderStatus from, boolean force, Consumer<String> action) {
@@ -67,5 +68,5 @@ public class PurchaseOrderBatchService {
         return success;
     }
 
-    public record BatchResult(int approved, int shipping, int delivered) {}
+    public record BatchResult(int approved, int readyToShip, int inTransit, int arrived) {}
 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -165,7 +165,7 @@ public class PurchaseOrderService {
         }
 
         PurchaseOrder po = lookupPurchaseOrder(code);
-        if (po.getStatus() != PurchaseOrderStatus.PENDING) {
+        if (po.getStatus() != PurchaseOrderStatus.REQUESTED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
 
@@ -219,9 +219,17 @@ public class PurchaseOrderService {
     }
 
     @Transactional
-    public PurchaseOrderDto.DetailRes startShipping(String code) {
+    public PurchaseOrderDto.DetailRes readyToShip(String code) {
         PurchaseOrder po = lookupPurchaseOrder(code);
-        po.markShipping();
+        po.markReadyToShip();
+        appendHistory(po, null, null);
+        return buildDetailRes(po);
+    }
+
+    @Transactional
+    public PurchaseOrderDto.DetailRes startInTransit(String code) {
+        PurchaseOrder po = lookupPurchaseOrder(code);
+        po.markInTransit();
         appendHistory(po, null, null);
         // 발주 ↔ 인벤토리 연결 (이슈 #169) — 가용재고 += 발주 수량 (도착 전 예약)
         itemRepository.findAllByPurchaseOrderId(po.getId())
@@ -230,9 +238,9 @@ public class PurchaseOrderService {
     }
 
     @Transactional
-    public PurchaseOrderDto.DetailRes deliver(String code) {
+    public PurchaseOrderDto.DetailRes arrive(String code) {
         PurchaseOrder po = lookupPurchaseOrder(code);
-        po.markDelivered();
+        po.markArrived();
         appendHistory(po, null, null);
         return buildDetailRes(po);
     }
@@ -254,7 +262,7 @@ public class PurchaseOrderService {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_CANCEL_REASON_REQUIRED);
         }
         PurchaseOrder po = lookupPurchaseOrder(code);
-        po.markRejected(req.getCancelReason());
+        po.markCancelled(req.getCancelReason());
         appendHistory(po, req.getCancelReason(), me);
         return buildDetailRes(po);
     }
@@ -298,28 +306,29 @@ public class PurchaseOrderService {
     }
 
     /**
-     * 코드 자동 생성 — PO-{YYYYMMDD}-{NNN}.
-     * NNN 은 같은 날 prefix count + 1 (3자리 zero-pad).
+     * 코드 자동 생성 — PO-{YYYYMMDD}-{NNNNN}.
+     * NNNNN 은 같은 날 prefix count + 1 (5자리 zero-pad).
      */
     private String generateCode() {
         String today = LocalDate.now().format(CODE_DATE_FORMAT);
         String prefix = "PO-" + today + "-";
         long seq = purchaseOrderRepository.countByCodeStartingWith(prefix) + 1;
-        return String.format("%s%03d", prefix, seq);
+        return String.format("%s%05d", prefix, seq);
     }
 
     /**
      * 진행 이력 한 행 추가. changedByName 은 도메인 책임자 기준 분기:
-     *   - APPROVED / SHIPPING / DELIVERED : "담당자명 (회사명)" 형식 — 발주 시점 공급처 스냅샷
-     *     (실제 트리거는 SYS-001 배치지만 자동화는 구현 디테일이라 도메인 이력에 노출하지 않음, ADR-013/019)
-     *     실무 ERP 표준 — 법적 주체(회사) + 실무 처리자(담당자) 둘 다 노출.
-     *     배치 호출이라 인증 사용자 없음 — me=null 로 들어옴.
-     *   - PENDING / REJECTED / COMPLETED : 인증 사용자(me) 의 실명. me 가 null 이면 NOT_AUTHENTICATED.
+     *   - APPROVED / READY_TO_SHIP / IN_TRANSIT / ARRIVED : "담당자명 (회사명)" 형식 — 발주 시점 공급처 스냅샷.
+     *     실제 트리거는 SYS-001 배치(거래처 책임 단계 자동화) — 자동화는 구현 디테일이라 도메인 이력에 노출하지 않음 (ADR-013/019).
+     *     실무 ERP 표준 — 법적 주체(회사) + 실무 처리자(담당자) 둘 다 노출. 배치 호출이라 인증 사용자 없음 (me=null).
+     *   - REQUESTED / COMPLETED / CANCELLED : 인증 사용자(me) 의 실명. me 가 null 이면 NOT_AUTHENTICATED.
+     *     본사 작성/창고 입고 확정/본사 취소 — 인증된 담당자의 책임 단계.
      */
     private void appendHistory(PurchaseOrder po, String note, AuthUserDetails me) {
         String changedByName = switch (po.getStatus()) {
-            case APPROVED, SHIPPING, DELIVERED -> po.getVendorContactName() + " (" + po.getVendorName() + ")";
-            case PENDING, REJECTED, COMPLETED -> {
+            case APPROVED, READY_TO_SHIP, IN_TRANSIT, ARRIVED ->
+                    po.getVendorContactName() + " (" + po.getVendorName() + ")";
+            case REQUESTED, COMPLETED, CANCELLED -> {
                 if (me == null) {
                     throw BaseException.from(BaseResponseStatus.NOT_AUTHENTICATED);
                 }

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrder.java
@@ -76,58 +76,64 @@ public class PurchaseOrder extends BaseEntity {
         this.memberId = memberId;
         this.memberName = memberName;
         this.totalAmount = totalAmount == null ? 0L : totalAmount;
-        this.status = PurchaseOrderStatus.PENDING;
+        this.status = PurchaseOrderStatus.REQUESTED;
     }
 
+    /** REQUESTED → APPROVED. SYS-001 배치 자동 전환 (거래처 책임). */
     public void markApproved() {
-        if (this.status != PurchaseOrderStatus.PENDING) {
+        if (this.status != PurchaseOrderStatus.REQUESTED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
         this.status = PurchaseOrderStatus.APPROVED;
     }
 
-    public void markShipping() {
+    /** APPROVED → READY_TO_SHIP. SYS-001 배치 자동 전환 (거래처 배송 준비). */
+    public void markReadyToShip() {
         if (this.status != PurchaseOrderStatus.APPROVED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
-        this.status = PurchaseOrderStatus.SHIPPING;
+        this.status = PurchaseOrderStatus.READY_TO_SHIP;
     }
 
-    /**
-     * 배송 완료 — SHIPPING → DELIVERED. SYS-001 배치 자동 (30분 경과) 또는 force 트리거.
-     * 공급처 책임 단계 (운송 도착) — ADR-013 / ADR-019 일관.
-     */
-    public void markDelivered() {
-        if (this.status != PurchaseOrderStatus.SHIPPING) {
+    /** READY_TO_SHIP → IN_TRANSIT. SYS-001 배치 자동 전환 — 인벤토리 가용재고 + 시점. */
+    public void markInTransit() {
+        if (this.status != PurchaseOrderStatus.READY_TO_SHIP) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
-        this.status = PurchaseOrderStatus.DELIVERED;
+        this.status = PurchaseOrderStatus.IN_TRANSIT;
     }
 
-    /**
-     * 입고 확정 — DELIVERED → COMPLETED. 창고 [입고 확정] 액션 (검수 미구현, ADR-015).
-     */
+    /** IN_TRANSIT → ARRIVED. SYS-001 배치 자동 전환 (창고 도착). */
+    public void markArrived() {
+        if (this.status != PurchaseOrderStatus.IN_TRANSIT) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
+        }
+        this.status = PurchaseOrderStatus.ARRIVED;
+    }
+
+    /** ARRIVED → COMPLETED. 창고 [입고 확정] 매뉴얼 (검수 미구현, ADR-015). */
     public void markCompleted() {
-        if (this.status != PurchaseOrderStatus.DELIVERED) {
+        if (this.status != PurchaseOrderStatus.ARRIVED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
         this.status = PurchaseOrderStatus.COMPLETED;
     }
 
-    public void markRejected(String reason) {
-        if (this.status != PurchaseOrderStatus.PENDING) {
+    /** REQUESTED → CANCELLED. 승인 대기 단계에서만 본사 [취소] 가능. */
+    public void markCancelled(String reason) {
+        if (this.status != PurchaseOrderStatus.REQUESTED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
-        this.status = PurchaseOrderStatus.REJECTED;
+        this.status = PurchaseOrderStatus.CANCELLED;
         this.cancelReason = reason;
     }
 
     /**
-     * items 교체 + totalAmount 재계산. PENDING 만 허용.
+     * items 교체 + totalAmount 재계산. REQUESTED 만 허용.
      * Service 가 기존 items 를 별도로 삭제하고 신규 items 를 save 한 뒤 호출.
      */
     public void recalculateTotalAmount(List<PurchaseOrderItem> items) {
-        if (this.status != PurchaseOrderStatus.PENDING) {
+        if (this.status != PurchaseOrderStatus.REQUESTED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
         long sum = items.stream().mapToLong(PurchaseOrderItem::getSubtotal).sum();
@@ -135,7 +141,7 @@ public class PurchaseOrder extends BaseEntity {
     }
 
     public void updateLogistics(Long warehouseId, String warehouseName) {
-        if (this.status != PurchaseOrderStatus.PENDING) {
+        if (this.status != PurchaseOrderStatus.REQUESTED) {
             throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_INVALID_STATUS_TRANSITION);
         }
         if (warehouseId != null) this.warehouseId = warehouseId;

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/model/PurchaseOrderStatus.java
@@ -1,5 +1,32 @@
 package org.example.stockitbe.hq.purchaseorder.model;
 
+/**
+ * 본사 발주 상태머신 — 7단계 단일 enum.
+ *
+ * 흐름: REQUESTED → APPROVED → READY_TO_SHIP → IN_TRANSIT → ARRIVED → COMPLETED
+ *      └─(REQUESTED 에서만)─→ CANCELLED
+ *
+ * 책임 분리:
+ *  - REQUESTED: 본사 관리자가 발주 작성 (인증 사용자)
+ *  - APPROVED / READY_TO_SHIP / IN_TRANSIT / ARRIVED: SYS-001 배치 자동 전환 (거래처 책임 단계, 30분 경과)
+ *  - COMPLETED: 창고 [입고 확정] 매뉴얼 (인증 사용자)
+ *  - CANCELLED: 본사 [취소] 매뉴얼 — REQUESTED 단계에서만 가능
+ *
+ * 라벨 분기 (FE view 책임):
+ *  - 본사 화면: COMPLETED = "종료"
+ *  - 창고 화면: COMPLETED = "입고 완료"
+ *  - 그 외 상태는 권한군 무관 단일 라벨
+ *
+ * 인벤토리 hook (PR #173):
+ *  - IN_TRANSIT 진입 시 → 가용재고 +
+ *  - COMPLETED 진입 시 → 가용 → 실재고 이동
+ */
 public enum PurchaseOrderStatus {
-    PENDING, APPROVED, SHIPPING, DELIVERED, COMPLETED, REJECTED
+    REQUESTED,
+    APPROVED,
+    READY_TO_SHIP,
+    IN_TRANSIT,
+    ARRIVED,
+    COMPLETED,
+    CANCELLED
 }

--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
@@ -45,10 +45,14 @@ public class DashboardService {
 
         Map<PurchaseOrderStatus, Long> statusBreakdown = buildStatusBreakdown(orders);
 
-        long scheduledCount = statusBreakdown.get(PurchaseOrderStatus.SHIPPING);
+        // scheduledCount 의미 — 입고 예정(미완료 거래처 단계 합산): READY_TO_SHIP + IN_TRANSIT + ARRIVED.
+        // 단일 SHIPPING 상태가 사라지고 거래처 단계가 4단계로 늘어났으므로 합산이 자연.
+        long scheduledCount = statusBreakdown.get(PurchaseOrderStatus.READY_TO_SHIP)
+                + statusBreakdown.get(PurchaseOrderStatus.IN_TRANSIT)
+                + statusBreakdown.get(PurchaseOrderStatus.ARRIVED);
         long completedCount = statusBreakdown.get(PurchaseOrderStatus.COMPLETED);
-        long rejectedCount = statusBreakdown.get(PurchaseOrderStatus.REJECTED);
-        long totalCount = orders.size() - rejectedCount;
+        long cancelledCount = statusBreakdown.get(PurchaseOrderStatus.CANCELLED);
+        long totalCount = orders.size() - cancelledCount;
         double progressRate = totalCount == 0 ? 0.0 : (double) completedCount / totalCount;
 
         Double avgProcessingHours = computeAvgProcessingHours(orders);

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -24,9 +24,9 @@ public class InboundService {
     private final PurchaseOrderService purchaseOrderService;
 
     /**
-     * 입고 목록 — 창고 관심사는 DELIVERED(도착됨)/COMPLETED(입고완료) 만.
-     * SHIPPING 은 공급처 단계(운송중)라 창고 화면에서 안 보임 — 본사 발주 화면에서 진행 상황만 확인.
-     * status 미지정 시 두 상태 모두, 지정 시 그 status 만 (DELIVERED/COMPLETED 외엔 빈 결과).
+     * 입고 목록 — 창고 관심사는 READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED 4상태.
+     * REQUESTED/APPROVED 는 본사 승인 단계라 창고 화면에서 숨김. CANCELLED 는 취소된 발주.
+     * status 미지정 시 4상태 모두, 지정 시 그 status 만 (4상태 외엔 빈 결과).
      */
     @Transactional(readOnly = true)
     public List<PurchaseOrderDto.ListRes> findAll(PurchaseOrderStatus status,
@@ -56,6 +56,9 @@ public class InboundService {
     }
 
     private static boolean isInboundStatus(PurchaseOrderStatus s) {
-        return s == PurchaseOrderStatus.DELIVERED || s == PurchaseOrderStatus.COMPLETED;
+        return s == PurchaseOrderStatus.READY_TO_SHIP
+                || s == PurchaseOrderStatus.IN_TRANSIT
+                || s == PurchaseOrderStatus.ARRIVED
+                || s == PurchaseOrderStatus.COMPLETED;
     }
 }

--- a/src/main/resources/sql/migration-purchase-order-status-2026-05-06.sql
+++ b/src/main/resources/sql/migration-purchase-order-status-2026-05-06.sql
@@ -15,7 +15,16 @@
 -- READY_TO_SHIP 단계는 신규 — 기존 row 의 history 에는 존재하지 않음 (정상).
 --
 -- 적용 순서: BE 서버 중지 → 본 SQL 실행 → BE 재시작.
--- ddl-auto: update 라 enum 컬럼 길이(VARCHAR(16)) 변경 불필요 — 신규 enum 값 모두 16자 안.
+--
+-- 주의: Hibernate 가 ddl-auto: update 모드에서 처음 테이블 생성 시 status 컬럼을
+-- MariaDB ENUM 타입으로 만들어두면 신규 enum 값 추가 시 ddl-auto 가 갱신 안 한다.
+-- 따라서 먼저 VARCHAR(32) 로 전환한 뒤 UPDATE 로 값 매핑.
+
+-- 1) 컬럼을 VARCHAR(32) 로 전환 (ENUM 타입이었던 경우 신규 값 허용)
+ALTER TABLE purchase_order                 MODIFY COLUMN status VARCHAR(32) NOT NULL;
+ALTER TABLE purchase_order_status_history  MODIFY COLUMN status VARCHAR(32) NOT NULL;
+
+-- 2) 옛 enum 값 → 신규 매핑
 
 -- purchase_order 테이블
 UPDATE purchase_order SET status = 'REQUESTED'  WHERE status = 'PENDING';

--- a/src/main/resources/sql/migration-purchase-order-status-2026-05-06.sql
+++ b/src/main/resources/sql/migration-purchase-order-status-2026-05-06.sql
@@ -1,0 +1,30 @@
+-- 발주 상태머신 7단계 확장 마이그레이션 (2026-05-06)
+--
+-- 변경 이유: 기존 6단계(PENDING/APPROVED/SHIPPING/DELIVERED/COMPLETED/REJECTED) 를
+-- 7단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED/CANCELLED) 로 확장.
+-- enum 값 rename + 신규 단계(READY_TO_SHIP) 추가.
+--
+-- 매핑:
+--   PENDING   → REQUESTED
+--   APPROVED  → APPROVED   (그대로)
+--   SHIPPING  → IN_TRANSIT
+--   DELIVERED → ARRIVED
+--   COMPLETED → COMPLETED  (그대로)
+--   REJECTED  → CANCELLED
+--
+-- READY_TO_SHIP 단계는 신규 — 기존 row 의 history 에는 존재하지 않음 (정상).
+--
+-- 적용 순서: BE 서버 중지 → 본 SQL 실행 → BE 재시작.
+-- ddl-auto: update 라 enum 컬럼 길이(VARCHAR(16)) 변경 불필요 — 신규 enum 값 모두 16자 안.
+
+-- purchase_order 테이블
+UPDATE purchase_order SET status = 'REQUESTED'  WHERE status = 'PENDING';
+UPDATE purchase_order SET status = 'IN_TRANSIT' WHERE status = 'SHIPPING';
+UPDATE purchase_order SET status = 'ARRIVED'    WHERE status = 'DELIVERED';
+UPDATE purchase_order SET status = 'CANCELLED'  WHERE status = 'REJECTED';
+
+-- purchase_order_status_history 테이블
+UPDATE purchase_order_status_history SET status = 'REQUESTED'  WHERE status = 'PENDING';
+UPDATE purchase_order_status_history SET status = 'IN_TRANSIT' WHERE status = 'SHIPPING';
+UPDATE purchase_order_status_history SET status = 'ARRIVED'    WHERE status = 'DELIVERED';
+UPDATE purchase_order_status_history SET status = 'CANCELLED'  WHERE status = 'REJECTED';


### PR DESCRIPTION
## 📌 요약
- 본사 발주 코드를 `PO-{YYYYMMDD}-{NNN}` (3자리) → `PO-{YYYYMMDD}-{NNNNN}` (5자리) 로 확장하고, 상태머신을 6단계 → 7단계(REQUESTED/APPROVED/READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED/CANCELLED) 로 확장한다. 거래처 책임 단계가 1개 늘어 SYS-001 자동 전환이 3단계 → 4단계가 됐다.

<br><br>

## 🎯 작업 내용
- `PurchaseOrderStatus` enum 7값 + `PurchaseOrder` 의 markXxx 메소드 6개(rename/추가) + 빌더 초기 상태 + recalculate/updateLogistics 가드 갱신 (PENDING → REQUESTED).
- `PurchaseOrderService`: `generateCode` 5자리, `appendHistory` 의 거래처 스냅샷 4단계 + 인증 사용자 3단계 분기, approve/readyToShip/startInTransit/arrive/complete/cancel 메소드 정리. 인벤토리 hook (PR #173) 의 가용재고 + 시점은 `markInTransit` (구 SHIPPING 의미적 후신).
- `PurchaseOrderBatchService.run` 4단계 자동 전환 + `BatchResult` record 4 카운트 (approved/readyToShip/inTransit/arrived).
- `InboundService.isInboundStatus` 4상태 (READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED), `DashboardService.scheduledCount` = READY_TO_SHIP+IN_TRANSIT+ARRIVED 합산.
- DB 마이그레이션 SQL 신규 (`sql/migration-purchase-order-status-2026-05-06.sql`) — ALTER COLUMN VARCHAR(32) + 옛 enum 값 UPDATE 매핑. Hibernate 가 ENUM 타입으로 잡아둔 컬럼을 신규 enum 값을 박을 때 truncate 되는 문제까지 함께 해결.

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
