### PR TITLE
refactor(auth): 인증 사용자 기반 4지점 마이그레이션 + actor 라벨 강화

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -332,7 +332,7 @@ public class PurchaseOrderService {
                 if (me == null) {
                     throw BaseException.from(BaseResponseStatus.NOT_AUTHENTICATED);
                 }
-                yield me.getName();
+                yield me.getName() + " (" + me.getLocationName() + ")";
             }
         };
         PurchaseOrderStatusHistory entry = PurchaseOrderStatusHistory.builder()

--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardController.java
@@ -2,8 +2,10 @@ package org.example.stockitbe.warehouse.dashboard;
 
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.user.model.AuthUserDetails;
 import org.example.stockitbe.warehouse.dashboard.model.DashboardDto;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,9 +16,9 @@ import java.time.LocalDate;
 /**
  * WHS-001 입고 진행률 — 창고 관리자 대시보드 컨트롤러.
  *
- * 권한군 prefix: /api/warehouse/dashboard/...
- * 인증 미정(ADR-011) 이라 warehouseId 는 옵셔널 query 파라미터.
- * 인증 도입 시 @AuthenticationPrincipal 로 me.warehouseId 자동 주입으로 마이그레이션.
+ * 권한군 prefix: /api/warehouse/dashboard/...  (SecurityConfig 가 hasRole("WAREHOUSE") 자동 차단)
+ * 자기 창고 데이터 격리 — 인증 사용자의 locationCode 만 신뢰. query param 으로 warehouseId
+ * 받지 않음 (위변조 방지).
  */
 @RestController
 @RequestMapping("/api/warehouse/dashboard")
@@ -27,9 +29,9 @@ public class DashboardController {
 
     @GetMapping("/inbound-progress")
     public BaseResponse<DashboardDto.InboundProgressRes> getInboundProgress(
-            @RequestParam(required = false) Long warehouseId,
+            @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
-        return BaseResponse.success(service.getInboundProgress(warehouseId, from, to));
+        return BaseResponse.success(service.getInboundProgress(me.getLocationCode(), from, to));
     }
 }

--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
@@ -2,6 +2,10 @@ package org.example.stockitbe.warehouse.dashboard;
 
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.purchaseorder.PurchaseOrderRepository;
 import org.example.stockitbe.hq.purchaseorder.PurchaseOrderStatusHistoryRepository;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
@@ -28,7 +32,8 @@ import java.util.stream.Collectors;
  * 집계 대상은 `purchase_order` + `purchase_order_status_history` 단일 진실 원천 (ADR-015).
  * 별 테이블·Entity 신설 없이 read-only 활용만 한다.
  *
- * 인증 미정(ADR-011) 으로 warehouseId 는 옵셔널 query 파라미터.
+ * 인증 사용자의 locationCode 를 받아 자기 창고 row 만 집계. Long warehouseId 는
+ * Infrastructure lookup 한 번에 격리되어 기존 Specification 로직 변경 없음.
  */
 @Service
 @RequiredArgsConstructor
@@ -36,10 +41,15 @@ public class DashboardService {
 
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final PurchaseOrderStatusHistoryRepository historyRepository;
+    private final InfrastructureRepository infrastructureRepository;
 
     @Transactional(readOnly = true)
-    public DashboardDto.InboundProgressRes getInboundProgress(Long warehouseId,
+    public DashboardDto.InboundProgressRes getInboundProgress(String locationCode,
                                                                 LocalDate from, LocalDate to) {
+        Long warehouseId = infrastructureRepository
+                .findByCodeAndLocationType(locationCode, LocationType.WAREHOUSE)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND))
+                .getId();
         Specification<PurchaseOrder> spec = buildSpec(warehouseId, from, to);
         List<PurchaseOrder> orders = purchaseOrderRepository.findAll(spec);
 

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundController.java
@@ -20,9 +20,9 @@ import java.util.List;
 /**
  * WHS-005/007/008 — 창고 관리자 입고 컨트롤러.
  *
- * 권한군 prefix: /api/warehouse/...
- * 인증 미정(ADR-011) 이라 warehouseId 는 query 파라미터로 받음 — 임시 신뢰 모델.
- * 인증 도입 시 @AuthenticationPrincipal 로 me.warehouseId 자동 주입으로 마이그레이션.
+ * 권한군 prefix: /api/warehouse/...  (SecurityConfig 가 hasRole("WAREHOUSE") 자동 차단)
+ * 자기 창고 데이터 격리 — 인증 사용자의 locationCode 만 신뢰. query param 으로 warehouseId
+ * 받지 않음 (위변조 방지). detail 도 @AuthenticationPrincipal 받아 다른 창고 발주 직접 URL 접근 차단.
  */
 @RestController
 @RequestMapping("/api/warehouse/inbound")
@@ -33,16 +33,18 @@ public class InboundController {
 
     @GetMapping
     public BaseResponse<List<PurchaseOrderDto.ListRes>> list(
+            @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) PurchaseOrderStatus status,
-            @RequestParam(required = false) Long warehouseId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
-        return BaseResponse.success(service.findAll(status, warehouseId, from, to));
+        return BaseResponse.success(service.findAll(me.getLocationCode(), status, from, to));
     }
 
     @GetMapping("/{code}")
-    public BaseResponse<PurchaseOrderDto.DetailRes> detail(@PathVariable String code) {
-        return BaseResponse.success(service.findByCode(code));
+    public BaseResponse<PurchaseOrderDto.DetailRes> detail(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String code) {
+        return BaseResponse.success(service.findByCode(code, me.getLocationCode()));
     }
 
     @PostMapping("/{code}/confirm")

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/InboundService.java
@@ -1,6 +1,10 @@
 package org.example.stockitbe.warehouse.inbound;
 
 import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.purchaseorder.PurchaseOrderService;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
@@ -16,12 +20,16 @@ import java.util.List;
  *
  * 별 테이블 만들지 않고 PurchaseOrder + statusHistory 단일 진실 원천 활용 (ADR-015).
  * PurchaseOrderService 메소드를 위임 호출만 한다.
+ *
+ * 인증 사용자의 locationCode 를 받아 자기 창고 row 만 노출 — 다른 창고 발주 직접 URL
+ * 접근 시 PURCHASE_ORDER_NOT_FOUND 으로 차단.
  */
 @Service
 @RequiredArgsConstructor
 public class InboundService {
 
     private final PurchaseOrderService purchaseOrderService;
+    private final InfrastructureRepository infrastructureRepository;
 
     /**
      * 입고 목록 — 창고 관심사는 READY_TO_SHIP/IN_TRANSIT/ARRIVED/COMPLETED 4상태.
@@ -29,21 +37,31 @@ public class InboundService {
      * status 미지정 시 4상태 모두, 지정 시 그 status 만 (4상태 외엔 빈 결과).
      */
     @Transactional(readOnly = true)
-    public List<PurchaseOrderDto.ListRes> findAll(PurchaseOrderStatus status,
-                                                    Long warehouseId,
+    public List<PurchaseOrderDto.ListRes> findAll(String locationCode,
+                                                    PurchaseOrderStatus status,
                                                     LocalDate from, LocalDate to) {
+        Long warehouseId = resolveWarehouseId(locationCode);
         // PurchaseOrderService.findAll 의 시그니처: (vendorCode, status, from, to).
         // vendorCode 는 창고 관심사 아니므로 null. status 가 비-입고 상태면 isInboundStatus 필터로 빈 결과 보장.
         List<PurchaseOrderDto.ListRes> all = purchaseOrderService.findAll(null, status, from, to);
         return all.stream()
                 .filter(po -> isInboundStatus(po.getStatus()))
-                .filter(po -> warehouseId == null || warehouseId.equals(po.getWarehouseId()))
+                .filter(po -> warehouseId.equals(po.getWarehouseId()))
                 .toList();
     }
 
+    /**
+     * 입고 상세 — 자기 창고 발주만 조회 가능. 다른 창고 코드로 직접 URL 접근하면
+     * PURCHASE_ORDER_NOT_FOUND 으로 차단 (창고 존재 사실 노출 회피).
+     */
     @Transactional(readOnly = true)
-    public PurchaseOrderDto.DetailRes findByCode(String code) {
-        return purchaseOrderService.findByCode(code);
+    public PurchaseOrderDto.DetailRes findByCode(String code, String locationCode) {
+        Long warehouseId = resolveWarehouseId(locationCode);
+        PurchaseOrderDto.DetailRes detail = purchaseOrderService.findByCode(code);
+        if (!warehouseId.equals(detail.getWarehouseId())) {
+            throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_NOT_FOUND);
+        }
+        return detail;
     }
 
     /**
@@ -53,6 +71,13 @@ public class InboundService {
      */
     public PurchaseOrderDto.DetailRes confirm(String code, AuthUserDetails me) {
         return purchaseOrderService.complete(code, me);
+    }
+
+    private Long resolveWarehouseId(String locationCode) {
+        return infrastructureRepository
+                .findByCodeAndLocationType(locationCode, LocationType.WAREHOUSE)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND))
+                .getId();
     }
 
     private static boolean isInboundStatus(PurchaseOrderStatus s) {


### PR DESCRIPTION
## 📌 요약
- 인증 도입 후에도 임시 가드(query param `warehouseId`)로 남아 있던 본인 영역 2지점을 `@AuthenticationPrincipal` 로 마이그레이션. `appendHistory` 의 매뉴얼 단계 actor 라벨도 본사/창고 구분 가능한 `"이름 (지점명)"` 형태로 강화

<br><br>

## 🎯 작업 내용
- `DashboardController.inbound-progress` / `InboundController.list,detail` — `@RequestParam Long warehouseId` 제거 + `@AuthenticationPrincipal AuthUserDetails me` 추가
- `DashboardService.getInboundProgress` / `InboundService.findAll,findByCode` 시그니처 `Long` → `String locationCode` 전환 + `infrastructureRepository.findByCodeAndLocationType(.., LocationType.WAREHOUSE).getId()` lookup
- `InboundService.findByCode` 에 자기 창고 발주 검증 추가 — 다른 창고 코드로 직접 URL 접근 시 `PURCHASE_ORDER_NOT_FOUND` 차단 (창고 존재 사실 노출 회피)
- `PurchaseOrderService.appendHistory` 의 `case REQUESTED, COMPLETED, CANCELLED` 분기에서 `me.getName() + " (" + me.getLocationName() + ")"` 라벨 강화 — 본사 회원가입 시 `locationName="본사"` 박혀 있으면 `"홍본사 (본사)" / "박창고 (서울1창고)"` 자동 박힘

<br><br>

## ✔️ 참고 사항
- query param actor 패턴 폐기 — 결합 차단 4패턴 중 ② 임시 패턴 졸업 (위변조 가능성 폐쇄)
- 본인 도메인 schema 변경 0 — `purchase_order.warehouse_id` Long FK 그대로, 변환은 `infrastructureRepository.findByCodeAndLocationType` 한 곳에 격리
- 수동 시연 6 케이스: 본사 계정 발주 작성 / 창고 계정 입고 확정 / 403 차단 / 자기 창고 격리 / SYS-001 배치 actor 보존 / 위변조 차단 — FE PR #397 머지 후 통합 시연

<br><br>

## ✔️ 관련 이슈

- Close #189

<br><br>
