### PR TITLE
feat: 로그인 매장 기준 재고 조회 API 추가 및 품목코드 PRD 기준 통일

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+    List<Inventory> findAllByLocationId(Long locationId);
     List<Inventory> findAllBySkuIdIn(Collection<Long> skuIds);
     List<Inventory> findAllByInventoryStatus(InventoryStatus inventoryStatus);
 

--- a/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryController.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryController.java
@@ -1,0 +1,36 @@
+package org.example.stockitbe.store.inventory;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.store.inventory.model.StoreInventoryDto;
+import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/store/inventories")
+public class StoreInventoryController {
+
+    private final StoreInventoryService service;
+
+    @GetMapping
+    public BaseResponse<List<StoreInventoryDto.ItemRes>> getStoreInventories(
+            @AuthenticationPrincipal AuthUserDetails me
+    ) {
+        return BaseResponse.success(service.getItems(me.getLocationCode()));
+    }
+
+    @GetMapping("/{itemCode}/skus")
+    public BaseResponse<List<StoreInventoryDto.SkuRes>> getStoreInventorySkus(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String itemCode
+    ) {
+        return BaseResponse.success(service.getItemSkus(me.getLocationCode(), itemCode));
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryService.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryService.java
@@ -1,0 +1,209 @@
+package org.example.stockitbe.store.inventory;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.category.CategoryRepository;
+import org.example.stockitbe.hq.category.model.Category;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.InventoryRepository;
+import org.example.stockitbe.hq.inventory.model.Inventory;
+import org.example.stockitbe.hq.product.ProductMasterRepository;
+import org.example.stockitbe.hq.product.ProductSkuRepository;
+import org.example.stockitbe.hq.product.model.ProductMaster;
+import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.store.inventory.model.StoreInventoryDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StoreInventoryService {
+
+    private final InfrastructureRepository infrastructureRepository;
+    private final InventoryRepository inventoryRepository;
+    private final ProductSkuRepository productSkuRepository;
+    private final ProductMasterRepository productMasterRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<StoreInventoryDto.ItemRes> getItems(String locationCode) {
+        Infrastructure store = resolveStore(locationCode);
+        List<Inventory> inventories = inventoryRepository.findAllByLocationId(store.getId());
+        if (inventories.isEmpty()) {
+            return List.of();
+        }
+
+        Context context = buildContext(inventories);
+        Map<String, ItemAccumulator> grouped = new HashMap<>();
+
+        for (Inventory inventory : inventories) {
+            ProductSku sku = context.skuById.get(inventory.getSkuId());
+            if (sku == null) continue;
+
+            ProductMaster master = context.masterByCode.get(sku.getProductCode());
+            if (master == null) continue;
+
+            Category child = context.categoryByCode.get(master.getCategoryCode());
+            if (child == null) continue;
+
+            Category parent = child.getParentId() == null ? child : context.categoryById.get(child.getParentId());
+            String parentCategory = parent == null ? child.getName() : parent.getName();
+            String childCategory = child.getName();
+            String itemCode = master.getCode();
+
+            ItemAccumulator acc = grouped.computeIfAbsent(itemCode, key -> ItemAccumulator.builder()
+                    .itemCode(itemCode)
+                    .parentCategory(parentCategory)
+                    .childCategory(childCategory)
+                    .itemName(master.getName())
+                    .actualStock(0)
+                    .availableStock(0)
+                    .safetyStock(0)
+                    .updatedAt(inventory.getUpdatedAt())
+                    .build());
+
+            acc.actualStock += n(inventory.getQuantity());
+            acc.availableStock += n(inventory.getAvailableQuantity());
+            acc.safetyStock += n(master.getStoreSafetyStock());
+            if (acc.updatedAt == null || (inventory.getUpdatedAt() != null && inventory.getUpdatedAt().after(acc.updatedAt))) {
+                acc.updatedAt = inventory.getUpdatedAt();
+            }
+        }
+
+        return grouped.values().stream()
+                .map(acc -> StoreInventoryDto.ItemRes.builder()
+                        .itemCode(acc.itemCode)
+                        .parentCategory(acc.parentCategory)
+                        .childCategory(acc.childCategory)
+                        .itemName(acc.itemName)
+                        .actualStock(acc.actualStock)
+                        .availableStock(acc.availableStock)
+                        .safetyStock(acc.safetyStock)
+                        .status(resolveStatus(acc.actualStock, acc.safetyStock))
+                        .updatedAt(acc.updatedAt)
+                        .build())
+                .sorted(Comparator
+                        .comparing(StoreInventoryDto.ItemRes::getParentCategory, this::compareMainCategory)
+                        .thenComparing(StoreInventoryDto.ItemRes::getChildCategory, Comparator.nullsLast(String::compareTo))
+                        .thenComparing(StoreInventoryDto.ItemRes::getItemName, Comparator.nullsLast(String::compareTo)))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoreInventoryDto.SkuRes> getItemSkus(String locationCode, String itemCode) {
+        Infrastructure store = resolveStore(locationCode);
+        List<Inventory> inventories = inventoryRepository.findAllByLocationId(store.getId());
+        if (inventories.isEmpty()) {
+            return List.of();
+        }
+
+        Context context = buildContext(inventories);
+
+        return inventories.stream()
+                .map(inventory -> toSkuRes(inventory, itemCode, context))
+                .filter(Objects::nonNull)
+                .sorted(Comparator
+                        .comparing(StoreInventoryDto.SkuRes::getColor, Comparator.nullsLast(String::compareTo))
+                        .thenComparing(StoreInventoryDto.SkuRes::getSize, Comparator.nullsLast(String::compareTo)))
+                .toList();
+    }
+
+    private StoreInventoryDto.SkuRes toSkuRes(Inventory inventory, String itemCode, Context context) {
+        ProductSku sku = context.skuById.get(inventory.getSkuId());
+        if (sku == null) return null;
+
+        ProductMaster master = context.masterByCode.get(sku.getProductCode());
+        if (master == null) return null;
+
+        Category child = context.categoryByCode.get(master.getCategoryCode());
+        if (child == null) return null;
+
+        Category parent = child.getParentId() == null ? child : context.categoryById.get(child.getParentId());
+        String resolvedItemCode = master.getCode();
+
+        if (!Objects.equals(resolvedItemCode, itemCode)) {
+            return null;
+        }
+
+        int actual = n(inventory.getQuantity());
+        int safety = n(master.getStoreSafetyStock());
+        return StoreInventoryDto.SkuRes.builder()
+                .skuCode(sku.getSkuCode())
+                .color(sku.getColor())
+                .size(sku.getSize())
+                .actualStock(actual)
+                .availableStock(n(inventory.getAvailableQuantity()))
+                .safetyStock(safety)
+                .status(resolveStatus(actual, safety))
+                .updatedAt(inventory.getUpdatedAt())
+                .build();
+    }
+
+    private Context buildContext(List<Inventory> inventories) {
+        Set<Long> skuIds = inventories.stream().map(Inventory::getSkuId).collect(Collectors.toSet());
+        Map<Long, ProductSku> skuById = productSkuRepository.findAllById(skuIds).stream()
+                .collect(Collectors.toMap(ProductSku::getId, sku -> sku));
+
+        Set<String> productCodes = skuById.values().stream().map(ProductSku::getProductCode).collect(Collectors.toSet());
+        Map<String, ProductMaster> masterByCode = productMasterRepository.findAllByCodeIn(productCodes).stream()
+                .collect(Collectors.toMap(ProductMaster::getCode, master -> master));
+
+        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
+        Map<Long, Category> categoryById = categories.stream().collect(Collectors.toMap(Category::getId, c -> c));
+        Map<String, Category> categoryByCode = categories.stream().collect(Collectors.toMap(Category::getCode, c -> c));
+
+        return new Context(skuById, masterByCode, categoryById, categoryByCode);
+    }
+
+    private Infrastructure resolveStore(String locationCode) {
+        return infrastructureRepository.findByCodeAndLocationType(locationCode, LocationType.STORE)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_SALE_STORE_NOT_FOUND));
+    }
+
+    private String resolveStatus(int actual, int safety) {
+        if (actual == 0) return "품절";
+        if (actual <= safety) return "부족";
+        return "정상";
+    }
+
+    private int compareMainCategory(String a, String b) {
+        List<String> order = List.of("상의", "바지", "치마", "아우터");
+        int ai = order.indexOf(a);
+        int bi = order.indexOf(b);
+        ai = ai < 0 ? order.size() : ai;
+        bi = bi < 0 ? order.size() : bi;
+        if (ai != bi) return Integer.compare(ai, bi);
+        return String.valueOf(a).compareTo(String.valueOf(b));
+    }
+
+    private int n(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private record Context(
+            Map<Long, ProductSku> skuById,
+            Map<String, ProductMaster> masterByCode,
+            Map<Long, Category> categoryById,
+            Map<String, Category> categoryByCode
+    ) {
+    }
+
+    @Builder
+    private static class ItemAccumulator {
+        private String itemCode;
+        private String parentCategory;
+        private String childCategory;
+        private String itemName;
+        private int actualStock;
+        private int availableStock;
+        private int safetyStock;
+        private Date updatedAt;
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/inventory/model/StoreInventoryDto.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/model/StoreInventoryDto.java
@@ -1,0 +1,36 @@
+package org.example.stockitbe.store.inventory.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+public class StoreInventoryDto {
+
+    @Getter
+    @Builder
+    public static class ItemRes {
+        private String itemCode;
+        private String parentCategory;
+        private String childCategory;
+        private String itemName;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+        private Date updatedAt;
+    }
+
+    @Getter
+    @Builder
+    public static class SkuRes {
+        private String skuCode;
+        private String color;
+        private String size;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+        private Date updatedAt;
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 로그인한 매장 관리자 기준으로 해당 매장 재고를 조회하는 API를 신설하고, 품목 코드 기준을 `PRD-...`로 통일했습니다.

<br><br>

## 🎯 작업 내용
- 매장 재고 조회 API 추가
  - `GET /api/store/inventories`
  - `GET /api/store/inventories/{itemCode}/skus`
- `@AuthenticationPrincipal`의 `locationCode`로 STORE 인프라 식별 후 해당 매장 재고만 조회하도록 서비스 구현
- `inventory/product_sku/product_master/category` 기반 집계 및 `InventoryRepository` 매장 단위 조회 메서드 추가

<br><br>

## ✔️ 참고 사항
- 매장 재고 `itemCode`를 화면용 변환 코드가 아닌 `product_master.code(PRD-...)` 기준으로 통일했습니다.
- 컴파일 검증 완료: `bash gradlew clean compileJava` / `bash gradlew compileJava`

<br><br>

## ✔️ 관련 이슈

- Close #191

<br><br>
