### PR TITLE
refactor: 매장 로그인 사용자는 자기 매장 데이터만 보이도록 판매/발주 api 수정

### DIFF
--- a/docs/codex/store/01-plan/매장_범위강제_백엔드_리팩토링_계획.md
+++ b/docs/codex/store/01-plan/매장_범위강제_백엔드_리팩토링_계획.md
@@ -1,0 +1,43 @@
+# 매장 범위 강제 백엔드 리팩토링 계획 (storeCode 제거)
+
+## 1. 목표
+- 매장 판매/발주 API를 로그인 사용자 컨텍스트 기준으로만 동작하게 변경한다.
+- 기존 임시 입력 필드(`storeCode`, `storeLocationId`) 의존을 제거한다.
+- 타 매장 접근 시 전용 에러코드를 반환한다.
+
+## 2. 적용 범위
+- 판매: `StoreSaleController`, `StoreSaleService`, `StoreSaleDto`
+- 발주: `StoreOrderController`, `StoreOrderService`, `StoreOrderDto`
+- 공통 에러코드: `BaseResponseStatus`
+
+## 3. 구현 원칙
+- 컨트롤러는 `@AuthenticationPrincipal AuthUserDetails me`를 주입받는다.
+- 서비스는 `me.locationCode` 기반으로 매장을 조회해 단일 기준으로 사용한다.
+- 요청 바디/쿼리의 매장 식별값은 입력 계약에서 제거한다.
+- 상세/수정/취소/승인은 대상 문서의 `storeId`와 로그인 매장 `storeId`를 반드시 검증한다.
+
+## 4. 세부 변경 계획
+### 4.1 판매 도메인
+- 판매 생성 요청 DTO에서 `storeCode` 제거
+- 판매 생성: 로그인 매장으로 강제
+- 판매 목록: 로그인 매장으로 필터 고정
+- 판매 상세: 소유 매장 불일치 시 차단
+
+### 4.2 발주 도메인
+- 발주 생성 요청 DTO에서 `storeCode`, `storeLocationId` 제거
+- 발주 생성: 로그인 매장 + 매핑 창고로 강제
+- 발주 목록/분석: 로그인 매장으로 필터 고정
+- 발주 상세/수정/취소/승인: 소유 매장 검증 후 처리
+
+### 4.3 에러코드
+- `STORE_SALE_SCOPE_FORBIDDEN` 추가
+- `STORE_ORDER_SCOPE_FORBIDDEN` 추가
+
+## 5. 테스트 기준
+- 생성 계약: `storeCode/storeLocationId` 없이 판매/발주 생성 성공
+- 매장 범위: 타 매장 문서 접근 시 전용 에러코드 반환
+- 정상 흐름: 동일 매장 문서는 기존 동작(재고 반영/상태 전이/이력 적재) 유지
+
+## 6. 가정
+- 로그인 사용자 `locationCode`는 유효한 STORE 코드다.
+- 프론트엔드 호출 계약은 본 변경에 맞춰 후속 반영한다.

--- a/docs/codex/store/02-implementation/매장_범위강제_백엔드_구현내역.md
+++ b/docs/codex/store/02-implementation/매장_범위강제_백엔드_구현내역.md
@@ -1,0 +1,78 @@
+# 매장 범위 강제 백엔드 구현 내역
+
+## 1. 구현 목적
+- 매장 판매/발주 API가 로그인 사용자 매장 컨텍스트 기준으로만 동작하도록 서버 범위 강제를 적용했다.
+- 기존 임시 입력 필드(`storeCode`, `storeLocationId`) 의존을 제거했다.
+- 타 매장 문서 접근 시 전용 에러코드를 반환하도록 처리했다.
+
+## 2. 주요 변경 사항
+
+### 2.1 에러코드 추가
+- 파일: `common/model/BaseResponseStatus.java`
+- 추가 코드
+  - `STORE_SALE_SCOPE_FORBIDDEN (4506)`
+  - `STORE_ORDER_SCOPE_FORBIDDEN (4608)`
+- 메시지
+  - `로그인한 매장 범위를 벗어난 요청입니다.`
+
+### 2.2 판매 도메인 변경
+- 대상 파일
+  - `store/sale/StoreSaleController.java`
+  - `store/sale/StoreSaleService.java`
+  - `store/sale/model/dto/StoreSaleDto.java`
+
+- 변경 내용
+  - 컨트롤러 전 엔드포인트에 `@AuthenticationPrincipal AuthUserDetails me` 주입
+  - 서비스 시그니처 변경
+    - `create(dto)` -> `create(dto, me)`
+    - `findAll(storeCode, from, to, keyword)` -> `findAll(me, from, to, keyword)`
+    - `findDetail(saleNo)` -> `findDetail(saleNo, me)`
+  - 생성 시 요청 바디의 매장값을 사용하지 않고 `me.locationCode`로 매장 강제
+  - 상세 조회 시 문서 소유 매장 검증(`assertOwnedByStore`) 적용
+  - `SaleReq` DTO에서 `storeCode` 필드 제거
+
+### 2.3 발주 도메인 변경
+- 대상 파일
+  - `store/order/StoreOrderController.java`
+  - `store/order/StoreOrderService.java`
+  - `store/order/model/dto/StoreOrderDto.java`
+
+- 변경 내용
+  - 컨트롤러 전 엔드포인트에 `@AuthenticationPrincipal AuthUserDetails me` 주입
+  - 서비스 시그니처 변경
+    - `create(dto)` -> `create(dto, me)`
+    - `update(orderNo, dto)` -> `update(orderNo, dto, me)`
+    - `cancel(orderNo, dto)` -> `cancel(orderNo, dto, me)`
+    - `approve(orderNo, dto)` -> `approve(orderNo, dto, me)`
+    - `list(storeCode, status, from, to, keyword)` -> `list(status, from, to, keyword, me)`
+    - `detail(orderNo)` -> `detail(orderNo, me)`
+    - `analytics(storeCode, from, to)` -> `analytics(from, to, me)`
+  - 생성 시 요청 바디의 매장값 대신 `me.locationCode`로 매장/창고 결정
+  - 상세/수정/취소/승인 시 소유 매장 검증(`getOwnedOrderByOrderNo`) 적용
+  - `CreateReq` DTO에서 `storeCode`, `storeLocationId` 제거
+
+## 3. API 계약 변경 요약
+- 판매 생성 요청: `storeCode` 제거
+- 발주 생성 요청: `storeCode`, `storeLocationId` 제거
+- 판매 목록 쿼리: `storeCode` 제거
+- 발주 목록/분석 쿼리: `storeCode` 제거
+- 공통: 매장 식별은 로그인 컨텍스트(`AuthUserDetails.locationCode`)를 단일 진실원으로 사용
+
+## 4. 보안/정합성 효과
+- 클라이언트에서 매장 코드를 조작해도 서버에서 무시된다.
+- 타 매장 문서번호 직접 접근(상세/수정/취소/승인)이 전용 에러코드로 차단된다.
+- 매장 범위 강제가 판매/발주 전 흐름에 일관 적용된다.
+
+## 5. 수정 파일 목록
+- `src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java`
+- `src/main/java/org/example/stockitbe/store/sale/StoreSaleController.java`
+- `src/main/java/org/example/stockitbe/store/sale/StoreSaleService.java`
+- `src/main/java/org/example/stockitbe/store/sale/model/dto/StoreSaleDto.java`
+- `src/main/java/org/example/stockitbe/store/order/StoreOrderController.java`
+- `src/main/java/org/example/stockitbe/store/order/StoreOrderService.java`
+- `src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java`
+
+## 6. 검증 메모
+- 코드 레벨에서 시그니처/참조 정합성은 반영 완료.
+- 로컬 환경 `JAVA_HOME` 미설정으로 `gradlew compileJava` 실행 검증은 미완료.
+  - 에러: `JAVA_HOME is not set and no 'java' command could be found in your PATH.`

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -90,6 +90,7 @@ public enum BaseResponseStatus {
     STORE_SALE_STORE_NOT_FOUND(false, 4503, "매장 정보를 찾을 수 없습니다."),
     STORE_SALE_SKU_NOT_FOUND(false, 4504, "판매 SKU를 찾을 수 없습니다."),
     STORE_SALE_INSUFFICIENT_STOCK(false, 4505, "재고가 부족하여 판매를 확정할 수 없습니다."),
+    STORE_SALE_SCOPE_FORBIDDEN(false, 4506, "로그인한 매장 범위를 벗어난 요청입니다."),
 
     // 4600번대~ 매장 발주
     STORE_ORDER_NOT_FOUND(false, 4600, "매장 발주를 찾을 수 없습니다."),
@@ -100,6 +101,7 @@ public enum BaseResponseStatus {
     STORE_ORDER_SKU_NOT_FOUND(false, 4605, "발주 SKU를 찾을 수 없습니다."),
     STORE_ORDER_INVALID_STATUS_TRANSITION(false, 4606, "허용되지 않는 발주 상태 전환입니다."),
     STORE_ORDER_CANCEL_REASON_REQUIRED(false, 4607, "발주 취소 사유는 필수입니다."),
+    STORE_ORDER_SCOPE_FORBIDDEN(false, 4608, "로그인한 매장 범위를 벗어난 요청입니다."),
 
     // 4400번대 회원 관리
     USER_NOT_PENDING(false, 4400, "대기 상태인 신청만 처리할 수 있습니다."),

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderController.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.example.stockitbe.user.model.AuthUserDetails;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,10 +21,11 @@ public class StoreOrderController {
 
     // 매장 발주 요청 생성
     @PostMapping
-    public BaseResponse<StoreOrderDto.CreateRes> create(@Valid @RequestBody StoreOrderDto.CreateReq dto) {
+    public BaseResponse<StoreOrderDto.CreateRes> create(@AuthenticationPrincipal AuthUserDetails me,
+                                                         @Valid @RequestBody StoreOrderDto.CreateReq dto) {
         // 1. 요청 수신: 매장 코드, 요청자, 발주 라인 목록을 받는다.
         // 2. 서비스 호출: 발주 헤더/아이템/상태이력 생성 로직을 수행한다.
-        StoreOrderDto.CreateRes result = service.create(dto);
+        StoreOrderDto.CreateRes result = service.create(dto, me);
         // 3. 응답 반환: 생성된 발주 상세를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }
@@ -30,10 +33,11 @@ public class StoreOrderController {
     // 매장 발주 요청 수정 (REQUESTED 상태일 때만 허용)
     @PutMapping("/{orderNo}")
     public BaseResponse<StoreOrderDto.UpdateRes> update(@PathVariable String orderNo,
+                                                         @AuthenticationPrincipal AuthUserDetails me,
                                                          @Valid @RequestBody StoreOrderDto.UpdateReq dto) {
         // 1. 요청 수신: 발주번호와 수정 요청 라인/메모를 받는다.
         // 2. 서비스 호출: 상태 검증 후 아이템 재구성과 합계 재계산을 수행한다.
-        StoreOrderDto.UpdateRes result = service.update(orderNo, dto);
+        StoreOrderDto.UpdateRes result = service.update(orderNo, dto, me);
         // 3. 응답 반환: 수정된 발주 상세를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }
@@ -41,10 +45,11 @@ public class StoreOrderController {
     // 매장 발주 요청 취소 (REQUESTED 상태만 허용)
     @PatchMapping("/{orderNo}/cancel")
     public BaseResponse<StoreOrderDto.CancelRes> cancel(@PathVariable String orderNo,
+                                                         @AuthenticationPrincipal AuthUserDetails me,
                                                          @Valid @RequestBody StoreOrderDto.CancelReq dto) {
         // 1. 요청 수신: 발주번호와 취소 사유를 받는다.
         // 2. 서비스 호출: 상태 검증 후 취소 처리 및 상태이력 적재를 수행한다.
-        StoreOrderDto.CancelRes result = service.cancel(orderNo, dto);
+        StoreOrderDto.CancelRes result = service.cancel(orderNo, dto, me);
         // 3. 응답 반환: 취소 반영된 발주 상세를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }
@@ -52,15 +57,16 @@ public class StoreOrderController {
     // 승인 완료 상태로 변경시 가용 재고에 발주량 반영
     @PatchMapping("/{orderNo}/approve")
     public BaseResponse<StoreOrderDto.ApproveRes> approve(@PathVariable String orderNo,
+                                                           @AuthenticationPrincipal AuthUserDetails me,
                                                            @RequestBody(required = false) StoreOrderDto.ApproveReq dto) {
-        StoreOrderDto.ApproveRes result = service.approve(orderNo, dto == null ? StoreOrderDto.ApproveReq.builder().build() : dto);
+        StoreOrderDto.ApproveRes result = service.approve(orderNo, dto == null ? StoreOrderDto.ApproveReq.builder().build() : dto, me);
         return BaseResponse.success(result);
     }
 
     // 매장 발주 내역 목록 조회
     @GetMapping
     public BaseResponse<List<StoreOrderDto.ListRes>> list(
-            @RequestParam(required = false) String storeCode,
+            @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
@@ -68,17 +74,18 @@ public class StoreOrderController {
     ) {
         // 1. 요청 수신: 매장/상태/기간/키워드 필터를 받는다.
         // 2. 서비스 호출: 필터 조건에 맞는 발주 내역 목록을 조회한다.
-        List<StoreOrderDto.ListRes> result = service.list(storeCode, status, from, to, keyword);
+        List<StoreOrderDto.ListRes> result = service.list(status, from, to, keyword, me);
         // 3. 응답 반환: 목록 데이터를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }
 
     // 매장 발주 상세 조회
     @GetMapping("/{orderNo}")
-    public BaseResponse<StoreOrderDto.DetailRes> detail(@PathVariable String orderNo) {
+    public BaseResponse<StoreOrderDto.DetailRes> detail(@PathVariable String orderNo,
+                                                         @AuthenticationPrincipal AuthUserDetails me) {
         // 1. 요청 수신: 발주번호를 경로 변수로 받는다.
         // 2. 서비스 호출: 헤더/아이템/상태이력을 포함한 상세를 조회한다.
-        StoreOrderDto.DetailRes result = service.detail(orderNo);
+        StoreOrderDto.DetailRes result = service.detail(orderNo, me);
         // 3. 응답 반환: 상세 데이터를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }
@@ -86,13 +93,13 @@ public class StoreOrderController {
     // 매장 발주 분석 조회
     @GetMapping("/analytics")
     public BaseResponse<StoreOrderDto.AnalyticsRes> analytics(
-            @RequestParam(required = false) String storeCode,
+            @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
     ) {
         // 1. 요청 수신: 매장/기간 필터를 받는다.
         // 2. 서비스 호출: 발주 집계 및 SKU/카테고리 분석 데이터를 계산한다.
-        StoreOrderDto.AnalyticsRes result = service.analytics(storeCode, from, to);
+        StoreOrderDto.AnalyticsRes result = service.analytics(from, to, me);
         // 3. 응답 반환: 분석 결과를 공통 응답 포맷으로 반환한다.
         return BaseResponse.success(result);
     }

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -24,6 +24,7 @@ import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
 import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
 import org.example.stockitbe.store.order.model.entity.StoreOrderItem;
 import org.example.stockitbe.store.order.model.entity.StoreOrderStatusHistory;
+import org.example.stockitbe.user.model.AuthUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,9 +56,9 @@ public class StoreOrderService {
     @Transactional
     // 매장 발주를 신규 생성한다.
     // 라인 검증, 매장/창고 조회, 헤더·라인 저장, 상태 이력 기록을 순차적으로 수행한다.
-    public StoreOrderDto.CreateRes create(StoreOrderDto.CreateReq dto) {
+    public StoreOrderDto.CreateRes create(StoreOrderDto.CreateReq dto, AuthUserDetails me) {
         validateCreateItems(dto.getItems());
-        Infrastructure store = lookupStore(dto.getStoreCode());
+        Infrastructure store = resolveStore(me);
         Infrastructure warehouse = lookupWarehouseFromStore(store);
         Date now = new Date();
 
@@ -75,9 +76,10 @@ public class StoreOrderService {
     @Transactional
     // 수정 가능한 발주를 업데이트한다.
     // 헤더 합계를 재계산하고 상세 라인을 전체 교체한 뒤 이력을 남긴다.
-    public StoreOrderDto.UpdateRes update(String orderNo, StoreOrderDto.UpdateReq dto) {
+    public StoreOrderDto.UpdateRes update(String orderNo, StoreOrderDto.UpdateReq dto, AuthUserDetails me) {
         validateUpdateItems(dto.getItems());
-        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        Infrastructure store = resolveStore(me);
+        StoreOrderHeader header = getOwnedOrderByOrderNo(orderNo, store.getId());
         Date now = new Date();
 
         header.updateRequested(
@@ -98,8 +100,9 @@ public class StoreOrderService {
     @Transactional
     // 발주를 취소한다.
     // 추적을 위해 취소 사유는 필수로 검증한다.
-    public StoreOrderDto.CancelRes cancel(String orderNo, StoreOrderDto.CancelReq dto) {
-        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+    public StoreOrderDto.CancelRes cancel(String orderNo, StoreOrderDto.CancelReq dto, AuthUserDetails me) {
+        Infrastructure store = resolveStore(me);
+        StoreOrderHeader header = getOwnedOrderByOrderNo(orderNo, store.getId());
         String cancelReason = trimToNull(dto.getCancelReason());
         if (cancelReason == null) throw BaseException.from(BaseResponseStatus.STORE_ORDER_CANCEL_REASON_REQUIRED);
 
@@ -111,8 +114,9 @@ public class StoreOrderService {
     }
 
     @Transactional
-    public StoreOrderDto.ApproveRes approve(String orderNo, StoreOrderDto.ApproveReq dto) {
-        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+    public StoreOrderDto.ApproveRes approve(String orderNo, StoreOrderDto.ApproveReq dto, AuthUserDetails me) {
+        Infrastructure store = resolveStore(me);
+        StoreOrderHeader header = getOwnedOrderByOrderNo(orderNo, store.getId());
         Date now = new Date();
 
         header.markApproved();
@@ -137,8 +141,9 @@ public class StoreOrderService {
     @Transactional(readOnly = true)
     // 발주 목록을 조회한다.
     // 매장/상태/기간/키워드 필터를 적용한다.
-    public List<StoreOrderDto.ListRes> list(String storeCode, String status, LocalDate from, LocalDate to, String keyword) {
-        Long storeIdFilter = (storeCode == null || storeCode.isBlank()) ? null : lookupStore(storeCode).getId();
+    public List<StoreOrderDto.ListRes> list(String status, LocalDate from, LocalDate to, String keyword, AuthUserDetails me) {
+        Infrastructure store = resolveStore(me);
+        Long storeIdFilter = store.getId();
         String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
         Date fromDate = from == null ? null : Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
         Date toDateExclusive = to == null ? null : Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
@@ -155,11 +160,11 @@ public class StoreOrderService {
             if (!matchesHeaderFilter(header, storeIdFilter, statusFilter, fromDate, toDateExclusive)) continue;
             List<StoreOrderItem> items = itemsByHeader.getOrDefault(header.getId(), List.of());
             if (!matchesKeyword(header, items, safeKeyword)) continue;
-            Infrastructure store = storeById.get(header.getStoreId());
+            Infrastructure headerStore = storeById.get(header.getStoreId());
             result.add(StoreOrderDto.ListRes.from(
                     header,
-                    store == null ? "" : store.getCode(),
-                    store == null ? "" : store.getName(),
+                    headerStore == null ? "" : headerStore.getCode(),
+                    headerStore == null ? "" : headerStore.getName(),
                     buildHeadline(items)
             ));
         }
@@ -170,16 +175,17 @@ public class StoreOrderService {
     @Transactional(readOnly = true)
     // 발주 상세를 조회한다.
     // 헤더, 아이템, 상태 이력을 결합해 응답한다.
-    public StoreOrderDto.DetailRes detail(String orderNo) {
-        return StoreOrderDto.DetailRes.from(buildCreateRes(getOrderByOrderNo(orderNo)));
+    public StoreOrderDto.DetailRes detail(String orderNo, AuthUserDetails me) {
+        Infrastructure store = resolveStore(me);
+        return StoreOrderDto.DetailRes.from(buildCreateRes(getOwnedOrderByOrderNo(orderNo, store.getId())));
     }
 
     // 매장 발주 분석 조회
     @Transactional(readOnly = true)
     // 발주 분석 데이터를 조회한다.
     // 상태별 건수, 상위 SKU, 카테고리 분포를 집계한다.
-    public StoreOrderDto.AnalyticsRes analytics(String storeCode, LocalDate from, LocalDate to) {
-        List<StoreOrderDto.ListRes> orders = list(storeCode, null, from, to, null);
+    public StoreOrderDto.AnalyticsRes analytics(LocalDate from, LocalDate to, AuthUserDetails me) {
+        List<StoreOrderDto.ListRes> orders = list(null, from, to, null, me);
         List<StoreOrderHeader> headers = orders.stream().map(o -> getOrderByOrderNo(o.getOrderId())).toList();
         Map<Long, List<StoreOrderItem>> itemsByHeader = loadItemsByHeader(headers);
 
@@ -277,6 +283,16 @@ public class StoreOrderService {
     private Infrastructure lookupStore(String storeCode) {
         return infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
+    }
+
+    // 사용하는 메서드: create, update, cancel, approve, list, detail, analytics
+    // 로그인 사용자 컨텍스트로 매장을 조회한다.
+    private Infrastructure resolveStore(AuthUserDetails me) {
+        String locationCode = me == null ? null : me.getLocationCode();
+        if (locationCode == null || locationCode.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND);
+        }
+        return lookupStore(locationCode);
     }
 
     // 사용하는 메서드: create
@@ -519,6 +535,16 @@ public class StoreOrderService {
     private StoreOrderHeader getOrderByOrderNo(String orderNo) {
         return headerRepository.findByOrderNo(orderNo)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_NOT_FOUND));
+    }
+
+    // 사용하는 메서드: update, cancel, approve, detail
+    // 주문 소유 매장과 로그인 매장의 일치 여부를 검증한다.
+    private StoreOrderHeader getOwnedOrderByOrderNo(String orderNo, Long actorStoreId) {
+        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        if (!Objects.equals(header.getStoreId(), actorStoreId)) {
+            throw BaseException.from(BaseResponseStatus.STORE_ORDER_SCOPE_FORBIDDEN);
+        }
+        return header;
     }
 
     private String trimToNull(String s) {

--- a/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderDto.java
@@ -27,9 +27,6 @@ public class StoreOrderDto {
     @AllArgsConstructor
     @Builder
     public static class CreateReq {
-        @NotBlank
-        private String storeCode;
-        private String storeLocationId;
         private String requestedByMemberId;
         @NotBlank
         private String requestedByName;

--- a/src/main/java/org/example/stockitbe/store/sale/StoreSaleController.java
+++ b/src/main/java/org/example/stockitbe/store/sale/StoreSaleController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.store.sale.model.dto.StoreSaleDto;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.example.stockitbe.user.model.AuthUserDetails;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -25,32 +27,34 @@ public class StoreSaleController {
 
     // 판매
     @PostMapping
-    public BaseResponse<StoreSaleDto.SaleRes> create(@Valid @RequestBody StoreSaleDto.SaleReq dto) {
+    public BaseResponse<StoreSaleDto.SaleRes> create(@AuthenticationPrincipal AuthUserDetails me,
+                                                     @Valid @RequestBody StoreSaleDto.SaleReq dto) {
         // 판매 생성 요청 DTO를 검증하여 요청을 받음
-        StoreSaleDto.SaleRes result = service.create(dto);
+        StoreSaleDto.SaleRes result = service.create(dto, me);
         return BaseResponse.success(result);
     }
 
     // 판매 내역 목록 조회
     @GetMapping
     public BaseResponse<List<StoreSaleDto.SaleListRes>> list(
-            @RequestParam(required = false) String storeCode,
+            @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
             @RequestParam(required = false) String keyword) {
         // 1. 요청 받기: 매장/기간/키워드 필터 파라미터를 받음
         // 2. 서비스 호출: 조건에 맞는 판매 목록을 조회
-        List<StoreSaleDto.SaleListRes> result = service.findAll(storeCode, from, to, keyword);
+        List<StoreSaleDto.SaleListRes> result = service.findAll(me, from, to, keyword);
         // 3. 응답 반환: 공통 응답 포맷으로 감싸 반환
         return BaseResponse.success(result);
     }
 
     // 판매 내역 상세 조회
     @GetMapping("/{saleNo}")
-    public BaseResponse<StoreSaleDto.SaleDetailRes> detail(@PathVariable String saleNo) {
+    public BaseResponse<StoreSaleDto.SaleDetailRes> detail(@AuthenticationPrincipal AuthUserDetails me,
+                                                           @PathVariable String saleNo) {
         // 1. 요청 받기: 판매번호(saleNo)를 경로 변수로 받음
         // 2. 서비스 호출: 판매 상세를 조회
-        StoreSaleDto.SaleDetailRes result = service.findDetail(saleNo);
+        StoreSaleDto.SaleDetailRes result = service.findDetail(saleNo, me);
         // 3. 응답 반환: 공통 응답 포맷으로 감싸 반환
         return BaseResponse.success(result);
     }

--- a/src/main/java/org/example/stockitbe/store/sale/StoreSaleService.java
+++ b/src/main/java/org/example/stockitbe/store/sale/StoreSaleService.java
@@ -19,6 +19,7 @@ import org.example.stockitbe.hq.product.model.ProductStatus;
 import org.example.stockitbe.store.sale.model.dto.StoreSaleDto;
 import org.example.stockitbe.store.sale.model.entity.StoreSaleHeader;
 import org.example.stockitbe.store.sale.model.entity.StoreSaleItem;
+import org.example.stockitbe.user.model.AuthUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -51,12 +53,12 @@ public class StoreSaleService {
 
     // 판매
     @Transactional
-    public StoreSaleDto.SaleRes create(StoreSaleDto.SaleReq dto) {
+    public StoreSaleDto.SaleRes create(StoreSaleDto.SaleReq dto, AuthUserDetails me) {
         // 1) 요청 데이터(판매 SKU 존재 여부)를 검증한다.
         validateCreateRequest(dto);
 
         // 2) 매장/카테고리 기준 데이터를 조회한다.
-        Infrastructure store = lookupStore(dto.getStoreCode());
+        Infrastructure store = resolveStore(me);
         CategoryLookup categoryLookup = buildCategoryLookup();
 
         // 3) 라인별로 SKU/재고/상품 정보를 조회하고 재고 락 기반 검증을 수행한다.
@@ -81,9 +83,10 @@ public class StoreSaleService {
 
     // 판매 내역 목록 조회
     @Transactional(readOnly = true)
-    public List<StoreSaleDto.SaleListRes> findAll(String storeCode, LocalDate from, LocalDate to, String keyword) {
+    public List<StoreSaleDto.SaleListRes> findAll(AuthUserDetails me, LocalDate from, LocalDate to, String keyword) {
         // 1) 조회 필터(매장/기간/키워드)를 표준 형태로 정리한다.
-        Long storeIdFilter = (storeCode == null || storeCode.isBlank()) ? null : lookupStore(storeCode).getId();
+        Infrastructure store = resolveStore(me);
+        Long storeIdFilter = store.getId();
         String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
         Date fromDate = from == null ? null : Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
         Date toDateExclusive = to == null ? null : Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
@@ -107,10 +110,10 @@ public class StoreSaleService {
                 continue;
             }
 
-            Infrastructure store = storeById.get(header.getStoreId());
+            Infrastructure headerStore = storeById.get(header.getStoreId());
             result.add(StoreSaleDto.SaleListRes.from(
                     header,
-                    store == null ? "" : store.getCode(),
+                    headerStore == null ? "" : headerStore.getCode(),
                     buildHeadline(saleItems)
             ));
         }
@@ -119,10 +122,12 @@ public class StoreSaleService {
 
     // 판매 내역 상세 조회
     @Transactional(readOnly = true)
-    public StoreSaleDto.SaleDetailRes findDetail(String saleNo) {
+    public StoreSaleDto.SaleDetailRes findDetail(String saleNo, AuthUserDetails me) {
         // 1) 판매번호로 판매 헤더를 조회한다.
         StoreSaleHeader header = headerRepository.findBySaleNo(saleNo)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_SALE_NOT_FOUND));
+        Infrastructure store = resolveStore(me);
+        assertOwnedByStore(header.getStoreId(), store.getId());
 
         // 2) 판매 아이템과 매장 코드를 조회한다.
         List<StoreSaleItem> items = itemRepository.findAllBySaleHeaderIdOrderByIdAsc(header.getId());
@@ -154,6 +159,24 @@ public class StoreSaleService {
     private Infrastructure lookupStore(String storeCode) {
         return infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_SALE_STORE_NOT_FOUND));
+    }
+
+    // 사용하는 메서드: create, findAll, findDetail
+    // 로그인 사용자 컨텍스트로 매장을 조회한다.
+    private Infrastructure resolveStore(AuthUserDetails me) {
+        String locationCode = me == null ? null : me.getLocationCode();
+        if (locationCode == null || locationCode.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.STORE_SALE_STORE_NOT_FOUND);
+        }
+        return lookupStore(locationCode);
+    }
+
+    // 사용하는 메서드: findDetail
+    // 판매 데이터의 소유 매장과 로그인 매장의 일치 여부를 검증한다.
+    private void assertOwnedByStore(Long targetStoreId, Long actorStoreId) {
+        if (!Objects.equals(targetStoreId, actorStoreId)) {
+            throw BaseException.from(BaseResponseStatus.STORE_SALE_SCOPE_FORBIDDEN);
+        }
     }
 
     // 사용하는 메서드: create

--- a/src/main/java/org/example/stockitbe/store/sale/model/dto/StoreSaleDto.java
+++ b/src/main/java/org/example/stockitbe/store/sale/model/dto/StoreSaleDto.java
@@ -25,8 +25,6 @@ public class StoreSaleDto {
     @AllArgsConstructor
     @Builder
     public static class SaleReq {
-        @NotBlank
-        private String storeCode;
         @Valid
         @NotEmpty
         private List<SaleLineReq> items;


### PR DESCRIPTION
## 📌 요약
- 판매/발주 API를 `storeCode/storeLocationId` 입력 기반에서 로그인 사용자(`locationCode`) 기반으로 전환
- 매장 데이터 범위를 서버에서 강제하도록 리팩토링

<br><br>

## 🎯 작업 내용
- 판매/발주 컨트롤러 주요 엔드포인트에 `@AuthenticationPrincipal AuthUserDetails me` 적용
- 판매/발주 서비스에서 로그인 사용자 매장(`me.locationCode`)으로 매장 식별 및 소유권 검증 로직 통일
- API 계약 정리:
  - 판매 생성 DTO에서 `storeCode` 제거
  - 발주 생성 DTO에서 `storeCode`, `storeLocationId` 제거
  - 판매/발주 목록/분석 API의 `storeCode` 쿼리 파라미터 제거
- 매장 범위 위반 시 전용 에러코드/메시지 추가 및 적용
- 발주 도메인에서 매장-창고 매핑 조회를 `StoreWarehouseMapRepository.findByStoreAndRole(store, PRIMARY)` 기준으로 정리
- 상태 전이 및 이력(`store_order_status_history`) 기존 동작 유지되도록 회귀 반영

<br><br>

## ✔️ 참고 사항
- FE는 본 PR의 신계약에 맞춰 `storeCode/storeLocationId` 전달 로직 제거가 필요합니다.
- 로그인 사용자 `locationCode`가 유효한 `STORE` 인프라 코드라는 전제가 필요합니다.

<br><br>

## ✔️ 관련 이슈

- Close #193 

<br><br>