### PR TITLE
refactor(warehouse-inbound): JPA 매핑 정석으로 전환 — Header↔Item + Infrastructure @ManyToOne

### DIFF
--- a/src/main/java/org/example/stockitbe/warehouse/inbound/WhInboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/WhInboundService.java
@@ -82,18 +82,15 @@ public class WhInboundService {
                 .inboundType(InboundType.PURCHASE_ORDER)
                 .sourceRefNo(po.getCode())
                 .sourceRefId(po.getId())
-                .warehouseId(po.getWarehouse().getId())
+                .warehouse(po.getWarehouse())
                 .warehouseName(po.getWarehouseName())
                 .sourceName(po.getVendorName())
                 .totalQuantity(totalQuantity)
                 .totalAmount(po.getTotalAmount());
 
-        WhInboundHeader header = saveHeaderWithCodeRetry(headerBuilder);
-
-        // items 시점 복사
+        // items 시점 복사 — replaceItems + cascade=ALL 로 부모 save 시 자식 자동 INSERT.
         List<WhInboundItem> items = poItems.stream()
                 .map(it -> WhInboundItem.builder()
-                        .inboundHeaderId(header.getId())
                         .productCode(it.getProductCode())
                         .productName(it.getProductName())
                         .skuCode(it.getSkuCode())
@@ -104,9 +101,8 @@ public class WhInboundService {
                         .subtotal(it.getSubtotal())
                         .build())
                 .toList();
-        itemRepository.saveAll(items);
 
-        return header;
+        return saveHeaderWithCodeRetry(headerBuilder, items);
     }
 
     /**
@@ -123,7 +119,7 @@ public class WhInboundService {
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.INBOUND_NOT_FOUND));
 
         Long myWarehouseId = resolveWarehouseId(me.getLocationCode());
-        if (!inbound.getWarehouseId().equals(myWarehouseId)) {
+        if (!inbound.getWarehouse().getId().equals(myWarehouseId)) {
             throw BaseException.from(BaseResponseStatus.INBOUND_NOT_FOUND);
         }
 
@@ -143,7 +139,7 @@ public class WhInboundService {
         // 인벤토리 실재고 인식
         List<WhInboundItem> items = itemRepository.findAllByInboundHeaderIdOrderByIdAsc(inbound.getId());
         items.forEach(item -> inventoryService.markPhysical(
-                inbound.getWarehouseId(), item.getSkuCode(), item.getQuantity()));
+                inbound.getWarehouse().getId(), item.getSkuCode(), item.getQuantity()));
 
         // source 도메인 mirror — 종료 단계 박음
         if (inbound.getInboundType() == InboundType.PURCHASE_ORDER) {
@@ -188,11 +184,11 @@ public class WhInboundService {
                 .filter(po -> poCodes.contains(po.getCode()))
                 .collect(Collectors.toMap(PurchaseOrder::getCode, Function.identity()));
 
-        // items batch 조회 (N+1 회피)
+        // items batch 조회 (N+1 회피). LAZY proxy 의 getId() 는 추가 쿼리 X.
         List<Long> headerIds = headers.stream().map(WhInboundHeader::getId).toList();
         Map<Long, List<WhInboundItem>> itemsByHeader = itemRepository
                 .findAllByInboundHeaderIdInOrderByIdAsc(headerIds).stream()
-                .collect(Collectors.groupingBy(WhInboundItem::getInboundHeaderId));
+                .collect(Collectors.groupingBy(it -> it.getInboundHeader().getId()));
 
         return headers.stream()
                 .map(h -> {
@@ -215,7 +211,7 @@ public class WhInboundService {
         Long myWarehouseId = resolveWarehouseId(me.getLocationCode());
         WhInboundHeader inbound = headerRepository.findByInboundCode(inboundCode)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.INBOUND_NOT_FOUND));
-        if (!inbound.getWarehouseId().equals(myWarehouseId)) {
+        if (!inbound.getWarehouse().getId().equals(myWarehouseId)) {
             throw BaseException.from(BaseResponseStatus.INBOUND_NOT_FOUND);
         }
         List<WhInboundItem> items = itemRepository
@@ -269,18 +265,15 @@ public class WhInboundService {
                     .inboundType(InboundType.PURCHASE_ORDER)
                     .sourceRefNo(po.getCode())
                     .sourceRefId(po.getId())
-                    .warehouseId(po.getWarehouse().getId())
+                    .warehouse(po.getWarehouse())
                     .warehouseName(po.getWarehouseName())
                     .sourceName(po.getVendorName())
                     .totalQuantity(totalQuantity)
                     .totalAmount(po.getTotalAmount())
                     .completedAt(completedAt);
 
-            WhInboundHeader header = saveHeaderWithCodeRetry(builder);
-
             List<WhInboundItem> items = poItems.stream()
                     .map(it -> WhInboundItem.builder()
-                            .inboundHeaderId(header.getId())
                             .productCode(it.getProductCode())
                             .productName(it.getProductName())
                             .skuCode(it.getSkuCode())
@@ -291,7 +284,8 @@ public class WhInboundService {
                             .subtotal(it.getSubtotal())
                             .build())
                     .toList();
-            itemRepository.saveAll(items);
+
+            WhInboundHeader header = saveHeaderWithCodeRetry(builder, items);
 
             created++;
             createdCodes.add(header.getInboundCode());
@@ -339,11 +333,18 @@ public class WhInboundService {
         return Date.from(d.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
-    private WhInboundHeader saveHeaderWithCodeRetry(WhInboundHeader.WhInboundHeaderBuilder builder) {
+    /**
+     * 헤더 + items 한 트랜잭션에 INSERT. cascade=ALL 이 자식 자동 INSERT.
+     * inboundCode unique 충돌 시 재시도 (최대 5회).
+     */
+    private WhInboundHeader saveHeaderWithCodeRetry(WhInboundHeader.WhInboundHeaderBuilder builder,
+                                                     List<WhInboundItem> items) {
         for (int i = 0; i < 5; i++) {
             String code = codeGenerator.nextCode(new Date());
             try {
-                return headerRepository.save(builder.inboundCode(code).build());
+                WhInboundHeader header = builder.inboundCode(code).build();
+                header.replaceItems(items);
+                return headerRepository.save(header);
             } catch (DataIntegrityViolationException ignore) {
                 // unique 충돌 — retry
             }

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/model/WhInboundDto.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/model/WhInboundDto.java
@@ -135,7 +135,7 @@ public class WhInboundDto {
                     .inboundType(header.getInboundType().name())
                     .sourceRefNo(header.getSourceRefNo())
                     .sourceName(header.getSourceName())
-                    .warehouseId(header.getWarehouseId())
+                    .warehouseId(header.getWarehouse().getId())
                     .warehouseName(header.getWarehouseName())
                     .status(status)
                     .totalQuantity(header.getTotalQuantity())

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/model/entity/WhInboundHeader.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/model/entity/WhInboundHeader.java
@@ -8,9 +8,12 @@ import lombok.NoArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseEntity;
 import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.warehouse.inbound.model.InboundType;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * 창고 입고 헤더 (ERP 표준 — Goods Receipt Note 패턴).
@@ -46,9 +49,12 @@ public class WhInboundHeader extends BaseEntity {
     @Column(name = "source_ref_id")
     private Long sourceRefId;
 
-    @Column(name = "warehouse_id", nullable = false)
-    private Long warehouseId;
+    // 외부 도메인 — Infrastructure 가 창고 마스터 (LocationType=WAREHOUSE).
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "warehouse_id", nullable = false)
+    private Infrastructure warehouse;
 
+    // warehouse.name 시점 박제 스냅샷 — 창고명 변경에 영향 안 받게 입고 시점 라벨 보존.
     @Column(name = "warehouse_name", nullable = false, length = 128)
     private String warehouseName;
 
@@ -73,16 +79,20 @@ public class WhInboundHeader extends BaseEntity {
     @Column(name = "memo", length = 500)
     private String memo;
 
+    // 부모-자식 컴포지션 — items 라이프사이클 동일, cascade 자동화 대상.
+    @OneToMany(mappedBy = "inboundHeader", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WhInboundItem> items = new ArrayList<>();
+
     @Builder
     private WhInboundHeader(String inboundCode, InboundType inboundType, String sourceRefNo, Long sourceRefId,
-                            Long warehouseId, String warehouseName, String sourceName,
+                            Infrastructure warehouse, String warehouseName, String sourceName,
                             Long totalQuantity, Long totalAmount, String memo,
                             Date completedAt, String confirmedByMemberId, String confirmedByName) {
         this.inboundCode = inboundCode;
         this.inboundType = inboundType;
         this.sourceRefNo = sourceRefNo;
         this.sourceRefId = sourceRefId;
-        this.warehouseId = warehouseId;
+        this.warehouse = warehouse;
         this.warehouseName = warehouseName;
         this.sourceName = sourceName;
         this.totalQuantity = totalQuantity == null ? 0L : totalQuantity;
@@ -92,6 +102,17 @@ public class WhInboundHeader extends BaseEntity {
         this.completedAt = completedAt;
         this.confirmedByMemberId = confirmedByMemberId;
         this.confirmedByName = confirmedByName;
+    }
+
+    /**
+     * items 일괄 등록 (시점 복사). cascade=ALL 이 자동 INSERT.
+     */
+    public void replaceItems(List<WhInboundItem> newItems) {
+        this.items.clear();
+        newItems.forEach(it -> {
+            it.linkToParent(this);
+            this.items.add(it);
+        });
     }
 
     /**

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/model/entity/WhInboundItem.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/model/entity/WhInboundItem.java
@@ -17,16 +17,19 @@ public class WhInboundItem extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // header FK Long ID (결합 차단 4패턴 #1 — @ManyToOne 안 박음, PurchaseOrderItem 패턴 일관)
-    @Column(name = "inbound_header_id", nullable = false)
-    private Long inboundHeaderId;
+    // 부모-자식 컴포지션 — 라이프사이클 동일, cascade 자동화 대상.
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "inbound_header_id", nullable = false)
+    private WhInboundHeader inboundHeader;
 
+    // 마스터 제품 자연 키 + 시점 박제 — ProductMaster.productCode (String 자연 키, 매핑 안 박음).
     @Column(name = "product_code", nullable = false, length = 64)
     private String productCode;
 
     @Column(name = "product_name", nullable = false, length = 256)
     private String productName;
 
+    // SKU 자연 키 + 옵션 시점 박제 — ProductSku.skuCode (String 자연 키, 매핑 안 박음).
     @Column(name = "sku_code", nullable = false, length = 32)
     private String skuCode;
 
@@ -47,10 +50,10 @@ public class WhInboundItem extends BaseEntity {
     private Long subtotal;
 
     @Builder
-    private WhInboundItem(Long inboundHeaderId, String productCode, String productName,
+    private WhInboundItem(WhInboundHeader inboundHeader, String productCode, String productName,
                           String skuCode, String color, String size,
                           Integer quantity, Long unitPrice, Long subtotal) {
-        this.inboundHeaderId = inboundHeaderId;
+        this.inboundHeader = inboundHeader;
         this.productCode = productCode;
         this.productName = productName;
         this.skuCode = skuCode;
@@ -61,7 +64,7 @@ public class WhInboundItem extends BaseEntity {
         this.subtotal = subtotal;
     }
 
-    public void linkToHeader(Long inboundHeaderId) {
-        this.inboundHeaderId = inboundHeaderId;
+    void linkToParent(WhInboundHeader parent) {
+        this.inboundHeader = parent;
     }
 }


### PR DESCRIPTION
## 📌 요약
- 창고 입고 도메인의 외부 마스터(창고) 참조와 헤더↔아이템 부모-자식 컴포지션을 JPA 정석 매핑(`@ManyToOne(LAZY)` / `@OneToMany cascade`)으로 전환. #205 본사 발주 매핑 전환과 같은 패턴 적용

<br><br>

## 🎯 작업 내용
- `WhInboundHeader.warehouse` 를 `@ManyToOne(LAZY) Infrastructure` 매핑 추가 — `warehouseName` 시점 박제 스냅샷 컬럼은 ERP 정석대로 그대로 유지 (매핑 + 스냅샷 둘 다)
- `WhInboundHeader ↔ WhInboundItem` 부모-자식 컴포지션을 `@OneToMany(cascade=ALL, orphanRemoval=true)` + `@ManyToOne(LAZY)` 양방향으로 추가. `replaceItems` + `linkToParent` 양방향 동기화 헬퍼로 부모 `save` 시 자식 자동 INSERT — `itemRepository.saveAll` 직접 호출 폐기
- `WhInboundItem.inboundHeader` 매핑 추가. `sku_code`/`product_code` String 자연 키 외부 참조는 매핑 안 박고 시점 박제 스냅샷 유지 (Long PK 매핑은 데이터 마이그레이션 동반 별 사이클)
- `saveHeaderWithCodeRetry` 가 `items` 인자 받아 unique 충돌 retry 시 cascade 로 자식까지 한 트랜잭션에 INSERT
- 호출부 정리: `inbound.getWarehouseId()` → `inbound.getWarehouse().getId()` (3곳), `WhInboundItem::getInboundHeaderId` → `it.getInboundHeader().getId()` (groupingBy), `WhInboundDto.from` 도 같은 패턴
- Spring Data JPA derived query (`findAllByInboundHeaderIdOrderByIdAsc` 등) 는 nested property traversal 자동 인식 — 메소드명 그대로 유지

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #206

<br><br>
