### PR TITLE
feat: 매장 관리자 발주 승인 배치 처리 api 구현확장 구현

### DIFF
--- a/docs/codex/store/01-plan/매장_발주_배치승인_백엔드_구현계획.md
+++ b/docs/codex/store/01-plan/매장_발주_배치승인_백엔드_구현계획.md
@@ -1,0 +1,91 @@
+# 매장 발주 배치승인 백엔드 구현 계획
+
+## 1. 목표
+- 매장 발주 상태를 `REQUESTED -> APPROVED`로 전이하는 발주 승인 배치 기능을 구현한다.
+- 자동 배치(스케줄러)와 수동 배치(API)를 모두 제공한다.
+- 수동 배치는 본사 관리자 전용으로 제한하고, 범위는 `전체`/`매장별(storeCode)`을 지원한다.
+  - 자동 배치: 전날(00:00~23:59) 발주건을 익일 00:00(KST) 에 승인
+  - 수동 배치: 본사 관리자 전용, 기준 무시 후 REQUESTED 전체 승인
+- 처리 결과는 주문건 단위 부분 성공(partial success)으로 반환한다.
+  - 주문건 단위 partial success(성공/실패 건별 반환), 성공 건은 이력 기록
+
+## 2. 범위
+- 포함:
+  - 자동 배치: 전날 요청건 익일 00:00(KST) 승인
+  - 수동 배치: `ALL` 또는 `STORE` (전체 승인, 매장별 승인)
+  - 배치 실행 결과 응답/로그 표준화
+  - 상태이력(`store_order_status_history`) 기록 보장(기존 승인 로직 재사용)
+- 제외:
+  - 승인 시 출고/입고 생성 오케스트레이션 연동(별도 브랜치)
+  - 배치 전용 DB 이력 테이블 추가
+
+## 3. API/스케줄 공개 인터페이스
+- 수동 실행 API:
+  - `POST /api/hq/store-orders/batch-approve/run`
+  - Request: `mode(ALL|STORE)`, `storeCode(mode=STORE 필수)`
+  - Response:
+    - `runId`, `triggerType(AUTO|MANUAL)`, `scope(ALL|STORE)`, `storeCode`
+    - `requestedCount`, `successCount`, `failCount`
+    - `results[] { orderNo, result, code, message }`
+- 자동 스케줄러:
+  - `store-order.batch.cron` (기본: `0 0 0 * * *`)
+  - `store-order.batch.zone` (기본: `Asia/Seoul`)
+
+## 4. 도메인/서비스 설계
+- 신규 서비스: `StoreOrderBatchApproveService`
+- 실행 모드:
+  - `AUTO_DAILY`: 전날 요청건만 승인
+  - `MANUAL_ALL`: 전체 REQUESTED 승인
+  - `MANUAL_STORE`: 특정 storeCode의 REQUESTED 승인
+- 처리 공통 흐름:
+  1. 대상 주문 조회
+  2. 입력/범위 검증
+  3. 기존 승인 로직 호출(`StoreOrderService` 재사용)
+  4. 건별 성공/실패 집계
+  5. 실행 로그 및 응답 반환
+
+## 5. 입력 검증/권한 정책
+- DTO 검증:
+  - `mode=STORE`이면 `storeCode` 필수
+- 서비스 검증:
+  - 잘못된 `scope` 방어 로직
+  - `storeCode -> storeId` 매핑 실패 시 예외
+- 권한:
+  - 수동 배치 API는 HQ 권한만 허용
+
+## 6. 에러코드 정책
+- 기존 `STORE_ORDER` 대역(4600번대) 확장:
+  - `STORE_ORDER_BATCH_STORE_CODE_REQUIRED`
+  - `STORE_ORDER_BATCH_SCOPE_INVALID`
+- 배치 실패는 건별 `code/message`로 응답에 포함한다.
+
+## 7. 리포지토리 확장
+- `StoreOrderHeaderRepository` 배치 조회 메서드 추가:
+  - 상태 전체 조회
+  - 상태 + 매장ID 조회
+  - 상태 + 요청일 범위 조회(자동 배치)
+
+## 8. 로깅/추적
+- 실행 단위 `runId(UUID)` 발급
+- 시작/종료/실패 로그에 `runId`, `scope`, `storeCode`, 처리 건수 기록
+- 배치 전용 이력 테이블 없이도 로그 + 상태이력 + 응답으로 추적 가능하도록 설계
+
+## 9. 테스트 시나리오
+- 자동 배치:
+  - 전날 요청건 승인, 당일 요청건 미승인 확인
+  - KST 자정 경계값 확인
+- 수동 배치:
+  - `ALL` 성공
+  - `STORE` 성공
+  - `STORE` + 잘못된 storeCode 실패
+  - `STORE` + storeCode 누락 검증 실패
+- 권한:
+  - HQ 성공
+  - 비-HQ 403
+- 정합성:
+  - 성공건 상태/이력 반영
+  - 실패건 상태 미변경
+  - 응답 집계값과 실제 처리 일치
+
+## 10. 후속 작업
+- 승인 시 출고/입고 생성 오케스트레이션 연동은 별도 브랜치로 진행한다.

--- a/docs/codex/store/02-implementation/매장_발주_배치승인_백엔드_구현내역.md
+++ b/docs/codex/store/02-implementation/매장_발주_배치승인_백엔드_구현내역.md
@@ -1,0 +1,77 @@
+# 매장 발주 배치승인 백엔드 구현내역
+
+## 1. 구현 요약
+- `REQUESTED -> APPROVED` 배치 승인 기능(자동/수동) 백엔드 구현을 완료했다.
+- 수동 실행은 HQ 전용 API로 제공했고, `전체/매장별` 범위를 지원한다.
+- 처리 정책은 주문건 단위 partial success로 구현했다.
+
+## 2. 추가/변경 파일
+- 배치 API/서비스/스케줄러
+  - `src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveController.java`
+  - `src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java`
+  - `src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveScheduler.java`
+- 배치 DTO/Enum
+  - `src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderBatchDto.java`
+  - `src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchScope.java`
+  - `src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchTriggerType.java`
+- 기존 서비스/리포지토리/코드체계 확장
+  - `src/main/java/org/example/stockitbe/store/order/StoreOrderService.java`
+  - `src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java`
+  - `src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java`
+
+## 3. 상세 구현
+### 3.1 수동 배치 API
+- 엔드포인트: `POST /api/hq/store-orders/batch-approve/run`
+- 입력:
+  - `mode`: `ALL` | `STORE`
+  - `storeCode`: `mode=STORE`일 때 필수
+- 출력:
+  - `runId`, `triggerType`, `scope`, `storeCode`
+  - `requestedCount`, `successCount`, `failCount`
+  - `results[] (orderNo, result, code, message)`
+
+### 3.2 자동 배치 스케줄러
+- 매일 00:00 KST 실행
+- 전날 요청건(`requestedAt` 기준)만 승인 대상으로 조회
+
+### 3.3 배치 서비스 처리 흐름
+1. 실행 단위 `runId` 생성
+2. 모드별 대상 조회
+3. 주문별 승인 처리(`StoreOrderService` 기존 승인 로직 재사용)
+4. 주문별 성공/실패 결과 적재
+5. 집계값 계산 및 응답 반환
+
+### 3.4 StoreOrderService 재사용 확장
+- 배치 전용 진입점(`approveByBatch`) 추가
+- 기존 수동 승인 로직과 공통화(`approveInternal`)하여 상태 전이/상태이력 로직 중복 제거
+
+### 3.5 조회 리포지토리 확장
+- `StoreOrderHeaderRepository`에 배치용 조회 메서드 추가:
+  - 상태 전체
+  - 상태 + 매장ID
+  - 상태 + 요청일 범위
+
+## 4. 검증 강화 반영(추가 요청사항)
+### 4.1 DTO 레벨 검증
+- `StoreOrderBatchDto.RunReq`에 조건부 검증 추가
+  - `@AssertTrue`: `mode=STORE`일 때 `storeCode` 필수
+
+### 4.2 에러코드 세분화
+- `BaseResponseStatus`에 배치 전용 코드 추가
+  - `STORE_ORDER_BATCH_STORE_CODE_REQUIRED (4609)`
+  - `STORE_ORDER_BATCH_SCOPE_INVALID (4610)`
+- 서비스 분기에서 코드 사용하도록 연결
+
+## 5. 로그/추적
+- 시작/종료/실패 로그에 `runId`를 포함
+- `scope`, `storeCode`, 처리 건수(`requested/success/fail`) 기록
+- 배치 전용 테이블 없이도 응답 + 로그 + 상태이력으로 추적 가능
+
+## 6. 현재 상태
+- 백엔드 기능 구현 기준:
+  - 수동 실행 API 구현 완료
+  - 자동 스케줄러 구현 완료
+  - 입력 검증/에러코드 세분화 완료
+- 잔여 작업(다음 브랜치):
+  - 승인 시 출고/입고 생성 오케스트레이션 연동
+  - 프론트 연동 및 통합 시나리오 검증

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -102,6 +102,8 @@ public enum BaseResponseStatus {
     STORE_ORDER_INVALID_STATUS_TRANSITION(false, 4606, "허용되지 않는 발주 상태 전환입니다."),
     STORE_ORDER_CANCEL_REASON_REQUIRED(false, 4607, "발주 취소 사유는 필수입니다."),
     STORE_ORDER_SCOPE_FORBIDDEN(false, 4608, "로그인한 매장 범위를 벗어난 요청입니다."),
+    STORE_ORDER_BATCH_STORE_CODE_REQUIRED(false, 4609, "배치 승인 STORE 모드에서는 storeCode가 필수입니다."),
+    STORE_ORDER_BATCH_SCOPE_INVALID(false, 4610, "유효하지 않은 배치 승인 범위입니다."),
 
     // 4400번대 회원 관리
     USER_NOT_PENDING(false, 4400, "대기 상태인 신청만 처리할 수 있습니다."),

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveController.java
@@ -6,10 +6,13 @@ import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.store.order.model.dto.StoreOrderBatchDto;
 import org.example.stockitbe.user.model.AuthUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/hq/store-orders/batch-approve")
@@ -18,7 +21,7 @@ public class StoreOrderBatchApproveController {
 
     private final StoreOrderBatchApproveService batchApproveService;
 
-    // 발주 수동 배치
+    // 발주 승인 배치 처리
     @PostMapping("/run")
     public BaseResponse<StoreOrderBatchDto.RunRes> run(
             @AuthenticationPrincipal AuthUserDetails me,
@@ -26,5 +29,12 @@ public class StoreOrderBatchApproveController {
     ) {
         return BaseResponse.success(batchApproveService.runManual(req, me));
     }
-}
 
+    // 승인 대기 발주건이 있는 매장 조회
+    @GetMapping("/pending-stores")
+    public BaseResponse<List<StoreOrderBatchDto.PendingStoreRes>> pendingStores(
+            @AuthenticationPrincipal AuthUserDetails me
+    ) {
+        return BaseResponse.success(batchApproveService.listPendingStores());
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveController.java
@@ -1,0 +1,30 @@
+package org.example.stockitbe.store.order;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.store.order.model.dto.StoreOrderBatchDto;
+import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hq/store-orders/batch-approve")
+@RequiredArgsConstructor
+public class StoreOrderBatchApproveController {
+
+    private final StoreOrderBatchApproveService batchApproveService;
+
+    // 발주 수동 배치
+    @PostMapping("/run")
+    public BaseResponse<StoreOrderBatchDto.RunRes> run(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @Valid @RequestBody(required = false) StoreOrderBatchDto.RunReq req
+    ) {
+        return BaseResponse.success(batchApproveService.runManual(req, me));
+    }
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveScheduler.java
@@ -1,0 +1,27 @@
+package org.example.stockitbe.store.order;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.store.order.model.dto.StoreOrderBatchDto;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StoreOrderBatchApproveScheduler {
+
+    private final StoreOrderBatchApproveService batchApproveService;
+
+    // 발주 자동 배치 스케줄러 추가
+    @Scheduled(
+            cron = "${store-order.batch.cron:0 0 0 * * *}",
+            zone = "${store-order.batch.zone:Asia/Seoul}"
+    )
+    public void runAutoBatch() {
+        StoreOrderBatchDto.RunRes result = batchApproveService.runAutoDaily();
+        log.info("[STORE-ORDER-BATCH] scheduler done runId={} requested={} success={} fail={}",
+                result.getRunId(), result.getRequestedCount(), result.getSuccessCount(), result.getFailCount());
+    }
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
@@ -20,8 +20,11 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -67,7 +70,7 @@ public class StoreOrderBatchApproveService {
                         header.getOrderNo(),
                         actorId,
                         actorName,
-                        "MANUAL_BATCH_APPROVE"
+                        "본사 수동 배치 처리"
                 );
                 success++;
                 itemResults.add(StoreOrderBatchDto.ItemRes.builder()
@@ -161,6 +164,36 @@ public class StoreOrderBatchApproveService {
                 .failCount(fail)
                 .results(itemResults)
                 .build();
+    }
+
+    // 승인 대기 발주건이 있는 매장 조회
+    @Transactional(readOnly = true)
+    public List<StoreOrderBatchDto.PendingStoreRes> listPendingStores() {
+        List<StoreOrderHeaderRepository.PendingStoreProjection> rows =
+                headerRepository.countPendingByStore(StoreOrderStatus.REQUESTED);
+        if (rows.isEmpty()) return List.of();
+
+        List<Long> storeIds = rows.stream().map(StoreOrderHeaderRepository.PendingStoreProjection::getStoreId).toList();
+        Map<Long, Infrastructure> infraById = new HashMap<>();
+        for (Infrastructure infra : infrastructureRepository.findAllById(storeIds)) {
+            infraById.put(infra.getId(), infra);
+        }
+
+        List<StoreOrderBatchDto.PendingStoreRes> result = new ArrayList<>();
+        for (StoreOrderHeaderRepository.PendingStoreProjection row : rows) {
+            Infrastructure store = infraById.get(row.getStoreId());
+            if (store == null) continue;
+            result.add(StoreOrderBatchDto.PendingStoreRes.builder()
+                    .storeCode(store.getCode())
+                    .storeName(store.getName())
+                    .region(store.getRegion())
+                    .requestedCount(row.getRequestedCount() == null ? 0 : row.getRequestedCount().intValue())
+                    .build());
+        }
+
+        result.sort(Comparator.comparing(StoreOrderBatchDto.PendingStoreRes::getRequestedCount).reversed()
+                .thenComparing(StoreOrderBatchDto.PendingStoreRes::getStoreName));
+        return result;
     }
 
     // ---------------------------- 내부 메서드 --------------------------------

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
@@ -47,12 +47,13 @@ public class StoreOrderBatchApproveService {
             case ALL -> headerRepository.findAllByStatusOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED);
             case STORE -> {
                 String storeCode = trimToNull(req == null ? null : req.getStoreCode());
-                if (storeCode == null) throw BaseException.from(BaseResponseStatus.REQUEST_ERROR);
+                if (storeCode == null) throw BaseException.from(BaseResponseStatus.STORE_ORDER_BATCH_STORE_CODE_REQUIRED);
                 Long storeId = infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
                         .map(Infrastructure::getId)
                         .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
                 yield headerRepository.findAllByStatusAndStoreIdOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED, storeId);
             }
+            default -> throw BaseException.from(BaseResponseStatus.STORE_ORDER_BATCH_SCOPE_INVALID);
         };
 
         log.info("[STORE-ORDER-BATCH] start runId={} trigger=MANUAL scope={} storeCode={} requested={}",
@@ -186,4 +187,3 @@ public class StoreOrderBatchApproveService {
         return trimmed.isEmpty() ? null : trimmed;
     }
 }
-

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
@@ -1,0 +1,189 @@
+package org.example.stockitbe.store.order;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.store.order.model.StoreOrderBatchScope;
+import org.example.stockitbe.store.order.model.StoreOrderBatchTriggerType;
+import org.example.stockitbe.store.order.model.StoreOrderStatus;
+import org.example.stockitbe.store.order.model.dto.StoreOrderBatchDto;
+import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
+import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreOrderBatchApproveService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final StoreOrderHeaderRepository headerRepository;
+    private final InfrastructureRepository infrastructureRepository;
+    private final StoreOrderService storeOrderService;
+
+    // 발주 수동 배치
+    @Transactional
+    public StoreOrderBatchDto.RunRes runManual(StoreOrderBatchDto.RunReq req, AuthUserDetails me) {
+        StoreOrderBatchScope scope = req == null || req.getMode() == null ? StoreOrderBatchScope.ALL : req.getMode();
+        String runId = UUID.randomUUID().toString();
+        String actorId = me == null ? "" : me.getEmployeeCode();
+        String actorName = me == null ? "SYSTEM" : me.getName();
+
+        List<StoreOrderHeader> targets = switch (scope) {
+            case ALL -> headerRepository.findAllByStatusOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED);
+            case STORE -> {
+                String storeCode = trimToNull(req == null ? null : req.getStoreCode());
+                if (storeCode == null) throw BaseException.from(BaseResponseStatus.REQUEST_ERROR);
+                Long storeId = infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
+                        .map(Infrastructure::getId)
+                        .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
+                yield headerRepository.findAllByStatusAndStoreIdOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED, storeId);
+            }
+        };
+
+        log.info("[STORE-ORDER-BATCH] start runId={} trigger=MANUAL scope={} storeCode={} requested={}",
+                runId, scope, req == null ? null : req.getStoreCode(), targets.size());
+
+        List<StoreOrderBatchDto.ItemRes> itemResults = new ArrayList<>();
+        int success = 0;
+        for (StoreOrderHeader header : targets) {
+            try {
+                storeOrderService.approveByBatch(
+                        header.getOrderNo(),
+                        actorId,
+                        actorName,
+                        "MANUAL_BATCH_APPROVE"
+                );
+                success++;
+                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
+                        .orderNo(header.getOrderNo())
+                        .result("SUCCESS")
+                        .code(BaseResponseStatus.SUCCESS.getCode())
+                        .message("APPROVED")
+                        .build());
+            } catch (Exception e) {
+                BaseResponseStatus status = extractStatus(e);
+                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
+                        .orderNo(header.getOrderNo())
+                        .result("FAIL")
+                        .code(status.getCode())
+                        .message(status.getMessage())
+                        .build());
+                log.warn("[STORE-ORDER-BATCH] fail runId={} orderNo={} code={} msg={}",
+                        runId, header.getOrderNo(), status.getCode(), status.getMessage(), e);
+            }
+        }
+
+        int fail = targets.size() - success;
+        log.info("[STORE-ORDER-BATCH] end runId={} trigger=MANUAL scope={} success={} fail={}",
+                runId, scope, success, fail);
+
+        return StoreOrderBatchDto.RunRes.builder()
+                .runId(runId)
+                .triggerType(StoreOrderBatchTriggerType.MANUAL)
+                .scope(scope)
+                .storeCode(req == null ? null : req.getStoreCode())
+                .requestedCount(targets.size())
+                .successCount(success)
+                .failCount(fail)
+                .results(itemResults)
+                .build();
+    }
+
+    // 발주 자동 배치
+    @Transactional
+    public StoreOrderBatchDto.RunRes runAutoDaily() {
+        String runId = UUID.randomUUID().toString();
+        Date[] range = previousDayRange();
+
+        List<StoreOrderHeader> targets = headerRepository.findAllByStatusAndRequestedAtBetweenOrderByRequestedAtDescIdDesc(
+                StoreOrderStatus.REQUESTED, range[0], range[1]
+        );
+
+        log.info("[STORE-ORDER-BATCH] start runId={} trigger=AUTO from={} to={} requested={}",
+                runId, range[0], range[1], targets.size());
+
+        List<StoreOrderBatchDto.ItemRes> itemResults = new ArrayList<>();
+        int success = 0;
+        for (StoreOrderHeader header : targets) {
+            try {
+                storeOrderService.approveByBatch(
+                        header.getOrderNo(),
+                        "SYSTEM_BATCH",
+                        "SYSTEM_BATCH",
+                        "AUTO_BATCH_APPROVE"
+                );
+                success++;
+                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
+                        .orderNo(header.getOrderNo())
+                        .result("SUCCESS")
+                        .code(BaseResponseStatus.SUCCESS.getCode())
+                        .message("APPROVED")
+                        .build());
+            } catch (Exception e) {
+                BaseResponseStatus status = extractStatus(e);
+                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
+                        .orderNo(header.getOrderNo())
+                        .result("FAIL")
+                        .code(status.getCode())
+                        .message(status.getMessage())
+                        .build());
+                log.warn("[STORE-ORDER-BATCH] fail runId={} orderNo={} code={} msg={}",
+                        runId, header.getOrderNo(), status.getCode(), status.getMessage(), e);
+            }
+        }
+
+        int fail = targets.size() - success;
+        log.info("[STORE-ORDER-BATCH] end runId={} trigger=AUTO success={} fail={}", runId, success, fail);
+
+        return StoreOrderBatchDto.RunRes.builder()
+                .runId(runId)
+                .triggerType(StoreOrderBatchTriggerType.AUTO)
+                .scope(StoreOrderBatchScope.ALL)
+                .storeCode(null)
+                .requestedCount(targets.size())
+                .successCount(success)
+                .failCount(fail)
+                .results(itemResults)
+                .build();
+    }
+
+    // ---------------------------- 내부 메서드 --------------------------------
+
+    private BaseResponseStatus extractStatus(Exception e) {
+        Throwable cur = e;
+        while (cur != null) {
+            if (cur instanceof BaseException be && be.getStatus() != null) return be.getStatus();
+            cur = cur.getCause();
+        }
+        return BaseResponseStatus.FAIL;
+    }
+
+    private Date[] previousDayRange() {
+        LocalDate prev = LocalDate.now(KST).minusDays(1);
+        ZonedDateTime start = prev.atStartOfDay(KST);
+        ZonedDateTime end = prev.plusDays(1).atStartOfDay(KST).minusNanos(1);
+        return new Date[]{Date.from(start.toInstant()), Date.from(end.toInstant())};
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
@@ -3,6 +3,7 @@ package org.example.stockitbe.store.order;
 import org.example.stockitbe.store.order.model.StoreOrderStatus;
 import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Date;
 import java.util.List;
@@ -16,5 +17,18 @@ public interface StoreOrderHeaderRepository extends JpaRepository<StoreOrderHead
     List<StoreOrderHeader> findAllByStatusAndRequestedAtBetweenOrderByRequestedAtDescIdDesc(
             StoreOrderStatus status, Date from, Date to
     );
+
+    @Query("""
+            select h.storeId as storeId, count(h.id) as requestedCount
+            from StoreOrderHeader h
+            where h.status = :status
+            group by h.storeId
+            """)
+    List<PendingStoreProjection> countPendingByStore(StoreOrderStatus status);
+
+    interface PendingStoreProjection {
+        Long getStoreId();
+        Long getRequestedCount();
+    }
 }
 

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderHeaderRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 public interface StoreOrderHeaderRepository extends JpaRepository<StoreOrderHeader, Long> {
     Optional<StoreOrderHeader> findByOrderNo(String orderNo);
     List<StoreOrderHeader> findAllByOrderByRequestedAtDescIdDesc();
+    List<StoreOrderHeader> findAllByStatusOrderByRequestedAtAscIdAsc(StoreOrderStatus status);
+    List<StoreOrderHeader> findAllByStatusAndStoreIdOrderByRequestedAtAscIdAsc(StoreOrderStatus status, Long storeId);
     List<StoreOrderHeader> findAllByStatusAndRequestedAtBetweenOrderByRequestedAtDescIdDesc(
             StoreOrderStatus status, Date from, Date to
     );

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderService.java
@@ -116,20 +116,18 @@ public class StoreOrderService {
     public StoreOrderDto.ApproveRes approve(String orderNo, StoreOrderDto.ApproveReq dto, AuthUserDetails me) {
         Infrastructure store = resolveStore(me);
         StoreOrderHeader header = getOwnedOrderByOrderNo(orderNo, store.getId());
-        Date now = new Date();
+        return approveInternal(
+                header,
+                safe(dto == null ? null : dto.getApprovedByMemberId()),
+                blankTo(dto == null ? null : dto.getApprovedByName(), "SYSTEM"),
+                "STORE_ORDER_APPROVE"
+        );
+    }
 
-        header.markApproved();
-
-        List<StoreOrderItem> items = itemRepository.findAllByOrderHeaderIdOrderByIdAsc(header.getId());
-        for (StoreOrderItem item : items) {
-            inventoryService.increaseAvailable(header.getStoreId(), item.getSkuCode(), item.getRequestedQuantity());
-        }
-
-        String actorMemberId = safe(dto == null ? null : dto.getApprovedByMemberId());
-        String actorName = blankTo(dto == null ? null : dto.getApprovedByName(), "시스템");
-        appendOrderStatusHistory(header.getId(), StoreOrderStatus.APPROVED.name(), now,
-                actorMemberId, actorName, "발주 승인 처리");
-        return StoreOrderDto.ApproveRes.from(buildCreateRes(header));
+    @Transactional
+    public StoreOrderDto.ApproveRes approveByBatch(String orderNo, String actorMemberId, String actorName, String reason) {
+        StoreOrderHeader header = getOrderByOrderNo(orderNo);
+        return approveInternal(header, safe(actorMemberId), blankTo(actorName, "SYSTEM"), blankTo(reason, "AUTO_BATCH_APPROVE"));
     }
 
     // 매장 발주 내역 목록 조회
@@ -418,6 +416,21 @@ public class StoreOrderService {
                         .reason(reason)
                         .build()
         );
+    }
+
+
+    private StoreOrderDto.ApproveRes approveInternal(StoreOrderHeader header, String actorMemberId, String actorName, String reason) {
+        Date now = new Date();
+        header.markApproved();
+
+        List<StoreOrderItem> items = itemRepository.findAllByOrderHeaderIdOrderByIdAsc(header.getId());
+        for (StoreOrderItem item : items) {
+            inventoryService.increaseAvailable(header.getStoreId(), item.getSkuCode(), item.getRequestedQuantity());
+        }
+
+        appendOrderStatusHistory(header.getId(), StoreOrderStatus.APPROVED.name(), now,
+                actorMemberId, actorName, reason);
+        return StoreOrderDto.ApproveRes.from(buildCreateRes(header));
     }
 
     // 사용하는 메서드: detail, create, update, cancel

--- a/src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchScope.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchScope.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.store.order.model;
+
+public enum StoreOrderBatchScope {
+    ALL,
+    STORE
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchTriggerType.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/StoreOrderBatchTriggerType.java
@@ -1,0 +1,7 @@
+package org.example.stockitbe.store.order.model;
+
+public enum StoreOrderBatchTriggerType {
+    AUTO,
+    MANUAL
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderBatchDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderBatchDto.java
@@ -1,0 +1,53 @@
+package org.example.stockitbe.store.order.model.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.store.order.model.StoreOrderBatchScope;
+import org.example.stockitbe.store.order.model.StoreOrderBatchTriggerType;
+
+import java.util.List;
+
+public class StoreOrderBatchDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RunReq {
+        private StoreOrderBatchScope mode;
+        private String storeCode;
+
+        @AssertTrue(message = "mode=STORE requires storeCode")
+        public boolean isStoreCodeValidForMode() {
+            if (mode != StoreOrderBatchScope.STORE) return true;
+            return storeCode != null && !storeCode.trim().isEmpty();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class RunRes {
+        private String runId;
+        private StoreOrderBatchTriggerType triggerType;
+        private StoreOrderBatchScope scope;
+        private String storeCode;
+        private Integer requestedCount;
+        private Integer successCount;
+        private Integer failCount;
+        private List<ItemRes> results;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ItemRes {
+        private String orderNo;
+        private String result;
+        private Integer code;
+        private String message;
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderBatchDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/model/dto/StoreOrderBatchDto.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public class StoreOrderBatchDto {
 
+    // 매장 발주 수동 배치 처리 요청 DTO
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -27,6 +28,7 @@ public class StoreOrderBatchDto {
         }
     }
 
+    // 매장 발주 수동 배치 처리 응답 DTO
     @Getter
     @AllArgsConstructor
     @Builder
@@ -49,5 +51,16 @@ public class StoreOrderBatchDto {
         private String result;
         private Integer code;
         private String message;
+    }
+
+    // 승인 대기 발주건이 있는 매장 조회 응답 DTO
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class PendingStoreRes {
+        private String storeCode;
+        private String storeName;
+        private String region;
+        private Integer requestedCount;
     }
 }


### PR DESCRIPTION
## 📌 요약
- 매장 발주 승인 배치(자동/수동) 기능을 구현했습니다.
- 본사 관리자 수동 실행 API와 자동 스케줄러를 통해 `REQUESTED -> APPROVED` 전환을 처리합니다.
- 건별 성공/실패(Partial Success) 응답, 권한/검증/로그/이력 기록을 포함해 운영 가능한 형태로 정리했습니다.

<br><br>

## 🎯 작업 내용
- 수동 배치 실행 API 구현: `POST /api/hq/store-orders/batch-approve/run` (`ALL`/`STORE`)
- 자동 배치 스케줄러 구현: 매일 00:00(KST) 전날 요청건 자동 승인
- 승인 대기 매장 조회 API 구현: `GET /api/hq/store-orders/batch-approve/pending-stores`
- 배치 실행 결과 DTO/코드 정리(`runId`, 건수 집계, 건별 결과)
- 입력 검증 강화(`mode=STORE`일 때 `storeCode` 필수) 및 에러코드 분기
- HQ 권한 제어, 실행 로그 표준화, 상태 이력 기록 연동

<br><br>

## ✔️ 참고 사항
- 자동 배치는 스케줄러 기반으로 동작하며 기본값은 `cron=0 0 0 * * *`, `zone=Asia/Seoul`입니다.
- 승인 시 출고/입고 생성 오케스트레이션 연동은 다음 단계(별도 브랜치)로 분리 예정입니다.

<br><br>

## ✔️ 관련 이슈

- Close #110 

<br><br>
