### PR TITLE
refactor(vendor-product): JPA 매핑 정석으로 전환 — vendor_id Long → @ManyToOne Vendor

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
@@ -68,7 +68,7 @@ public class PurchaseOrderCatalogService {
 
         // 2) Vendor 일괄 조회 + ACTIVE 만 통과
         Set<Long> vendorIds = vendorProducts.stream()
-                .map(VendorProduct::getVendorId)
+                .map(vp -> vp.getVendor().getId())
                 .collect(Collectors.toSet());
         Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
                 .filter(v -> v.getStatus() == VendorStatus.ACTIVE)
@@ -91,7 +91,7 @@ public class PurchaseOrderCatalogService {
         // 5) MasterRes 빌드 (SKU 0건 마스터 제외)
         List<PurchaseOrderCatalogDto.MasterRes> masters = new ArrayList<>();
         for (VendorProduct vp : vendorProducts) {
-            Vendor vendor = vendorMap.get(vp.getVendorId());
+            Vendor vendor = vendorMap.get(vp.getVendor().getId());
             if (vendor == null) continue; // vendor 비ACTIVE
             ProductMaster master = productMap.get(vp.getProductCode());
             if (master == null) continue; // master 비ACTIVE 또는 없음

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -121,7 +121,7 @@ public class PurchaseOrderService {
         List<VendorProduct> vendorProducts = req.getItems().stream()
                 .map(itemReq -> {
                     VendorProduct vp = lookupVendorProduct(itemReq.getVendorProductCode());
-                    if (!vp.getVendorId().equals(vendor.getId())) {
+                    if (!vp.getVendor().getId().equals(vendor.getId())) {
                         throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH);
                     }
                     return vp;
@@ -178,7 +178,7 @@ public class PurchaseOrderService {
         List<VendorProduct> vendorProducts = req.getItems().stream()
                 .map(itemReq -> {
                     VendorProduct vp = lookupVendorProduct(itemReq.getVendorProductCode());
-                    if (!vp.getVendorId().equals(po.getVendor().getId())) {
+                    if (!vp.getVendor().getId().equals(po.getVendor().getId())) {
                         throw BaseException.from(BaseResponseStatus.PURCHASE_ORDER_VENDOR_PRODUCT_MISMATCH);
                     }
                     return vp;

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
@@ -50,13 +50,13 @@ public class VendorProductService {
         }
 
         // N+1 방지 — vendorIds 일괄 lookup
-        Set<Long> vendorIds = list.stream().map(VendorProduct::getVendorId).collect(Collectors.toSet());
+        Set<Long> vendorIds = list.stream().map(vp -> vp.getVendor().getId()).collect(Collectors.toSet());
         Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
                 .collect(Collectors.toMap(Vendor::getId, v -> v));
 
         return list.stream()
                 .map(vp -> {
-                    Vendor vendor = vendorMap.get(vp.getVendorId());
+                    Vendor vendor = vendorMap.get(vp.getVendor().getId());
                     if (vendor == null) {
                         throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
                     }
@@ -68,7 +68,7 @@ public class VendorProductService {
     @Transactional(readOnly = true)
     public VendorProductDto.DetailRes findByCode(String code) {
         VendorProduct vp = lookupVendorProduct(code);
-        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
         return VendorProductDto.DetailRes.from(vp, vendor);
     }
@@ -108,7 +108,7 @@ public class VendorProductService {
                 req.getContractStart(),
                 req.getContractEnd()
         );
-        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
         return VendorProductDto.DetailRes.from(vp, vendor);
     }
@@ -145,7 +145,7 @@ public class VendorProductService {
     public VendorProductDto.DetailRes updateStatus(String code, VendorProductDto.StatusUpdateReq req) {
         VendorProduct vp = lookupVendorProduct(code);
         vp.changeStatus(req.getStatus());
-        Vendor vendor = vendorRepository.findById(vp.getVendorId())
+        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
         return VendorProductDto.DetailRes.from(vp, vendor);
     }

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
@@ -24,10 +24,12 @@ public class VendorProduct extends BaseEntity {
     @Column(name = "code", nullable = false, length = 64)
     private String code;
 
-    @Column(name = "vendor_id", nullable = false)
-    private Long vendorId;
+    // 외부 도메인 — JPA 정석 매핑 (ADR-024).
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "vendor_id", nullable = false)
+    private Vendor vendor;
 
-    // 마스터 제품 logical reference (FK 제약 없음 — 마스터 제품 BE 미구현)
+    // 마스터 제품 자연 키 — ProductMaster.code (String 자연 키, 매핑 안 박음).
     @Column(name = "product_code", nullable = false, length = 64)
     private String productCode;
 
@@ -55,11 +57,11 @@ public class VendorProduct extends BaseEntity {
     private VendorProductStatus status;
 
     @Builder
-    private VendorProduct(String code, Long vendorId, String productCode, String productName,
+    private VendorProduct(String code, Vendor vendor, String productCode, String productName,
                           Long unitPrice, Integer moq, Integer leadTimeDays,
                           LocalDate contractStart, LocalDate contractEnd, VendorProductStatus status) {
         this.code = code;
-        this.vendorId = vendorId;
+        this.vendor = vendor;
         this.productCode = productCode;
         this.productName = productName;
         this.unitPrice = unitPrice;

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProductDto.java
@@ -38,7 +38,7 @@ public class VendorProductDto {
         public VendorProduct toEntity(Vendor vendor, String code, String productName) {
             return VendorProduct.builder()
                     .code(code)
-                    .vendorId(vendor.getId())
+                    .vendor(vendor)
                     .productCode(this.productCode)
                     .productName(productName)
                     .unitPrice(this.unitPrice)

--- a/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
+++ b/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
@@ -60,17 +60,17 @@ class PurchaseOrderCatalogServiceTest {
                 .status(VendorStatus.ACTIVE).build();
         ReflectionTestUtils.setField(vendorB, "id", 2L);
 
-        vpA1 = VendorProduct.builder().code("VP-A-001").vendorId(1L)
+        vpA1 = VendorProduct.builder().code("VP-A-001").vendor(vendorA)
                 .productCode("PM-A").productName("티셔츠").unitPrice(6800L)
                 .status(VendorProductStatus.ACTIVE).build();
         ReflectionTestUtils.setField(vpA1, "id", 11L);
 
-        vpB1 = VendorProduct.builder().code("VP-B-001").vendorId(2L)
+        vpB1 = VendorProduct.builder().code("VP-B-001").vendor(vendorB)
                 .productCode("PM-B").productName("니트").unitPrice(15000L)
                 .status(VendorProductStatus.ACTIVE).build();
         ReflectionTestUtils.setField(vpB1, "id", 21L);
 
-        vpA2 = VendorProduct.builder().code("VP-A-002").vendorId(1L)
+        vpA2 = VendorProduct.builder().code("VP-A-002").vendor(vendorA)
                 .productCode("PM-EMPTY").productName("빈제품").unitPrice(9000L)
                 .status(VendorProductStatus.ACTIVE).build();
         ReflectionTestUtils.setField(vpA2, "id", 12L);


### PR DESCRIPTION
## 📌 요약
- 본인 담당 도메인 안 마지막 Long FK 잔재였던 `VendorProduct.vendor_id` → `@ManyToOne(LAZY) Vendor` JPA 정석 매핑으로 전환

<br><br>

## 🎯 작업 내용
- `VendorProduct` 엔티티에 `@ManyToOne(LAZY) Vendor vendor` + `@JoinColumn(name = "vendor_id")` 매핑 추가, Builder 가 `Vendor` 객체를 받게 변경
- `VendorProductDto.CreateReq.toEntity` Builder 호출을 `.vendorId(...)` → `.vendor(vendor)` 로 정리
- `VendorProductService` / `PurchaseOrderCatalogService` / `PurchaseOrderService` 의 `vp.getVendorId()` 호출 9곳을 `vp.getVendor().getId()` 로 통일
- `VendorProductRepository` derived query (`findAllByVendorIdAnd...`, `existsByVendorIdAnd...`, `countByVendorId`) 는 Spring Data JPA 의 nested property auto-traversal 이 `vendor.id` 매핑을 자동 인식해 메소드 시그니처 그대로 유지
- `PurchaseOrderCatalogServiceTest` Builder 호출 3곳 동기 업데이트

<br><br>

## ✔️ 참고 사항
- LAZY proxy 의 `getId()` 는 FK 컬럼만 읽어 초기화 트리거 안 함 → 기존 N+1 회피 패턴 (`vendorRepository.findAllById` 배치 lookup) 그대로 유효
- ADR-024 의 외부 도메인 매핑 패턴 — PR #207 (PurchaseOrder), PR #208 (WhInbound) 와 동일 톤으로 통일
- `./gradlew compileJava` + `./gradlew build` 단위 테스트 통과 (사전부터 있던 `contextLoads` DB 연결 의존 테스트는 환경 이슈로 무관)

<br><br>

## ✔️ 관련 이슈

- Close #209

<br><br>
