### PR TITLE
feat: 친환경 발자국 현황판 탄소 배출권 시세 공공데이터 api 연동

### DIFF
--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -109,7 +109,12 @@ public enum BaseResponseStatus {
 
 
     // 5000번대 실패
-    FAIL(false, 5000, "요청 실패");
+    FAIL(false, 5000, "요청 실패"),
+
+
+    // 5100번대 외부 API 관련 (시스템 에러)
+    EXTERNAL_API_ERROR(false, 5100, "외부 API 호출 중 오류가 발생했습니다."),
+    CARBON_PRICE_UNAVAILABLE(false, 5101, "배출권 시세 정보를 불러올 수 없습니다.");
 
     private final boolean success;
     private final int code;

--- a/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceApiClient.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceApiClient.java
@@ -1,0 +1,137 @@
+package org.example.stockitbe.hq.esg;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.hq.esg.model.CarbonPriceDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class CarbonPriceApiClient {
+
+    private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.BASIC_ISO_DATE;
+    private static final String SUCCESS_CODE = "00";   // 공공데이터포털 정상 코드
+
+    private final WebClient webClient;
+    private final String serviceKey;
+    private final String targetSymbol;
+
+    public CarbonPriceApiClient(
+            @Value("${esg.carbon-api.base-url}") String baseUrl,
+            @Value("${esg.carbon-api.service-key}") String serviceKey,
+            @Value("${esg.carbon-api.target-symbol}") String targetSymbol
+    ) {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(baseUrl);
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+
+        this.webClient = WebClient.builder()
+                .uriBuilderFactory(factory)
+                .build();
+        this.serviceKey = serviceKey;
+        this.targetSymbol = targetSymbol;
+    }
+
+    public List<CarbonPriceDto.Item> fetchPrices(LocalDate from, LocalDate to) {
+        try {
+            CarbonPriceDto.ApiResponse res = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/getCertifiedEmissionReductionPriceInfo")
+                            .queryParam("serviceKey", serviceKey)
+                            .queryParam("numOfRows", 1000)              // 6개월치
+                            .queryParam("pageNo", 1)
+                            .queryParam("resultType", "json")
+                            .queryParam("itmsNm", targetSymbol)
+                            .queryParam("beginBasDt", from.format(YYYYMMDD))
+                            .queryParam("endBasDt", to.format(YYYYMMDD))
+                            .build())
+                    .retrieve()
+                    .bodyToMono(CarbonPriceDto.ApiResponse.class)
+                    .block();
+
+            if (res == null
+                    || res.getResponse() == null
+                    || res.getResponse().getHeader() == null) {
+                log.error("배출권 API 응답 구조 비정상");
+                return Collections.emptyList();
+            }
+            CarbonPriceDto.Header header = res.getResponse().getHeader();
+            if (!SUCCESS_CODE.equals(header.getResultCode())) {
+                log.error("배출권 API 비정상 응답: code={}, msg={}",
+                        header.getResultCode(), header.getResultMsg());
+                return Collections.emptyList();
+            }
+            return Optional.ofNullable(res.getResponse().getBody())
+                    .map(CarbonPriceDto.Body::getItems)
+                    .map(CarbonPriceDto.Items::getItem)
+                    .orElse(Collections.emptyList());
+        } catch (Exception e) {
+            log.error("배출권 시세 API 호출 실패", e);
+            return Collections.emptyList();
+        }
+    }
+
+
+
+
+    /**
+     * KAU25 시세 최근 2주 일별 데이터 조회.
+     *
+     * 정책 — Graceful Degradation:
+     *  - 네트워크 / 파싱 / 외부 API 비정상응답 모두 빈 리스트로 반환
+     *  - 호출 측(Service) 에서 fallbackPrice 로 대체 → 화면 끊김 방지
+     *  - 의심 케이스는 log.error 로 흔적 남김 (운영 모니터링 시 확인)
+     */
+    public List<CarbonPriceDto.Item> fetchRecentPrices() {
+        LocalDate today = LocalDate.now();
+        LocalDate from = today.minusDays(14);
+
+        try {
+            CarbonPriceDto.ApiResponse res = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/getCertifiedEmissionReductionPriceInfo")
+                            .queryParam("serviceKey", serviceKey)
+                            .queryParam("numOfRows", 30)
+                            .queryParam("pageNo", 1)
+                            .queryParam("resultType", "json")
+                            .queryParam("itmsNm", targetSymbol)
+                            .queryParam("beginBasDt", from.format(YYYYMMDD))
+                            .queryParam("endBasDt", today.format(YYYYMMDD))
+                            .build())
+                    .retrieve()
+                    .bodyToMono(CarbonPriceDto.ApiResponse.class)
+                    .block();
+
+            // 응답 헤더 검증 — resultCode 가 "00" 이 아니면 외부 API 비정상 응답
+            if (res == null
+                    || res.getResponse() == null
+                    || res.getResponse().getHeader() == null) {
+                log.error("배출권 API 응답 구조 비정상 (헤더 없음)");
+                return Collections.emptyList();
+            }
+
+            CarbonPriceDto.Header header = res.getResponse().getHeader();
+            if (!SUCCESS_CODE.equals(header.getResultCode())) {
+                log.error("배출권 API 비정상 응답: code={}, msg={}",
+                        header.getResultCode(), header.getResultMsg());
+                return Collections.emptyList();
+            }
+
+            return Optional.ofNullable(res.getResponse().getBody())
+                    .map(CarbonPriceDto.Body::getItems)
+                    .map(CarbonPriceDto.Items::getItem)
+                    .orElse(Collections.emptyList());
+
+        } catch (Exception e) {
+            log.error("배출권 시세 API 호출 실패", e);
+            return Collections.emptyList();   // 폴백 (Service 에서 fallbackPrice 사용)
+        }
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceController.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceController.java
@@ -1,0 +1,32 @@
+package org.example.stockitbe.hq.esg;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.esg.model.CarbonPriceDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hq/esg")
+@RequiredArgsConstructor
+public class CarbonPriceController {
+
+    private final CarbonPriceService carbonPriceService;
+
+    @GetMapping("/carbon-price/latest")
+    public ResponseEntity<BaseResponse<CarbonPriceDto.Snapshot>> getLatest() {
+        return ResponseEntity.ok(BaseResponse.success(carbonPriceService.getLatestPrice()));
+    }
+
+    @GetMapping("/carbon-price/trend")
+    public ResponseEntity<BaseResponse<List<CarbonPriceDto.Snapshot>>> getTrend(
+            @RequestParam(defaultValue = "SEVEN_DAYS") CarbonPriceService.Period period
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(carbonPriceService.getTrend(period)));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/CarbonPriceService.java
@@ -1,0 +1,80 @@
+package org.example.stockitbe.hq.esg;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.hq.esg.model.CarbonPriceDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CarbonPriceService {
+
+    private final CarbonPriceApiClient apiClient;
+
+    @Value("${esg.carbon-api.fallback-price:9200}")
+    private int fallbackPrice;
+
+    /** 그래프 기간 옵션 — FE 탭과 1:1 매핑 */
+    public enum Period {
+        SEVEN_DAYS(14),
+        ONE_MONTH(45),
+        SIX_MONTHS(200);
+
+        public final int dayRange;
+        Period(int dayRange) { this.dayRange = dayRange; }
+    }
+
+    /** 가장 최근 거래일의 KAU 종가 (KPI 카드용) — 14일 범위에서 추출 */
+    public CarbonPriceDto.Snapshot getLatestPrice() {
+        List<CarbonPriceDto.Item> items = apiClient.fetchRecentPrices().stream()
+                .filter(this::hasTrading)
+                .toList();
+        return items.stream()
+                .max(Comparator.comparing(CarbonPriceDto.Item::getBasDt))
+                .map(this::toSnapshot)
+                .orElseGet(() -> {
+                    log.warn("배출권 시세 폴백 사용 (가격={}원/톤)", fallbackPrice);
+                    return new CarbonPriceDto.Snapshot(
+                            fallbackPrice, "FALLBACK", null, null, true);
+                });
+    }
+
+    /** 시계열 — 기간 옵션에 따라 호출 범위 다르게, 거래량 0 제외 */
+    public List<CarbonPriceDto.Snapshot> getTrend(Period period) {
+        LocalDate today = LocalDate.now();
+        LocalDate from = today.minusDays(period.dayRange);
+
+        return apiClient.fetchPrices(from, today).stream()
+                .filter(this::hasTrading)              // 거래량 > 0 만
+                .sorted(Comparator.comparing(CarbonPriceDto.Item::getBasDt))
+                .map(this::toSnapshot)
+                .toList();
+    }
+
+    /** 거래량 > 0 인지 검사 (실제 거래된 날짜만 의미 있음) */
+    private boolean hasTrading(CarbonPriceDto.Item item) {
+        String trqu = item.getTrqu();
+        if (trqu == null || trqu.isBlank()) return false;
+        try {
+            return Long.parseLong(trqu.replace(",", "")) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private CarbonPriceDto.Snapshot toSnapshot(CarbonPriceDto.Item item) {
+        return new CarbonPriceDto.Snapshot(
+                Integer.parseInt(item.getClpr().replace(",", "")),
+                item.getItmsNm(),
+                item.getBasDt(),
+                item.getFltRt(),
+                false
+        );
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/model/CarbonPriceDto.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/model/CarbonPriceDto.java
@@ -1,0 +1,71 @@
+package org.example.stockitbe.hq.esg.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CarbonPriceDto {
+
+    // ─────────── 외부 공공데이터 API 응답 매핑 ───────────
+
+    @Getter @NoArgsConstructor
+    public static class ApiResponse {
+        private ResponseBody response;
+    }
+
+    @Getter @NoArgsConstructor
+    public static class ResponseBody {
+        private Header header;
+        private Body body;
+    }
+
+    @Getter @NoArgsConstructor
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Getter @NoArgsConstructor
+    public static class Body {
+        private Integer numOfRows;
+        private Integer pageNo;
+        private Integer totalCount;
+        private Items items;
+    }
+
+    @Getter @NoArgsConstructor
+    public static class Items {
+        @JsonProperty("item")
+        private List<Item> item;
+    }
+
+    @Getter @NoArgsConstructor
+    public static class Item {
+        private String basDt;     // 기준일자 YYYYMMDD
+        private String srtnCd;    // 단축코드
+        private String isinCd;    // ISIN 코드
+        private String itmsNm;    // 종목명 (KAU25 등)
+        private String clpr;      // 종가 (원/톤)
+        private String vs;        // 전일대비
+        private String fltRt;     // 등락률
+        private String mkp;       // 시가
+        private String hipr;      // 고가
+        private String lopr;      // 저가
+        private String trqu;      // 거래량
+        private String trPrc;     // 거래대금
+    }
+
+    // ─────────── BE → FE 응답 ───────────
+
+    @Getter @AllArgsConstructor @NoArgsConstructor
+    public static class Snapshot {
+        private int pricePerTon;    // 원/톤
+        private String symbol;      // KAU25
+        private String basDt;       // YYYYMMDD
+        private String fltRt;       // 등락률
+        private boolean fallback;   // 폴백값 여부
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -44,3 +44,11 @@ jwt:
   access-expiration-ms: ${JWT_ACCESS_EXPIRATION_MS}
   refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION_MS}
 
+
+esg:
+  carbon-api:
+    base-url: https://apis.data.go.kr/1160100/service/GetGeneralProductInfoService
+    service-key: ${PUBLIC_DATA_API_KEY}
+    target-symbol: KAU25       # 현재 거래 활성 종목
+    fallback-price: 9200
+


### PR DESCRIPTION
## 📌 요약
- 친환경 발자국 현황판 탄소 배출권 시세 공공데이터 api 연동

<br><br>

## 🎯 작업 내용
- 외부 데이터 소스
- 공공데이터포털 — 금융위원회 일반상품시세정보 서비스
- 종목코드: KAU25 (한국거래소 배출권 시장)
- 운영시간: 평일 10:00~12:00 (휴장일 데이터 없음 → 차트 자동 제외)
-  `CarbonPriceApiClient.java - 공공데이터포털 외부 API 호출 클라이언트 (RestTemplate / WebClient) |
- `CarbonPriceController.java`  - `GET /api/hq/esg/carbon-price/...` 엔드포인트 |
-  `CarbonPriceService.java` -  캐싱·폴백·에러 처리 비즈니스 로직 |
-  `model/CarbonPriceDto.java`  - 시세 응답 DTO (latest / trend) |
-  `application-dev.yml`  - 공공데이터포털 API 키 + 엔드포인트 환경변수 |
-  `BaseResponseStatus.java`   - 외부 API 실패 응답 코드 추가 |
- 

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #187 

<br><br>
