### PR TITLE
refactor(jpa): list 쿼리 N+1 해소 — @EntityGraph 도입

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogService.java
@@ -66,13 +66,7 @@ public class PurchaseOrderCatalogService {
                     .build();
         }
 
-        // 2) Vendor 일괄 조회 + ACTIVE 만 통과
-        Set<Long> vendorIds = vendorProducts.stream()
-                .map(vp -> vp.getVendor().getId())
-                .collect(Collectors.toSet());
-        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
-                .filter(v -> v.getStatus() == VendorStatus.ACTIVE)
-                .collect(Collectors.toMap(Vendor::getId, v -> v));
+        // 2) Vendor — VendorProductRepository.@EntityGraph 가 fetch 한 vendor 직접 사용 (ACTIVE 만 통과)
 
         // 3) ProductMaster 일괄 조회 + ACTIVE 만 통과 (productCode key)
         Set<String> productCodes = vendorProducts.stream()
@@ -91,8 +85,8 @@ public class PurchaseOrderCatalogService {
         // 5) MasterRes 빌드 (SKU 0건 마스터 제외)
         List<PurchaseOrderCatalogDto.MasterRes> masters = new ArrayList<>();
         for (VendorProduct vp : vendorProducts) {
-            Vendor vendor = vendorMap.get(vp.getVendor().getId());
-            if (vendor == null) continue; // vendor 비ACTIVE
+            Vendor vendor = vp.getVendor();
+            if (vendor.getStatus() != VendorStatus.ACTIVE) continue; // vendor 비ACTIVE
             ProductMaster master = productMap.get(vp.getProductCode());
             if (master == null) continue; // master 비ACTIVE 또는 없음
             List<ProductSku> skus = skusByProductCode.getOrDefault(vp.getProductCode(), List.of());

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
@@ -2,6 +2,8 @@ package org.example.stockitbe.hq.purchaseorder;
 
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -12,7 +14,12 @@ import java.util.Optional;
 public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>,
                                                   JpaSpecificationExecutor<PurchaseOrder> {
 
+    @EntityGraph(attributePaths = {"vendor", "warehouse"})
     Optional<PurchaseOrder> findByCode(String code);
+
+    @Override
+    @EntityGraph(attributePaths = {"vendor", "warehouse"})
+    List<PurchaseOrder> findAll(Specification<PurchaseOrder> spec);
 
     long countByCodeStartingWith(String prefix);
 

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -61,26 +61,15 @@ public class PurchaseOrderService {
         }
 
         Specification<PurchaseOrder> spec = buildSpec(vendorIdFilter, status, from, to);
+        // @EntityGraph(vendor, warehouse) — 단일 LEFT JOIN 으로 fetch.
         List<PurchaseOrder> orders = purchaseOrderRepository.findAll(spec);
         if (orders.isEmpty()) {
             return List.of();
         }
 
-        // vendor / warehouse / itemCount 매핑.
-        // LAZY proxy 의 getId() 는 추가 쿼리 X — proxy 안에 id 미리 채워져 있음.
-        Set<Long> vendorIds = orders.stream().map(po -> po.getVendor().getId()).collect(Collectors.toSet());
-        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
-                .collect(Collectors.toMap(Vendor::getId, v -> v));
-
-        Set<Long> warehouseIds = orders.stream().map(po -> po.getWarehouse().getId()).collect(Collectors.toSet());
-        Map<Long, String> warehouseCodeById = infrastructureRepository.findAllById(warehouseIds).stream()
-                .filter(infra -> infra.getLocationType() == LocationType.WAREHOUSE)
-                .collect(Collectors.toMap(Infrastructure::getId, Infrastructure::getCode));
-
         Set<Long> orderIds = orders.stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
         // batch 1회 조회 결과를 itemCountMap + productNamesMap 두 가지로 활용 (쿼리 0추가)
         List<PurchaseOrderItem> allItems = itemRepository.findAllByPurchaseOrderIdIn(orderIds);
-        // LAZY proxy 의 getId() 는 추가 쿼리 X — proxy 안에 id 미리 채워져 있음.
         Map<Long, Long> itemCountMap = allItems.stream()
                 .collect(Collectors.groupingBy(it -> it.getPurchaseOrder().getId(), Collectors.counting()));
         Map<Long, List<String>> productNamesMap = allItems.stream()
@@ -90,14 +79,9 @@ public class PurchaseOrderService {
 
         return orders.stream()
                 .map(po -> {
-                    Vendor vendor = vendorMap.get(po.getVendor().getId());
-                    if (vendor == null) {
-                        throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
-                    }
                     int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
                     List<String> names = productNamesMap.getOrDefault(po.getId(), List.of());
-                    String warehouseCode = warehouseCodeById.getOrDefault(po.getWarehouse().getId(), "");
-                    return PurchaseOrderDto.ListRes.from(po, vendor, warehouseCode, count, names);
+                    return PurchaseOrderDto.ListRes.from(po, po.getVendor(), po.getWarehouse().getCode(), count, names);
                 })
                 .toList();
     }
@@ -351,14 +335,9 @@ public class PurchaseOrderService {
     }
 
     private PurchaseOrderDto.DetailRes buildDetailRes(PurchaseOrder po) {
-        Vendor vendor = vendorRepository.findById(po.getVendor().getId())
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
-
-        // warehouse code lookup (응답용 — id → code 변환)
-        String warehouseCode = infrastructureRepository.findById(po.getWarehouse().getId())
-                .filter(infra -> infra.getLocationType() == LocationType.WAREHOUSE)
-                .map(Infrastructure::getCode)
-                .orElse("");
+        // @EntityGraph(vendor, warehouse) on findByCode — proxy 가 아닌 실 entity. 추가 lookup 불필요.
+        Vendor vendor = po.getVendor();
+        String warehouseCode = po.getWarehouse().getCode();
 
         List<PurchaseOrderItem> items = itemRepository.findAllByPurchaseOrderId(po.getId());
         List<PurchaseOrderStatusHistory> history = historyRepository.findAllByPurchaseOrderIdOrderByChangedAtAsc(po.getId());

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductRepository.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.hq.vendor;
 
 import org.example.stockitbe.hq.vendor.model.VendorProduct;
 import org.example.stockitbe.hq.vendor.model.VendorProductStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,12 +10,16 @@ import java.util.Optional;
 
 public interface VendorProductRepository extends JpaRepository<VendorProduct, Long> {
 
+    @EntityGraph(attributePaths = "vendor")
     Optional<VendorProduct> findByCode(String code);
 
+    @EntityGraph(attributePaths = "vendor")
     List<VendorProduct> findAllByVendorIdAndStatusNotOrderByIdDesc(Long vendorId, VendorProductStatus excluded);
 
+    @EntityGraph(attributePaths = "vendor")
     List<VendorProduct> findAllByStatusOrderByIdDesc(VendorProductStatus status);
 
+    @EntityGraph(attributePaths = "vendor")
     List<VendorProduct> findAllByStatusNotOrderByIdDesc(VendorProductStatus excluded);
 
     boolean existsByVendorIdAndProductCodeAndStatusNot(Long vendorId, String productCode, VendorProductStatus excluded);

--- a/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/VendorProductService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -48,29 +47,15 @@ public class VendorProductService {
         if (list.isEmpty()) {
             return List.of();
         }
-
-        // N+1 방지 — vendorIds 일괄 lookup
-        Set<Long> vendorIds = list.stream().map(vp -> vp.getVendor().getId()).collect(Collectors.toSet());
-        Map<Long, Vendor> vendorMap = vendorRepository.findAllById(vendorIds).stream()
-                .collect(Collectors.toMap(Vendor::getId, v -> v));
-
         return list.stream()
-                .map(vp -> {
-                    Vendor vendor = vendorMap.get(vp.getVendor().getId());
-                    if (vendor == null) {
-                        throw BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND);
-                    }
-                    return VendorProductDto.ListRes.from(vp, vendor);
-                })
+                .map(vp -> VendorProductDto.ListRes.from(vp, vp.getVendor()))
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public VendorProductDto.DetailRes findByCode(String code) {
         VendorProduct vp = lookupVendorProduct(code);
-        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
-        return VendorProductDto.DetailRes.from(vp, vendor);
+        return VendorProductDto.DetailRes.from(vp, vp.getVendor());
     }
 
     @Transactional
@@ -108,9 +93,7 @@ public class VendorProductService {
                 req.getContractStart(),
                 req.getContractEnd()
         );
-        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
-        return VendorProductDto.DetailRes.from(vp, vendor);
+        return VendorProductDto.DetailRes.from(vp, vp.getVendor());
     }
 
     /**
@@ -145,9 +128,7 @@ public class VendorProductService {
     public VendorProductDto.DetailRes updateStatus(String code, VendorProductDto.StatusUpdateReq req) {
         VendorProduct vp = lookupVendorProduct(code);
         vp.changeStatus(req.getStatus());
-        Vendor vendor = vendorRepository.findById(vp.getVendor().getId())
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.VENDOR_NOT_FOUND));
-        return VendorProductDto.DetailRes.from(vp, vendor);
+        return VendorProductDto.DetailRes.from(vp, vp.getVendor());
     }
 
     @Transactional

--- a/src/main/java/org/example/stockitbe/warehouse/inbound/WhInboundHeaderRepository.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inbound/WhInboundHeaderRepository.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.warehouse.inbound;
 
 import org.example.stockitbe.warehouse.inbound.model.InboundType;
 import org.example.stockitbe.warehouse.inbound.model.entity.WhInboundHeader;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -11,14 +12,18 @@ import java.util.Optional;
 public interface WhInboundHeaderRepository extends JpaRepository<WhInboundHeader, Long>,
         JpaSpecificationExecutor<WhInboundHeader> {
 
+    @EntityGraph(attributePaths = "warehouse")
     Optional<WhInboundHeader> findByInboundCode(String inboundCode);
 
     Optional<WhInboundHeader> findBySourceRefNoAndInboundType(String sourceRefNo, InboundType inboundType);
 
     Optional<WhInboundHeader> findTopByInboundCodeStartingWithOrderByInboundCodeDesc(String prefix);
 
+    // items 는 OneToMany 라 카타시안 회피로 @EntityGraph 미포함 — Service 가 batch 별도 fetch.
+    @EntityGraph(attributePaths = "warehouse")
     List<WhInboundHeader> findAllByWarehouseIdAndInboundTypeOrderByCreatedAtDesc(
             Long warehouseId, InboundType inboundType);
 
+    @EntityGraph(attributePaths = "warehouse")
     List<WhInboundHeader> findAllByWarehouseIdOrderByCreatedAtDesc(Long warehouseId);
 }

--- a/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
+++ b/src/test/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderCatalogServiceTest.java
@@ -102,7 +102,6 @@ class PurchaseOrderCatalogServiceTest {
     void getCatalog_allVendors() {
         when(vendorProductRepository.findAllByStatusOrderByIdDesc(VendorProductStatus.ACTIVE))
                 .thenReturn(List.of(vpA1, vpB1));
-        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA, vendorB));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmB));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
                 sku("SKU-A-1", "PM-A", "화이트", "L", 6800L),
@@ -133,7 +132,6 @@ class PurchaseOrderCatalogServiceTest {
     void getCatalog_skipMastersWithoutSkus() {
         when(vendorProductRepository.findAllByStatusOrderByIdDesc(VendorProductStatus.ACTIVE))
                 .thenReturn(List.of(vpA1, vpA2));
-        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA, pmEmpty));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
                 sku("SKU-A-1", "PM-A", "화이트", "L", 6800L)
@@ -152,7 +150,6 @@ class PurchaseOrderCatalogServiceTest {
         when(vendorRepository.findByCode("VND-A")).thenReturn(java.util.Optional.of(vendorA));
         when(vendorProductRepository.findAllByVendorIdAndStatusNotOrderByIdDesc(1L, VendorProductStatus.DELETED))
                 .thenReturn(List.of(vpA1));
-        when(vendorRepository.findAllById(any())).thenReturn(List.of(vendorA));
         when(productMasterRepository.findAllByCodeIn(any())).thenReturn(List.of(pmA));
         when(productSkuRepository.findAllByProductCodeInOrderByIdAsc(any())).thenReturn(List.of(
                 sku("SKU-A-1", "PM-A", "화이트", "L", 6800L)


### PR DESCRIPTION
## 📌 요약
- list 쿼리에서 외부 도메인 `@ManyToOne(LAZY)` join 을 `@EntityGraph` 로 일괄 처리. service 단의 manual batch lookup 제거.

<br><br>

## 🎯 작업 내용
- `VendorProductRepository` 4개 메소드에 `@EntityGraph(attributePaths = "vendor")` 추가
- `PurchaseOrderRepository.findByCode` + `findAll(Specification)` 에 `@EntityGraph(attributePaths = {"vendor", "warehouse"})` 추가
- `WhInboundHeaderRepository` list/detail 3개 메소드에 `@EntityGraph(attributePaths = "warehouse")` 추가 (items 카타시안 회피)
- `VendorProductService` / `PurchaseOrderService` / `PurchaseOrderCatalogService` 의 manual batch lookup 제거 → entity 직접 사용

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #214

<br><br>
