### PR TITLE
fix(warehouse-dashboard): warehouseId 참조를 warehouse.id 로 정정

### DIFF
--- a/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/dashboard/DashboardService.java
@@ -144,7 +144,8 @@ public class DashboardService {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             if (warehouseId != null) {
-                predicates.add(cb.equal(root.get("warehouseId"), warehouseId));
+                // PurchaseOrder 외부 도메인 매핑 정석화(이슈 #205) 후 entity 필드는 warehouseId(Long) → warehouse(@ManyToOne).
+                predicates.add(cb.equal(root.get("warehouse").get("id"), warehouseId));
             }
             if (from != null) {
                 Date fromDate = Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());


### PR DESCRIPTION
## 📌 요약
- 창고 대시보드 진입 시 axios 인증 만료 chain 으로 로그인 페이지로 튕기던 현상 fix. 실제 원인은 401 이 아니라 `DashboardService` 의 옛 `warehouseId` 참조 → `PathElementException` → 500 응답 → FE interceptor 가 forceLogout 처리.

<br><br>

## 🎯 작업 내용
- `DashboardService.buildSpec` 의 `root.get("warehouseId")` → `root.get("warehouse").get("id")` 로 정정
- 이슈 #205 (PR #211) 에서 `PurchaseOrder` 의 외부 도메인 매핑이 `@ManyToOne(LAZY) Infrastructure warehouse` 로 정석화되며 옛 `warehouseId` Long 컬럼이 제거된 영향 반영

<br><br>

## ✔️ 참고 사항
- 본인 영역(이슈 #218) PR #225 머지 직후 시연 검증 중 발견된 별 도메인 fix
- 동일 패턴(`warehouseId` 직접 참조) 이 다른 곳에도 남아있는지 본인 영역(`warehouse.dashboard`) 외 추가 점검 필요할 수 있음

<br><br>

## ✔️ 관련 이슈

- 

<br><br>
