### PR TITLE
feat: 창고간 재고 이동 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -258,7 +258,6 @@ public class InventoryService {
     @Transactional(readOnly = true)
     public List<InventoryDto.ImbalancedSkuRes> findImbalancedSkus() {
         List<Inventory> inventories = inventoryRepository.findAll();
-        if (inventories.isEmpty()) return List.of();
 
         Map<Long, Infrastructure> warehouseById = infrastructureRepository.findAll().stream()
                 .filter(infra -> infra.getLocationType() == LocationType.WAREHOUSE)
@@ -267,6 +266,7 @@ public class InventoryService {
 
         Set<Long> skuIds = inventories.stream()
                 .filter(inv -> warehouseById.containsKey(inv.getLocationId()))
+                .filter(inv -> InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inv.getInventoryStatus()))
                 .map(Inventory::getSkuId)
                 .collect(Collectors.toSet());
         if (skuIds.isEmpty()) return List.of();
@@ -296,22 +296,28 @@ public class InventoryService {
         }
 
         Map<Long, ImbalancedSkuAggregate> aggregateBySkuId = new HashMap<>();
-        for (WarehouseSkuStock stock : stockByWarehouseSkuKey.values()) {
-            ProductSku sku = skuById.get(stock.skuId);
-            if (sku == null) continue;
+        for (ProductSku sku : skuById.values()) {
             ProductMaster master = masterByCode.get(sku.getProductCode());
             if (master == null) continue;
 
-            ImbalancedSkuAggregate agg = aggregateBySkuId.computeIfAbsent(sku.getId(), key -> new ImbalancedSkuAggregate(sku, master));
+            ImbalancedSkuAggregate agg = new ImbalancedSkuAggregate(sku, master);
             int safetyStock = Math.max(0, n(master.getWarehouseSafetyStock()));
 
-            agg.totalOnHand += stock.totalOnHand;
-            agg.totalAvailable += stock.totalAvailable;
+            for (Long warehouseId : warehouseById.keySet()) {
+                String key = sku.getId() + ":" + warehouseId;
+                WarehouseSkuStock stock = stockByWarehouseSkuKey.get(key);
+                int onHand = stock == null ? 0 : stock.totalOnHand;
+                int available = stock == null ? 0 : stock.totalAvailable;
 
-            if (stock.totalAvailable < safetyStock) {
-                agg.shortageWarehouseCount += 1;
-                agg.totalShortageQty += (safetyStock - stock.totalAvailable);
+                agg.totalOnHand += onHand;
+                agg.totalAvailable += available;
+
+                if (available < safetyStock) {
+                    agg.shortageWarehouseCount += 1;
+                    agg.totalShortageQty += (safetyStock - available);
+                }
             }
+            aggregateBySkuId.put(sku.getId(), agg);
         }
 
         return aggregateBySkuId.values().stream()

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -288,6 +288,7 @@ public class InventoryService {
         Map<String, WarehouseSkuStock> stockByWarehouseSkuKey = new HashMap<>();
         for (Inventory inventory : inventories) {
             if (!warehouseById.containsKey(inventory.getLocationId())) continue;
+            if (!InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inventory.getInventoryStatus())) continue;
             String key = inventory.getSkuId() + ":" + inventory.getLocationId();
             WarehouseSkuStock stock = stockByWarehouseSkuKey.computeIfAbsent(key, ignored -> new WarehouseSkuStock(inventory.getSkuId()));
             stock.totalOnHand += Math.max(0, n(inventory.getQuantity()));

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
@@ -357,12 +357,8 @@ public class WarehouseTransferService {
                     .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
             skuByCode.put(line.getSkuCode(), sku);
 
-            int fromAvailable = inventoryRepository.findBySkuIdAndLocationId(sku.getId(), fromWarehouse.getId())
-                    .map(Inventory::getAvailableQuantity)
-                    .orElse(0);
-            int toAvailable = inventoryRepository.findBySkuIdAndLocationId(sku.getId(), toWarehouse.getId())
-                    .map(Inventory::getAvailableQuantity)
-                    .orElse(0);
+            int fromAvailable = sumAvailableForTransfer(sku.getId(), fromWarehouse.getId());
+            int toAvailable = sumAvailableForTransfer(sku.getId(), toWarehouse.getId());
             if (safeQty(line.getQty()) > Math.max(0, fromAvailable)) {
                 throw BaseException.from(BaseResponseStatus.REQUEST_ERROR);
             }
@@ -370,6 +366,13 @@ public class WarehouseTransferService {
             toAvailableBySkuId.put(sku.getId(), Math.max(0, toAvailable));
         }
         return new ExecuteGroupContext(fromWarehouse, toWarehouse, skuByCode, fromAvailableBySkuId, toAvailableBySkuId);
+    }
+
+    private int sumAvailableForTransfer(Long skuId, Long locationId) {
+        return inventoryRepository.findAllBySkuIdAndLocationId(skuId, locationId).stream()
+                .filter(inv -> InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inv.getInventoryStatus()))
+                .mapToInt(inv -> Math.max(0, nz(inv.getAvailableQuantity())))
+                .sum();
     }
 
     private Infrastructure loadWarehouse(String code) {

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
@@ -8,6 +8,7 @@ import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.inventory.InventoryRepository;
 import org.example.stockitbe.hq.inventory.model.Inventory;
+import org.example.stockitbe.hq.inventory.model.InventoryStatusPolicy;
 import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.ProductSkuRepository;
 import org.example.stockitbe.hq.product.model.ProductMaster;
@@ -149,14 +150,23 @@ public class WarehouseTransferService {
         ProductMaster master = productMasterRepository.findByCode(sku.getProductCode())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND));
 
-        Map<Long, Inventory> inventoryByLocation = inventoryRepository.findAllBySkuIdIn(List.of(sku.getId())).stream()
-                .collect(Collectors.toMap(Inventory::getLocationId, Function.identity(), (a, b) -> a));
+        Map<Long, WarehouseSkuStockAggregate> stockByLocation = new HashMap<>();
+        inventoryRepository.findAllBySkuIdIn(List.of(sku.getId())).stream()
+                .filter(inv -> InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inv.getInventoryStatus()))
+                .forEach(inv -> {
+                    WarehouseSkuStockAggregate stock = stockByLocation.computeIfAbsent(inv.getLocationId(), ignored -> new WarehouseSkuStockAggregate());
+                    stock.onHand += Math.max(0, nz(inv.getQuantity()));
+                    stock.available += Math.max(0, nz(inv.getAvailableQuantity()));
+                    if (stock.updatedAt == null || (inv.getUpdatedAt() != null && inv.getUpdatedAt().after(stock.updatedAt))) {
+                        stock.updatedAt = inv.getUpdatedAt();
+                    }
+                });
 
         return infrastructureRepository.findByLocationTypeOrderByIdDesc(LocationType.WAREHOUSE).stream()
                 .map(warehouse -> {
-                    Inventory inv = inventoryByLocation.get(warehouse.getId());
-                    int onHand = inv == null ? 0 : nz(inv.getQuantity());
-                    int available = inv == null ? 0 : nz(inv.getAvailableQuantity());
+                    WarehouseSkuStockAggregate stock = stockByLocation.get(warehouse.getId());
+                    int onHand = stock == null ? 0 : stock.onHand;
+                    int available = stock == null ? 0 : stock.available;
                     int reserved = Math.max(0, onHand - available);
                     int safety = Math.max(0, nz(master.getWarehouseSafetyStock()));
                     String status = available <= 0 ? "품절" : (available < safety ? "부족" : "정상");
@@ -169,11 +179,17 @@ public class WarehouseTransferService {
                             .availableStock(available)
                             .safetyStock(safety)
                             .status(status)
-                            .updatedAt(inv == null ? null : inv.getUpdatedAt())
+                            .updatedAt(stock == null ? null : stock.updatedAt)
                             .build();
                 })
                 .sorted(Comparator.comparing(WarehouseTransferDto.WarehouseSkuDistributionRes::getWarehouseCode))
                 .toList();
+    }
+
+    private static class WarehouseSkuStockAggregate {
+        private int onHand;
+        private int available;
+        private Date updatedAt;
     }
 
     private List<WarehouseTransferDto.TransferListItemRes> buildListItems(List<WarehouseTransferHeader> headers, String keyword) {

--- a/src/main/resources/sql/05-1-inventory_dummy_data_dev_light.sql
+++ b/src/main/resources/sql/05-1-inventory_dummy_data_dev_light.sql
@@ -1,0 +1,120 @@
+-- 재고 더미 데이터 (개발용 경량 버전, 상태별 다중 행)
+-- 실행 순서:
+-- 1) 01-infrastructure_dummy_data.sql
+-- 2) 02-store_warehouse_map_dummy_data.sql
+-- 3) 03-category_two_level_seed.sql
+-- 4) 04-product_master_dummy_data.sql
+-- 5) 본 파일(05-1-inventory_dummy_data_dev_light.sql) 실행
+--
+-- 안내:
+-- - 개발 환경에서는 기존 05-inventory_dummy_data.sql 대신 본 파일을 선택 실행한다.
+-- - 기존 규칙/포맷(컬럼, 상태, upsert)을 유지하되 대상 SKU/거점을 축소해 로딩 부담을 줄인다.
+
+INSERT INTO inventory
+(sku_id, location_id, inventory_status, quantity, reserved_quantity, in_transit_quantity, available_quantity, status_changed_at, last_movement_at, create_date, update_date)
+SELECT
+    x.sku_id,
+    x.location_id,
+    x.inventory_status,
+    x.quantity,
+    x.reserved_quantity,
+    x.in_transit_quantity,
+    GREATEST(x.quantity - x.reserved_quantity, 0) AS available_quantity,
+    x.status_changed_at,
+    x.last_movement_at,
+    NOW(),
+    NOW()
+FROM (
+    SELECT
+        b.sku_id,
+        b.location_id,
+        st.inventory_status,
+        b.target_sum,
+        b.candidate_qty,
+        b.normal_qty,
+        CASE st.inventory_status
+            WHEN 'NORMAL' THEN b.normal_qty
+            WHEN 'CIRCULAR_CANDIDATE' THEN b.candidate_qty
+            ELSE
+                GREATEST(
+                    1,
+                    FLOOR(
+                        b.target_sum * (0.03 + MOD(b.sku_id * 2 + b.location_id, 4) * 0.01)
+                    )
+                )
+        END AS quantity,
+        CASE st.inventory_status
+            WHEN 'NORMAL' THEN
+                GREATEST(
+                    0,
+                    LEAST(
+                        FLOOR(b.normal_qty * 0.20),
+                        MOD(b.sku_id * 11 + b.location_id * 7,
+                            FLOOR(b.normal_qty * 0.25) + 1)
+                    )
+                )
+            ELSE 0
+        END AS reserved_quantity,
+        CASE st.inventory_status
+            WHEN 'NORMAL' THEN MOD(b.sku_id * 3 + b.location_id * 5, 25)
+            ELSE 0
+        END AS in_transit_quantity,
+        CASE st.inventory_status
+            WHEN 'NORMAL' THEN DATE_SUB(NOW(), INTERVAL MOD(b.sku_id * 2 + b.location_id * 3, 120) DAY)
+            WHEN 'CIRCULAR_CANDIDATE' THEN DATE_SUB(NOW(), INTERVAL 90 + MOD(b.sku_id * 5 + b.location_id * 7, 180) DAY)
+            ELSE DATE_SUB(NOW(), INTERVAL 240 + MOD(b.sku_id * 11 + b.location_id * 13, 420) DAY)
+        END AS status_changed_at,
+        CASE st.inventory_status
+            WHEN 'NORMAL' THEN DATE_SUB(NOW(), INTERVAL MOD(b.sku_id * 7 + b.location_id * 3, 365) DAY)
+            WHEN 'CIRCULAR_CANDIDATE' THEN DATE_SUB(NOW(), INTERVAL 400 + MOD(b.sku_id * 13 + b.location_id * 2, 500) DAY)
+            ELSE DATE_SUB(NOW(), INTERVAL 760 + MOD(b.sku_id * 17 + b.location_id * 5, 700) DAY)
+        END AS last_movement_at
+    FROM (
+        SELECT
+            s.id AS sku_id,
+            i.id AS location_id,
+            CASE
+                WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71)
+                ELSE MOD(s.id * 13 + i.id * 11, 41)
+            END AS target_sum,
+            -- 후보는 (NORMAL + CANDIDATE) 합의 20% 미만 보장
+            CASE
+                WHEN (CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) <= 0
+                    THEN 0
+                ELSE LEAST(
+                    FLOOR((((CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) - 1) * (0.05 + MOD(s.id + i.id, 15) * 0.01))),
+                    FLOOR((((CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) - 1) * 0.19))
+                )
+            END AS candidate_qty,
+            CASE
+                WHEN (CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) <= 0
+                    THEN 0
+                ELSE (CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END)
+                    - LEAST(
+                        FLOOR((((CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) - 1) * (0.05 + MOD(s.id + i.id, 15) * 0.01))),
+                        FLOOR((((CASE WHEN i.location_type = 'WAREHOUSE' THEN 50 + MOD(s.id * 17 + i.id * 19, 71) ELSE MOD(s.id * 13 + i.id * 11, 41) END) - 1) * 0.19))
+                    )
+            END AS normal_qty
+        FROM product_sku s
+        CROSS JOIN infrastructure i
+        WHERE i.status = 'ACTIVE'
+          AND MOD(s.id, 5) = 1
+          AND (
+                (i.location_type = 'WAREHOUSE' AND MOD(i.id, 3) = 1)
+                OR (i.location_type = 'STORE' AND MOD(i.id, 12) = 1)
+              )
+    ) b
+    CROSS JOIN (
+        SELECT 'NORMAL' AS inventory_status
+        UNION ALL SELECT 'CIRCULAR_CANDIDATE'
+        UNION ALL SELECT 'CIRCULAR'
+    ) st
+) x
+ON DUPLICATE KEY UPDATE
+quantity = VALUES(quantity),
+reserved_quantity = VALUES(reserved_quantity),
+in_transit_quantity = VALUES(in_transit_quantity),
+available_quantity = VALUES(available_quantity),
+status_changed_at = VALUES(status_changed_at),
+last_movement_at = VALUES(last_movement_at),
+update_date = NOW();


### PR DESCRIPTION
## 📌 요약
- `inventory` 조회/집계 기준을 `NORMAL`, `CIRCULAR_CANDIDATE` 상태로 통일해 재고 이동 화면 수치 정합성을 맞췄습니다.
- 부족 창고 수/순부족 수량 계산을 전체 창고 기준(재고 row 미존재 = 0)으로 보정했습니다.
- 재고 이동 실행 시 발생하던 `NonUniqueResultException`(단건 조회 충돌)을 합산 조회 방식으로 해결했습니다.

<br><br>

## 🎯 작업 내용
- `창고간 재고 이동 리스트` 집계 로직 수정  
  - 창고 재고 집계 시 `InventoryStatusPolicy.QUERY_ALLOWED_STATUSES`만 반영
  - 부족 창고 수(`shortageWarehouseCount`), 순부족 수량(`totalShortageQty`)을 SKU별 **전체 창고 기준**으로 계산하도록 변경
- `창고별 SKU 분포 상세` 집계 로직 수정  
  - `(sku, location)` 단일 row 선택 방식 제거
  - 상태 필터(`NORMAL`, `CIRCULAR_CANDIDATE`) 적용 후 창고별 합산값으로 `onHand/available/reserved/status` 계산
- `재고 이동 실행 검증` 오류 수정  
  - `validateGroup()`에서 `findBySkuIdAndLocationId()` 단건 조회 제거
  - `findAllBySkuIdAndLocationId()` + 상태 필터 + `available_quantity` 합산으로 변경하여 다중 status row 충돌 해소

<br><br>

## ✔️ 참고 사항
- API 스펙(엔드포인트/응답 필드)은 변경하지 않았고, 서비스 내부 집계/검증 로직만 수정했습니다.
- 컴파일 검증 완료: `./gradlew --no-daemon compileJava` (`BUILD SUCCESSFUL`)

<br><br>

## ✔️ 관련 이슈

- Close #235

<br><br>
