### PR TITLE
docs: 재고 관련 api 문서 작성

### DIFF
--- a/docs/codex/inventory/03-postman/순환_재고전환_API_Postman_가이드.md
+++ b/docs/codex/inventory/03-postman/순환_재고전환_API_Postman_가이드.md
@@ -1,0 +1,106 @@
+# 순환 재고 전환 API Postman 가이드
+
+## 1. 개요
+- 대상 API
+  - `POST /api/hq/inventories/circular-candidates/convert`
+- 기능
+  - `CIRCULAR_CANDIDATE` 상태 재고를 `CIRCULAR` 재고로 전환
+  - 다건 요청 가능 (배열 입력)
+- 공통 응답 형식: `BaseResponse`
+
+## 2. 사전 준비
+- Base URL 예시: `http://localhost:8080`
+- 인증/권한
+  - `Authorization: Bearer {{hqAccessToken}}`
+  - `/api/hq/**`는 `ROLE_HQ` 권한 필요
+- 전환 대상 후보 재고가 있어야 함
+  - 필요 시 먼저 `POST /api/hq/inventories/circular-candidates/refresh` 실행
+
+## 3. API 사용법
+- Method: `POST`
+- URL: `{{baseUrl}}/api/hq/inventories/circular-candidates/convert`
+- Request Body: JSON 배열
+
+요청 스키마:
+- `inventoryId` (Long, 필수)
+- `convertQuantity` (Integer, 필수, `>= 1`)
+
+요청 예시(전체 성공):
+```json
+[
+  {
+    "inventoryId": 101,
+    "convertQuantity": 10
+  },
+  {
+    "inventoryId": 102,
+    "convertQuantity": 5
+  }
+]
+```
+
+요청 예시(부분 성공):
+```json
+[
+  {
+    "inventoryId": 101,
+    "convertQuantity": 3
+  },
+  {
+    "inventoryId": 999999,
+    "convertQuantity": 2
+  },
+  {
+    "inventoryId": 103,
+    "convertQuantity": 99999
+  }
+]
+```
+
+## 4. 응답 확인 포인트
+- 집계 필드
+  - `result.requestedCount`: 요청 라인 수
+  - `result.convertedCount`: 성공 건수
+  - `result.skippedCount`: 실패/스킵 건수
+- 상세 필드
+  - `result.items[]`
+  - `inventoryId`, `requested`, `converted`, `reason`
+
+성공 항목 예시:
+- `reason: "SUCCESS"`
+- `requested == converted`
+
+실패 항목 예시:
+- `converted: 0`
+- `reason`에 실패 사유 문자열 포함
+
+## 5. 실패 사유(주요 유형)
+- `유효하지 않은 전환 수량입니다.`
+  - `inventoryId`가 null이거나 `convertQuantity <= 0`
+- `재고를 찾을 수 없습니다.`
+  - 대상 `inventoryId` 미존재
+- `순환 재고 후보 상태가 아닙니다.`
+  - 대상 재고 상태가 `CIRCULAR_CANDIDATE`가 아님
+- `창고 재고만 전환할 수 있습니다.`
+  - 창고(`WAREHOUSE`) 재고가 아님
+- `전환 가능 재고를 초과했습니다.`
+  - 요청 수량이 `availableQuantity`보다 큼
+
+## 6. 전환 제약 및 동작 메모
+- 전환 제약
+  - 후보 상태여야 전환 가능
+  - 창고 재고만 전환 가능
+  - 전환 수량은 전환 가능 수량 이내여야 함
+- 처리 동작
+  - 요청 라인 단위로 성공/실패 판정
+  - 실패 라인이 있어도 다른 라인은 계속 처리되어 부분 성공 가능
+
+## 7. 빠른 테스트 세트
+1) 후보 조회
+- `GET {{baseUrl}}/api/hq/inventories/circular-candidates`
+
+2) 전환 실행
+- `POST {{baseUrl}}/api/hq/inventories/circular-candidates/convert`
+
+3) 결과 확인
+- `GET {{baseUrl}}/api/hq/inventories/circular`

--- a/docs/codex/inventory/03-postman/순환_재고조회_API_Postman_가이드.md
+++ b/docs/codex/inventory/03-postman/순환_재고조회_API_Postman_가이드.md
@@ -1,0 +1,94 @@
+# 순환 재고 조회 API Postman 가이드
+
+## 1. 개요
+- 대상 API
+  - `POST /api/hq/inventories/circular-candidates/refresh` (순환 재고 후보 재산정)
+  - `GET /api/hq/inventories/circular-candidates` (순환 재고 후보 조회)
+  - `GET /api/hq/inventories/circular` (순환 재고 조회)
+- 공통 응답 형식: `BaseResponse`
+
+## 2. 사전 준비
+- Base URL 예시: `http://localhost:8080`
+- 인증/권한
+  - `Authorization: Bearer {{hqAccessToken}}`
+  - `/api/hq/**`는 `ROLE_HQ` 권한 필요
+- 후보/순환 재고를 확인하려면 재고 데이터가 충분해야 함
+
+## 3. 권장 실행 순서
+1. 후보 재산정: `POST /api/hq/inventories/circular-candidates/refresh`
+2. 후보 조회: `GET /api/hq/inventories/circular-candidates`
+3. 순환 조회: `GET /api/hq/inventories/circular`
+
+## 4. API별 사용법
+
+### 4.1 순환 재고 후보 재산정
+- Method: `POST`
+- URL: `{{baseUrl}}/api/hq/inventories/circular-candidates/refresh`
+- Request Body: 없음
+
+성공 시 확인:
+- `result.scannedCount`: 스캔한 NORMAL 재고 수
+- `result.convertedCount`: 후보 상태로 전환된 건수
+
+### 4.2 순환 재고 후보 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/inventories/circular-candidates`
+
+성공 시 확인:
+- `result[]` 반환
+- 주요 필드
+  - `inventoryId`, `skuCode`, `itemCode`, `itemName`
+  - `parentCategory`, `childCategory`
+  - `warehouseCode`, `warehouseName`
+  - `color`, `size`
+  - `actualStock`, `availableStock`, `convertibleStock`
+  - `updatedAt`
+  - `matchedConditionCodes[]` (후보 조건 코드)
+
+### 4.3 순환 재고 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/inventories/circular`
+
+성공 시 확인:
+- `result[]` 반환
+- 주요 필드
+  - `inventoryId`, `skuCode`, `itemCode`, `itemName`
+  - `warehouseCode`, `warehouseName`
+  - `parentCategory`, `childCategory`, `color`, `size`
+  - `availableQuantity`
+  - `materialType`
+  - `materialCompositions[]` (`materialCode`, `materialNameKo`, `ratio`)
+  - `materialKgPrice`, `unitWeightKg`, `totalWeightKg`, `circularSalePrice`
+
+## 5. 빈 결과/조건 미충족 케이스
+
+### 5.1 후보 조회 결과가 비어 있음
+- 원인
+  - 후보 재산정 미실행
+  - 후보 조건에 맞는 재고가 없음
+  - 창고(`WAREHOUSE`) 재고가 아님
+- 점검
+  - refresh API 먼저 실행
+  - 기본 전사 재고 조회에서 창고 재고와 수량 확인
+
+### 5.2 순환 조회 결과가 비어 있음
+- 원인
+  - 아직 후보를 순환(`CIRCULAR`) 상태로 전환하지 않음
+- 점검
+  - 전환 API(`POST /api/hq/inventories/circular-candidates/convert`) 실행 후 재조회
+
+### 5.3 인증 실패(401/403)
+- 원인
+  - HQ 토큰 누락/만료/권한 불일치
+- 점검
+  - HQ 계정 토큰 재발급 후 재호출
+
+## 6. 빠른 테스트 세트
+1) 후보 재산정
+- `POST {{baseUrl}}/api/hq/inventories/circular-candidates/refresh`
+
+2) 후보 조회
+- `GET {{baseUrl}}/api/hq/inventories/circular-candidates`
+
+3) 순환 조회
+- `GET {{baseUrl}}/api/hq/inventories/circular`

--- a/docs/codex/inventory/03-postman/전사_재고조회_API_Postman_가이드.md
+++ b/docs/codex/inventory/03-postman/전사_재고조회_API_Postman_가이드.md
@@ -4,26 +4,26 @@
 - 대상 API
   - `GET /api/hq/inventories/company-wide` (전사 재고 목록 조회)
   - `GET /api/hq/inventories/company-wide/{itemCode}/skus` (전사 재고 SKU 상세 조회)
-  - `GET /api/hq/inventories/circular-candidates` (순환재고 후보 조회)
-  - `GET /api/hq/inventories/circular` (순환재고 조회)
 - 공통 응답 형식: `BaseResponse`
+- 문서 범위: 전사 조회 API만 포함 (순환 재고/창고간 이동 API는 별도 문서 참조)
 
 ## 2. 사전 준비
 - 서버 실행 후 Base URL 확인
   - 예: `http://localhost:8080`
 - 재고/인프라/상품 데이터가 먼저 준비되어 있어야 함
-  - 예: `src/main/resources/sql/infrastructure_dummy_data.sql`
-  - 예: `src/main/resources/sql/product_master_dummy_data.sql`
-  - 예: `src/main/resources/sql/inventory_dummy_data.sql`
+  - 예: `src/main/resources/sql/01-infrastructure_dummy_data.sql`
+  - 예: `src/main/resources/sql/04-product_master_dummy_data.sql`
+  - 예: `src/main/resources/sql/05-inventory_dummy_data.sql`
 
 ## 3. Postman 공통 설정
 - Method: 모두 `GET`
 - URL: `{{baseUrl}}` 환경변수 사용 권장
 - Header
-  - 조회 API 기준 필수 Header 없음
-  - 필요 시 `Accept: application/json`
-- 인증
-  - 현재 코드 기준 인증 토큰 필수 아님
+  - `Accept: application/json`
+  - `Authorization: Bearer {{hqAccessToken}}`
+- 인증/권한
+  - 현재 보안 설정 기준 `/api/hq/**`는 `ROLE_HQ` 권한이 필요
+  - 토큰 누락/만료 시 `401`, 권한 불일치 시 `403` 발생 가능
 
 ## 4. API별 사용법
 
@@ -33,22 +33,25 @@
 - Query Params (모두 선택)
   - `locationType`: `STORE` | `WAREHOUSE`
   - `locationIds`: Long 리스트 (반복 키 방식) 예) `locationIds=1&locationIds=2`
-  - `parentCategory`: 상위 카테고리명
-  - `childCategory`: 하위 카테고리명
-  - `status`: `NORMAL` | `LOW` | `OUT`
-  - `keyword`: 품목코드/품목명 검색어
+  - `parentCategory`: 상위 카테고리명 (정확 일치)
+  - `childCategory`: 하위 카테고리명 (정확 일치)
+  - `status`: `InventoryStatus` enum (`NORMAL`, `CIRCULAR_CANDIDATE`, `CIRCULAR`)
+  - `keyword`: 품목코드/품목명/SKU코드/거점코드/거점명 부분 검색
 
 요청 예시:
 - `{{baseUrl}}/api/hq/inventories/company-wide`
 - `{{baseUrl}}/api/hq/inventories/company-wide?locationType=WAREHOUSE`
 - `{{baseUrl}}/api/hq/inventories/company-wide?locationType=STORE&locationIds=1&locationIds=2`
 - `{{baseUrl}}/api/hq/inventories/company-wide?parentCategory=상의&childCategory=반팔티`
-- `{{baseUrl}}/api/hq/inventories/company-wide?status=LOW&keyword=SKU-TOP`
+- `{{baseUrl}}/api/hq/inventories/company-wide?status=NORMAL&keyword=ITEM`
 
 성공 시 확인:
 - `result.items[]` 존재 여부
-- `result.items[].itemCode`, `itemName`, `actualStock`, `availableStock`, `safetyStock`, `status`
-- `result.locationOptions[]`의 `id`, `code`, `name`
+- `result.items[].itemCode`, `parentCategory`, `childCategory`, `itemName`
+- `result.items[].actualStock`, `availableStock`, `safetyStock`, `updatedAt`
+- `result.items[].status`는 UI 문자열 `정상` | `부족` | `품절`
+- `result.locationOptions[]` 포함 여부
+- `result.locationOptions[].id`, `code`, `name`
 
 ### 4.2 전사 재고 SKU 상세 조회
 - Method: `GET`
@@ -61,75 +64,49 @@
 요청 예시:
 - `{{baseUrl}}/api/hq/inventories/company-wide/ITEM-0001/skus`
 - `{{baseUrl}}/api/hq/inventories/company-wide/ITEM-0001/skus?locationType=WAREHOUSE&locationIds=1`
-- `{{baseUrl}}/api/hq/inventories/company-wide/ITEM-0001/skus?status=OUT`
+- `{{baseUrl}}/api/hq/inventories/company-wide/ITEM-0001/skus?status=NORMAL&keyword=BLACK`
 
 성공 시 확인:
 - `result[]` 반환
 - 각 항목의 `skuCode`, `color`, `size`, `unitPrice`
-- 각 항목의 `actualStock`, `availableStock`, `safetyStock`, `status`, `updatedAt`
-
-### 4.3 순환재고 후보 조회
-- Method: `GET`
-- URL: `{{baseUrl}}/api/hq/inventories/circular-candidates`
-
-요청 예시:
-- `{{baseUrl}}/api/hq/inventories/circular-candidates`
-
-성공 시 확인:
-- `result[]` 반환
-- 각 항목의 `inventoryId`, `skuCode`, `itemCode`, `itemName`
-- `warehouseCode`, `warehouseName`, `convertibleStock`
-- `matchedConditionCodes[]`
-
-### 4.4 순환재고 조회
-- Method: `GET`
-- URL: `{{baseUrl}}/api/hq/inventories/circular`
-
-요청 예시:
-- `{{baseUrl}}/api/hq/inventories/circular`
-
-성공 시 확인:
-- `result[]` 반환
-- 각 항목의 `inventoryId`, `skuCode`, `itemCode`, `itemName`
-- `availableQuantity`, `materialType`, `materialKgPrice`, `unitWeightKg`, `totalWeightKg`, `circularSalePrice`
-- `materialCompositions[]`의 `materialCode`, `materialNameKo`, `ratio`
+- 각 항목의 `actualStock`, `availableStock`, `safetyStock`, `updatedAt`
+- 각 항목의 `status`는 UI 문자열 `정상` | `부족` | `품절`
 
 ## 5. 자주 나는 오류와 점검 방법
 
 ### 5.1 조회 결과가 비어 있음
-- 원인:
+- 원인
   - `locationType`, `locationIds`, `status`, `keyword` 필터 조합이 너무 좁은 경우
-- 점검:
+  - 입력한 `itemCode`가 실제 데이터와 다른 경우
+- 점검
   - 필터 없이 `GET /api/hq/inventories/company-wide` 먼저 호출
   - 이후 파라미터를 하나씩 추가하며 결과 비교
 
-### 5.2 잘못된 itemCode로 SKU 상세 조회
-- 원인:
-  - `/company-wide/{itemCode}/skus`의 `itemCode` 오타 또는 미존재
-- 점검:
-  - `GET /api/hq/inventories/company-wide`에서 `itemCode`를 먼저 확인
-  - 확인한 `itemCode`로 상세 조회 재시도
+### 5.2 status 값으로 400 오류 발생
+- 원인
+  - enum 파라미터에 허용되지 않은 값 전달
+- 점검
+  - `NORMAL`, `CIRCULAR_CANDIDATE`, `CIRCULAR` 중 하나로 재시도
 
 ### 5.3 locationIds 필터 적용이 안 되는 것처럼 보임
-- 원인:
+- 원인
   - Postman에서 리스트 파라미터 전달 방식 오류
-- 점검:
+- 점검
   - `locationIds=1&locationIds=2` 형태로 같은 키를 반복 입력
   - 또는 Params 탭에서 `locationIds`를 여러 줄로 추가
 
-### 5.4 status 값 오류
-- 원인:
-  - 허용값(`NORMAL`, `LOW`, `OUT`) 외 값 사용
-- 점검:
-  - Query의 `status`를 허용값 중 하나로 변경
+### 5.4 인증 실패(401/403)
+- 원인
+  - HQ 권한 토큰 누락/만료/권한 불일치
+- 점검
+  - 로그인 후 발급된 `HQ` 계정 Access Token 사용
+  - `Authorization: Bearer <token>` 형식 확인
 
 ## 6. 전사 재고 조회 테스트 권장 순서
 1. 기본 목록 확인: `GET /api/hq/inventories/company-wide`
 2. 위치 옵션 확인: `result.locationOptions[]`에서 `id/code/name` 확인
 3. 필터 목록 조회: `locationType`, `locationIds`, `status`, `keyword` 순으로 필터 적용
 4. 품목 SKU 상세 조회: `GET /api/hq/inventories/company-wide/{itemCode}/skus`
-5. 순환재고 후보 조회: `GET /api/hq/inventories/circular-candidates`
-6. 순환재고 조회: `GET /api/hq/inventories/circular`
 
 ## 7. 빠른 테스트 세트
 
@@ -140,13 +117,7 @@
 - `GET {{baseUrl}}/api/hq/inventories/company-wide?locationType=WAREHOUSE&locationIds=1&locationIds=2`
 
 3) 전사 목록(상태 + 키워드)
-- `GET {{baseUrl}}/api/hq/inventories/company-wide?status=LOW&keyword=ITEM`
+- `GET {{baseUrl}}/api/hq/inventories/company-wide?status=NORMAL&keyword=ITEM`
 
 4) SKU 상세 조회
 - `GET {{baseUrl}}/api/hq/inventories/company-wide/ITEM-0001/skus`
-
-5) 순환재고 후보 조회
-- `GET {{baseUrl}}/api/hq/inventories/circular-candidates`
-
-6) 순환재고 조회
-- `GET {{baseUrl}}/api/hq/inventories/circular`

--- a/docs/codex/inventory/03-postman/창고간_재고이동_API_Postman_가이드.md
+++ b/docs/codex/inventory/03-postman/창고간_재고이동_API_Postman_가이드.md
@@ -117,9 +117,9 @@
 
 성공 시 확인:
 - `result[]`
-- 헤더: `transferNo`, `fromWarehouseCode`, `toWarehouseCode`, `requestedBy`, `requestedAt`, `status`
+- 헤더: `transferNo`, `fromWarehouseCode`, `fromWarehouseName`, `toWarehouseCode`, `toWarehouseName`, `requestedBy`, `requestedAt`, `status`
 - 집계: `skuCount`, `totalQty`, `reasonCount`, `memoCount`
-- 상세 라인: `lines[]` (`skuCode`, `qty`, `reason`, `memo`, `fromStockBefore/After`, `toStockBefore/After`)
+- 상세 라인: `lines[]` (`skuCode`, `itemCode`, `itemName`, `color`, `size`, `qty`, `reason`, `memo`, `fromStockBefore`, `fromStockAfter`, `toStockBefore`, `toStockAfter`)
 
 ### 4.5 이동 상세 조회
 - Method: `GET`
@@ -130,7 +130,9 @@
 
 성공 시 확인:
 - 이력 조회와 동일한 구조의 단건 상세
-- `lines[]`에서 SKU별 이동 수량/사유/메모 및 전후 가용재고 확인
+- 헤더: `transferNo`, `fromWarehouseCode`, `fromWarehouseName`, `toWarehouseCode`, `toWarehouseName`, `requestedBy`, `requestedAt`, `status`
+- 집계: `skuCount`, `totalQty`, `reasonCount`, `memoCount`
+- `lines[]`에서 SKU별 `skuCode`, `itemCode`, `itemName`, `color`, `size`, `qty`, `reason`, `memo` 및 전후 가용재고(`fromStockBefore`, `fromStockAfter`, `toStockBefore`, `toStockAfter`) 확인
 
 ## 5. 주요 검증/실패 포인트
 

--- a/docs/codex/inventory/03-postman/창고간_재고이동_API_Postman_가이드.md
+++ b/docs/codex/inventory/03-postman/창고간_재고이동_API_Postman_가이드.md
@@ -1,0 +1,175 @@
+# 창고간 재고 이동 API Postman 가이드
+
+## 1. 개요
+- 대상 API (전체 이동 흐름)
+  - `GET /api/hq/warehouse-transfers/imbalanced-skus` (불균형 SKU 조회)
+  - `GET /api/hq/warehouse-transfers/sku-distribution?skuCode=...` (SKU 창고 분포 조회)
+  - `POST /api/hq/warehouse-transfers/execute` (이동 실행)
+  - `GET /api/hq/warehouse-transfers` (이동 이력 조회)
+  - `GET /api/hq/warehouse-transfers/{transferNo}` (이동 상세 조회)
+- 공통 응답 형식: `BaseResponse`
+
+## 2. 사전 준비
+- Base URL 예시: `http://localhost:8080`
+- 인증/권한
+  - `Authorization: Bearer {{hqAccessToken}}`
+  - `/api/hq/**`는 `ROLE_HQ` 권한 필요
+- 재고/창고/상품 데이터 준비 필요
+
+## 3. 권장 실행 순서
+1. 불균형 SKU 확인
+2. SKU 분포 확인
+3. 이동 실행
+4. 이동 이력 조회
+5. 이동 상세 조회
+
+## 4. API별 사용법
+
+### 4.1 불균형 SKU 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/warehouse-transfers/imbalanced-skus`
+
+성공 시 확인:
+- `result[]`
+- `skuCode`, `itemCode`, `itemName`, `color`, `size`, `category`
+- `totalOnHand`, `totalAvailable`, `shortageWarehouseCount`, `totalShortageQty`
+
+### 4.2 SKU 창고 분포 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/warehouse-transfers/sku-distribution`
+- Query Params
+  - `skuCode` (필수)
+
+요청 예시:
+- `{{baseUrl}}/api/hq/warehouse-transfers/sku-distribution?skuCode=SKU-00001`
+
+성공 시 확인:
+- `result[]`
+- `warehouseCode`, `warehouseName`, `location`
+- `onHandStock`, `reservedStock`, `availableStock`, `safetyStock`
+- `status` (`정상` | `부족` | `품절`)
+- `updatedAt`
+
+### 4.3 이동 실행
+- Method: `POST`
+- URL: `{{baseUrl}}/api/hq/warehouse-transfers/execute`
+- Request Body
+  - `requestedBy` (선택, 미입력 시 서버 기본값 사용)
+  - `lines[]` (필수, 1건 이상)
+
+라인 스키마:
+- `lineId` (선택)
+- `skuCode` (필수)
+- `fromWarehouseCode` (필수)
+- `toWarehouseCode` (필수)
+- `qty` (필수, `>= 1`)
+- `reason` (선택)
+- `memo` (선택)
+
+요청 예시:
+```json
+{
+  "requestedBy": "hq-admin",
+  "lines": [
+    {
+      "lineId": "L1",
+      "skuCode": "SKU-00001",
+      "fromWarehouseCode": "WH-SU-0001",
+      "toWarehouseCode": "WH-SU-0002",
+      "qty": 10,
+      "reason": "권역 수요 불균형",
+      "memo": "긴급 이동"
+    },
+    {
+      "lineId": "L2",
+      "skuCode": "SKU-00002",
+      "fromWarehouseCode": "WH-SU-0001",
+      "toWarehouseCode": "WH-SU-0002",
+      "qty": 4,
+      "reason": "권역 수요 불균형"
+    }
+  ]
+}
+```
+
+실행 규칙 메모:
+- 서버는 `fromWarehouseCode + toWarehouseCode` 기준으로 라인을 그룹 처리
+- 같은 route 그룹마다 `transferNo` 1건 생성
+
+성공 시 확인:
+- `result.requestedCount`, `successCount`, `failureCount`
+- `result.lineResults[]`: 라인별 성공 여부와 `transferNo`
+- `result.createdTransfers[]`: 생성된 이동 문서 요약
+
+### 4.4 이동 이력 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/warehouse-transfers`
+- Query Params (모두 선택)
+  - `status`: `REQUESTED` | `IN_PROGRESS` | `COMPLETED` | `CANCELED`
+  - `fromDate`: `yyyy-MM-dd`
+  - `toDate`: `yyyy-MM-dd`
+  - `keyword`: 이동번호/창고코드/창고명/SKU/품목/사유/메모 검색
+
+요청 예시:
+- `{{baseUrl}}/api/hq/warehouse-transfers`
+- `{{baseUrl}}/api/hq/warehouse-transfers?status=IN_PROGRESS`
+- `{{baseUrl}}/api/hq/warehouse-transfers?fromDate=2026-05-01&toDate=2026-05-09&keyword=WH-SU-0001`
+
+성공 시 확인:
+- `result[]`
+- 헤더: `transferNo`, `fromWarehouseCode`, `toWarehouseCode`, `requestedBy`, `requestedAt`, `status`
+- 집계: `skuCount`, `totalQty`, `reasonCount`, `memoCount`
+- 상세 라인: `lines[]` (`skuCode`, `qty`, `reason`, `memo`, `fromStockBefore/After`, `toStockBefore/After`)
+
+### 4.5 이동 상세 조회
+- Method: `GET`
+- URL: `{{baseUrl}}/api/hq/warehouse-transfers/{transferNo}`
+
+요청 예시:
+- `{{baseUrl}}/api/hq/warehouse-transfers/STF-20260509-00001`
+
+성공 시 확인:
+- 이력 조회와 동일한 구조의 단건 상세
+- `lines[]`에서 SKU별 이동 수량/사유/메모 및 전후 가용재고 확인
+
+## 5. 주요 검증/실패 포인트
+
+### 5.1 요청 형식 오류
+- 원인
+  - `lines` 비어 있음, `qty < 1`, 필수 코드 누락
+- 점검
+  - JSON 구조와 필수 필드 재확인
+
+### 5.2 동일 출발/도착 창고
+- 원인
+  - `fromWarehouseCode == toWarehouseCode`
+- 점검
+  - 출발/도착 창고를 서로 다르게 지정
+
+### 5.3 가용재고 초과 이동
+- 원인
+  - `qty`가 출발 창고 가용재고보다 큼
+- 점검
+  - `sku-distribution` 조회로 가용재고 확인 후 수량 조정
+
+### 5.4 SKU/창고 코드 불일치
+- 원인
+  - 미존재 SKU 코드, 미존재 창고 코드
+- 점검
+  - SKU/창고 마스터 데이터 확인 후 재시도
+
+## 6. 빠른 테스트 세트
+1) 불균형 SKU 조회
+- `GET {{baseUrl}}/api/hq/warehouse-transfers/imbalanced-skus`
+
+2) SKU 분포 조회
+- `GET {{baseUrl}}/api/hq/warehouse-transfers/sku-distribution?skuCode=SKU-00001`
+
+3) 이동 실행
+- `POST {{baseUrl}}/api/hq/warehouse-transfers/execute`
+
+4) 이동 이력 조회
+- `GET {{baseUrl}}/api/hq/warehouse-transfers?status=IN_PROGRESS`
+
+5) 이동 상세 조회
+- `GET {{baseUrl}}/api/hq/warehouse-transfers/{transferNo}`


### PR DESCRIPTION
## 📌 요약
- 재고 API 문서를 현재 백엔드 구현과 일치하도록 최신화했습니다.
- 전사 재고 조회 문서에서 순환/이동 내용을 분리하고, 순환 재고(조회/전환) 및 창고간 재고 이동 문서를 기능별로 신규 작성했습니다.

<br><br>

## 🎯 작업 내용
- `전사_재고조회_API_Postman_가이드.md` 업데이트
  - 범위를 `company-wide`, `company-wide/{itemCode}/skus`로 한정
  - `/api/hq/**` 인증/권한(HQ JWT) 반영
  - 필터/응답 필드(특히 `locationOptions`, UI 상태값) 최신 코드 기준 정정
- `순환_재고조회_API_Postman_가이드.md` 신규 작성
  - 후보 재산정/후보 조회/순환 조회 API 분리 정리
  - `matchedConditionCodes`, `convertibleStock`, `materialCompositions`, `circularSalePrice` 등 실제 응답 필드 반영
- `순환_재고전환_API_Postman_가이드.md` 신규 작성
  - 전환 요청 스키마, 성공/부분실패 예시, 집계 응답 및 실패 사유 케이스 정리
- `창고간_재고이동_API_Postman_가이드.md` 신규 작성
  - 불균형 SKU 조회 → 분포 조회 → 이동 실행 → 이력/상세 조회 전체 흐름 정리
  - 이력/상세 헤더(`fromWarehouseName`, `toWarehouseName`) 및 `lines[]` 상세 필드(`itemCode`, `itemName`, `color`, `size`) 반영

<br><br>

## ✔️ 참고 사항
- 문서의 URL/메서드/파라미터는 컨트롤러 시그니처와 1:1 대조했습니다.
- 응답 필드는 DTO 기준으로 검증했고, 인증 설명은 `SecurityConfig` 기준으로 반영했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #237

<br><br>
