### PR TITLE
feat: 물류창고 출고 기능 관련 API 구현 (출고 목록 조회, 상세 조회, 상태 변경(출고 확정, 도착 완료) 등)

### DIFF
--- a/docs/codex/wh-outbound/02-implementation/출고_도메인_API_구현내역_2026-05-10.md
+++ b/docs/codex/wh-outbound/02-implementation/출고_도메인_API_구현내역_2026-05-10.md
@@ -1,0 +1,41 @@
+# 출고 도메인 API 구현내역 (2026-05-10)
+
+## 1. 구현 요약
+- 매장 발주 승인 오케스트레이션으로 생성된 출고 문서를 실제 운영 단계에서 처리할 수 있도록 출고 API를 신설했다.
+- 창고 전용 경로로 목록/상세/출고확정/도착완료를 제공한다.
+- 상태 전이 규칙 `READY_TO_SHIP -> IN_TRANSIT -> ARRIVED`를 강제하고, 상태 이력을 기록한다.
+
+## 2. 신규 API
+- `GET /api/warehouse/outbound`
+  - 상태/기간/키워드 필터 지원
+- `GET /api/warehouse/outbound/{outboundNo}`
+  - 헤더/아이템/상태이력/연계 입고 요약 제공
+- `POST /api/warehouse/outbound/{outboundNo}/confirm`
+  - `READY_TO_SHIP -> IN_TRANSIT`
+- `POST /api/warehouse/outbound/{outboundNo}/arrive`
+  - `IN_TRANSIT -> ARRIVED`
+
+## 3. 재고 반영 정책
+- `confirm` 시:
+  - outbound item 기준으로 창고 NORMAL 재고를 락 조회
+  - `reservedQuantity` 감소, `inTransitQuantity` 증가
+  - `available/quantity`는 변경하지 않음
+- `arrive` 시:
+  - 출고 상태/이력만 처리 (입고 확정 단계와 책임 분리)
+
+## 4. 권한/검증/예외
+- 로그인 사용자의 `locationCode`를 WAREHOUSE로 해석해 출고 소유 창고를 검증한다.
+- 타 창고 출고 접근/전이 요청은 차단한다.
+- 상태 전이 불일치, 예약 재고 부족 등을 에러코드로 분리했다.
+  - `OUTBOUND_NOT_FOUND(4705)`
+  - `OUTBOUND_INVALID_STATUS_TRANSITION(4706)`
+  - `OUTBOUND_SCOPE_FORBIDDEN(4707)`
+  - `OUTBOUND_RESERVED_STOCK_NOT_ENOUGH(4708)`
+
+## 5. 코드 반영 파일
+- `warehouse/outbound/WhOutboundController.java`
+- `warehouse/outbound/WhOutboundService.java`
+- `warehouse/outbound/model/WhOutboundDto.java`
+- `hq/inventory/InventoryService.java`
+- `hq/inventory/model/Inventory.java`
+- `common/model/BaseResponseStatus.java`

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -113,6 +113,10 @@ public enum BaseResponseStatus {
     INVALID_INBOUND_STATUS_TRANSITION(false, 4702, "허용되지 않은 입고 상태 전환입니다."),
     INBOUND_ALREADY_EXISTS_FOR_SOURCE(false, 4703, "해당 발주/이동에 대한 입고가 이미 존재합니다."),
     INBOUND_NOT_CONFIRMABLE(false, 4704, "입고 확정 가능한 상태가 아닙니다."),
+    OUTBOUND_NOT_FOUND(false, 4705, "해당 출고 정보를 찾을 수 없습니다."),
+    OUTBOUND_INVALID_STATUS_TRANSITION(false, 4706, "허용되지 않은 출고 상태 전환입니다."),
+    OUTBOUND_SCOPE_FORBIDDEN(false, 4707, "로그인한 창고 범위를 벗어난 출고 요청입니다."),
+    OUTBOUND_RESERVED_STOCK_NOT_ENOUGH(false, 4708, "예약 재고가 부족하여 출고를 확정할 수 없습니다."),
 
     // 4800번대 회원 관리
     USER_NOT_PENDING(false, 4800, "대기 상태인 신청만 처리할 수 있습니다."),

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -363,6 +363,22 @@ public class InventoryService {
                 .orElse(0);
     }
 
+    // 출고 확정 시점에 특정 창고/상품 재고를 reserved -> inTransit으로 옮기는 역할
+    // 반환값은 "실제로 이동된 수량"이며, 호출부에서 요청수량과 일치하는지 검증해 예외 처리한다.
+    @Transactional
+        public int moveReservedToInTransit(Long locationId, Long skuId, int requestedQuantity) {
+        // 1. 필수 파라미터가 없거나 요청 수량이 0 이하이면 처리하지 않는다.
+        if (locationId == null || skuId == null || requestedQuantity <= 0) return 0;
+
+        // 2. NORMAL 재고 row를 락으로 조회해 동시성 충돌 없이 전이 처리한다.
+        // 3. row가 있으면 reserved -> inTransit 전이를 수행하고, 없으면 0을 반환한다.
+        return inventoryRepository.findWithLockBySkuIdAndLocationIdAndInventoryStatus(
+                        skuId, locationId, InventoryStatus.NORMAL
+                )
+                .map(inv -> inv.moveReservedToInTransit(requestedQuantity))
+                .orElse(0);
+    }
+
     /**
      * 발주 IN_TRANSIT 진입 시 해당 창고 SKU 의 가용재고 증가 (이슈 #169 — 발주 ↔ 인벤토리 연결 룰).
      * row 부재 시 신규 INSERT 분기. 동일 트랜잭션에서 호출자(PurchaseOrderService.startInTransit)

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
@@ -157,4 +157,16 @@ public class Inventory extends BaseEntity {
         this.lastMovementAt = new Date();
         return reserved;
     }
+
+    // ------------- 물류 창고 출고 관련 ------------------
+    // 출고리스트에서 reserved로 잡힌 아이템을 출고 확정 시 InTransit 재고로 반영
+    public int moveReservedToInTransit(int requestedQuantity) {
+        int safeRequested = Math.max(0, requestedQuantity);
+        int movable = Math.max(0, n(this.reservedQuantity));
+        int moved = Math.min(safeRequested, movable);
+        this.reservedQuantity = n(this.reservedQuantity) - moved;
+        this.inTransitQuantity = n(this.inTransitQuantity) + moved;
+        this.lastMovementAt = new Date();
+        return moved;
+    }
 }

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundController.java
@@ -1,0 +1,68 @@
+package org.example.stockitbe.warehouse.outbound;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.user.model.AuthUserDetails;
+import org.example.stockitbe.warehouse.outbound.model.WhOutboundDto;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/warehouse/outbound")
+public class WhOutboundController {
+
+    private final WhOutboundService whOutboundService;
+
+    // 출고 내역 목록 조회
+    @GetMapping
+    public BaseResponse<List<WhOutboundDto.ListRes>> list(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(whOutboundService.list(me, status, from, to, keyword));
+    }
+
+    // 출고 내역 상세 조회
+    @GetMapping("/{outboundNo}")
+    public BaseResponse<WhOutboundDto.DetailRes> detail(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String outboundNo
+    ) {
+        return BaseResponse.success(whOutboundService.detail(me, outboundNo));
+    }
+
+    // 출고 확정 처리
+    // 배송 중 단계로 이동 (InTransit으로 재고가 반영됨)
+    @PostMapping("/{outboundNo}/confirm")
+    public BaseResponse<WhOutboundDto.DetailRes> confirm(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String outboundNo,
+            @RequestBody(required = false) WhOutboundDto.ActionReq req
+    ) {
+        return BaseResponse.success(whOutboundService.confirm(me, outboundNo, req == null ? null : req.getReason()));
+    }
+
+    // 도착 확정 (매장 배송 완료)
+    @PostMapping("/{outboundNo}/arrive")
+    public BaseResponse<WhOutboundDto.DetailRes> arrive(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String outboundNo,
+            @RequestBody(required = false) WhOutboundDto.ActionReq req
+    ) {
+        return BaseResponse.success(whOutboundService.arrive(me, outboundNo, req == null ? null : req.getReason()));
+    }
+}

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
@@ -1,0 +1,189 @@
+package org.example.stockitbe.warehouse.outbound;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.InventoryService;
+import org.example.stockitbe.store.inbound.StoreInboundHeaderRepository;
+import org.example.stockitbe.store.inbound.model.entity.StoreInboundHeader;
+import org.example.stockitbe.user.model.AuthUserDetails;
+import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
+import org.example.stockitbe.warehouse.outbound.model.WhOutboundDto;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundItem;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHistory;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class WhOutboundService {
+
+    private final WhOutboundHeaderRepository outboundHeaderRepository;
+    private final WhOutboundItemRepository outboundItemRepository;
+    private final WhOutboundStatusHistoryRepository outboundStatusHistoryRepository;
+    private final StoreInboundHeaderRepository inboundHeaderRepository;
+    private final InfrastructureRepository infrastructureRepository;
+    private final InventoryService inventoryService;
+
+    @Transactional(readOnly = true)
+    public List<WhOutboundDto.ListRes> list(AuthUserDetails me, String status, LocalDate from, LocalDate to, String keyword) {
+        Long myWarehouseId = resolveWarehouseId(me);
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        OutboundStatus statusFilter = parseStatus(status);
+        Date fromDate = from == null ? null : Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date toDateExclusive = to == null ? null : Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+
+        List<WhOutboundHeader> headers = outboundHeaderRepository.findAllByWarehouseIdOrderByRequestedAtDescIdDesc(myWarehouseId);
+        if (headers.isEmpty()) return List.of();
+
+        Infrastructure myWarehouse = infrastructureRepository.findById(myWarehouseId)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_NOT_FOUND));
+
+        return headers.stream()
+                .filter(h -> statusFilter == null || h.getStatus() == statusFilter)
+                .filter(h -> fromDate == null || !h.getRequestedAt().before(fromDate))
+                .filter(h -> toDateExclusive == null || h.getRequestedAt().before(toDateExclusive))
+                .filter(h -> safeKeyword.isBlank() || matchesKeyword(h, safeKeyword))
+                .map(h -> WhOutboundDto.toListRes(h, myWarehouse.getCode(), myWarehouse.getName()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public WhOutboundDto.DetailRes detail(AuthUserDetails me, String outboundNo) {
+        Long myWarehouseId = resolveWarehouseId(me);
+        WhOutboundHeader header = findOwnedOutbound(outboundNo, myWarehouseId);
+        Infrastructure warehouse = infrastructureRepository.findById(header.getWarehouseId())
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_NOT_FOUND));
+        List<WhOutboundItem> items = outboundItemRepository.findAllByOutboundHeaderIdOrderByIdAsc(header.getId());
+        List<WhOutboundStatusHistory> history = outboundStatusHistoryRepository.findAllByOutboundHeaderIdOrderByChangedAtAscIdAsc(header.getId());
+        StoreInboundHeader inbound = inboundHeaderRepository.findByOutboundNo(header.getOutboundNo()).orElse(null);
+
+        return WhOutboundDto.DetailRes.builder()
+                .outboundNo(header.getOutboundNo())
+                .sourceType(header.getSourceType().name())
+                .sourceRefNo(header.getSourceRefNo())
+                .sourceRefSeq(header.getSourceRefSeq())
+                .sourceRefId(header.getSourceRefId())
+                .warehouseId(header.getWarehouseId())
+                .warehouseCode(warehouse.getCode())
+                .warehouseName(warehouse.getName())
+                .destinationType(header.getDestinationType().name())
+                .destinationId(header.getDestinationId())
+                .status(header.getStatus())
+                .totalRequestedQuantity(header.getTotalRequestedQuantity())
+                .requestedAt(header.getRequestedAt())
+                .confirmedAt(header.getConfirmedAt())
+                .departedAt(header.getDepartedAt())
+                .arrivedAt(header.getArrivedAt())
+                .requestedByMemberId(header.getRequestedByMemberId())
+                .requestedByName(header.getRequestedByName())
+                .memo(header.getMemo())
+                .items(items.stream().map(WhOutboundDto.ItemRes::from).toList())
+                .statusHistory(history.stream().map(WhOutboundDto.StatusHistoryRes::from).toList())
+                .inbound(inbound == null ? null : WhOutboundDto.InboundSummaryRes.builder()
+                        .inboundNo(inbound.getInboundNo())
+                        .inboundStatus(inbound.getStatus())
+                        .build())
+                .build();
+    }
+
+    @Transactional
+    public WhOutboundDto.DetailRes confirm(AuthUserDetails me, String outboundNo, String reason) {
+        Long myWarehouseId = resolveWarehouseId(me);
+        WhOutboundHeader header = findOwnedOutbound(outboundNo, myWarehouseId);
+        if (header.getStatus() != OutboundStatus.READY_TO_SHIP) {
+            throw BaseException.from(BaseResponseStatus.OUTBOUND_INVALID_STATUS_TRANSITION);
+        }
+
+        List<WhOutboundItem> items = outboundItemRepository.findAllByOutboundHeaderIdOrderByIdAsc(header.getId());
+        for (WhOutboundItem item : items) {
+            int moved = inventoryService.moveReservedToInTransit(header.getWarehouseId(), item.getSkuId(), item.getRequestedQuantity());
+            if (moved != item.getRequestedQuantity()) {
+                throw BaseException.from(BaseResponseStatus.OUTBOUND_RESERVED_STOCK_NOT_ENOUGH);
+            }
+        }
+
+        Date now = new Date();
+        header.markInTransit(now);
+        outboundStatusHistoryRepository.save(
+                WhOutboundStatusHistory.builder()
+                        .outboundHeaderId(header.getId())
+                        .status(OutboundStatus.IN_TRANSIT)
+                        .changedAt(now)
+                        .changedByMemberId(me.getEmployeeCode())
+                        .changedByName(me.getName())
+                        .reason(reason == null || reason.isBlank() ? "OUTBOUND_CONFIRM" : reason)
+                        .build()
+        );
+
+        return detail(me, outboundNo);
+    }
+
+    @Transactional
+    public WhOutboundDto.DetailRes arrive(AuthUserDetails me, String outboundNo, String reason) {
+        Long myWarehouseId = resolveWarehouseId(me);
+        WhOutboundHeader header = findOwnedOutbound(outboundNo, myWarehouseId);
+        if (header.getStatus() != OutboundStatus.IN_TRANSIT) {
+            throw BaseException.from(BaseResponseStatus.OUTBOUND_INVALID_STATUS_TRANSITION);
+        }
+
+        Date now = new Date();
+        header.markArrived(now);
+        outboundStatusHistoryRepository.save(
+                WhOutboundStatusHistory.builder()
+                        .outboundHeaderId(header.getId())
+                        .status(OutboundStatus.ARRIVED)
+                        .changedAt(now)
+                        .changedByMemberId(me.getEmployeeCode())
+                        .changedByName(me.getName())
+                        .reason(reason == null || reason.isBlank() ? "OUTBOUND_ARRIVED" : reason)
+                        .build()
+        );
+
+        return detail(me, outboundNo);
+    }
+
+    private Long resolveWarehouseId(AuthUserDetails me) {
+        String locationCode = me == null ? null : me.getLocationCode();
+        if (locationCode == null || locationCode.isBlank()) {
+            throw BaseException.from(BaseResponseStatus.OUTBOUND_SCOPE_FORBIDDEN);
+        }
+        return infrastructureRepository.findByCodeAndLocationType(locationCode, LocationType.WAREHOUSE)
+                .map(Infrastructure::getId)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_SCOPE_FORBIDDEN));
+    }
+
+    private WhOutboundHeader findOwnedOutbound(String outboundNo, Long warehouseId) {
+        WhOutboundHeader header = outboundHeaderRepository.findByOutboundNo(outboundNo)
+                .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_NOT_FOUND));
+        if (!header.getWarehouseId().equals(warehouseId)) {
+            throw BaseException.from(BaseResponseStatus.OUTBOUND_SCOPE_FORBIDDEN);
+        }
+        return header;
+    }
+
+    private OutboundStatus parseStatus(String status) {
+        if (status == null || status.isBlank() || "전체".equals(status)) return null;
+        try {
+            return OutboundStatus.valueOf(status);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean matchesKeyword(WhOutboundHeader header, String safeKeyword) {
+        String text = (header.getOutboundNo() + " " + header.getSourceRefNo() + " " + header.getDestinationType().name())
+                .toLowerCase(Locale.ROOT);
+        return text.contains(safeKeyword);
+    }
+}

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/model/WhOutboundDto.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/model/WhOutboundDto.java
@@ -1,0 +1,160 @@
+package org.example.stockitbe.warehouse.outbound.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.stockitbe.store.inbound.model.StoreInboundStatus;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundItem;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHistory;
+
+import java.util.Date;
+import java.util.List;
+
+public class WhOutboundDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ActionReq {
+        private String reason;
+    }
+
+    // 발주 내역 목록 조회 응답 DTO
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ListRes {
+        private String outboundNo;
+        private String sourceType;
+        private String sourceRefNo;
+        private Integer sourceRefSeq;
+        private Long warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private String destinationType;
+        private Long destinationId;
+        private OutboundStatus status;
+        private Integer totalRequestedQuantity;
+        private Date requestedAt;
+    }
+
+    // 발주 내역 상세 조회 응답 DTO
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DetailRes {
+        private String outboundNo;
+        private String sourceType;
+        private String sourceRefNo;
+        private Integer sourceRefSeq;
+        private Long sourceRefId;
+        private Long warehouseId;
+        private String warehouseCode;
+        private String warehouseName;
+        private String destinationType;
+        private Long destinationId;
+        private OutboundStatus status;
+        private Integer totalRequestedQuantity;
+        private Date requestedAt;
+        private Date confirmedAt;
+        private Date departedAt;
+        private Date arrivedAt;
+        private String requestedByMemberId;
+        private String requestedByName;
+        private String memo;
+        private List<ItemRes> items;
+        private List<StatusHistoryRes> statusHistory;
+        private InboundSummaryRes inbound;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ItemRes {
+        private Long id;
+        private Long sourceLineRefId;
+        private Long skuId;
+        private String skuCode;
+        private String productCode;
+        private String productName;
+        private String mainCategory;
+        private String subCategory;
+        private String color;
+        private String size;
+        private Long unitPrice;
+        private Integer requestedQuantity;
+        private String memo;
+
+        public static ItemRes from(WhOutboundItem item) {
+            return ItemRes.builder()
+                    .id(item.getId())
+                    .sourceLineRefId(item.getSourceLineRefId())
+                    .skuId(item.getSkuId())
+                    .skuCode(item.getSkuCode())
+                    .productCode(item.getProductCode())
+                    .productName(item.getProductName())
+                    .mainCategory(item.getMainCategory())
+                    .subCategory(item.getSubCategory())
+                    .color(item.getColor())
+                    .size(item.getSize())
+                    .unitPrice(item.getUnitPrice())
+                    .requestedQuantity(item.getRequestedQuantity())
+                    .memo(item.getMemo())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StatusHistoryRes {
+        private OutboundStatus status;
+        private Date changedAt;
+        private String changedByMemberId;
+        private String changedByName;
+        private String reason;
+
+        public static StatusHistoryRes from(WhOutboundStatusHistory history) {
+            return StatusHistoryRes.builder()
+                    .status(history.getStatus())
+                    .changedAt(history.getChangedAt())
+                    .changedByMemberId(history.getChangedByMemberId())
+                    .changedByName(history.getChangedByName())
+                    .reason(history.getReason())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class InboundSummaryRes {
+        private String inboundNo;
+        private StoreInboundStatus inboundStatus;
+    }
+
+    public static ListRes toListRes(WhOutboundHeader header, String warehouseCode, String warehouseName) {
+        return ListRes.builder()
+                .outboundNo(header.getOutboundNo())
+                .sourceType(header.getSourceType().name())
+                .sourceRefNo(header.getSourceRefNo())
+                .sourceRefSeq(header.getSourceRefSeq())
+                .warehouseId(header.getWarehouseId())
+                .warehouseCode(warehouseCode)
+                .warehouseName(warehouseName)
+                .destinationType(header.getDestinationType().name())
+                .destinationId(header.getDestinationId())
+                .status(header.getStatus())
+                .totalRequestedQuantity(header.getTotalRequestedQuantity())
+                .requestedAt(header.getRequestedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 요약
- 창고 전용 출고 API(목록/상세/출고확정/도착완료)를 신규 구현했습니다.
- 출고 상태 전이(`READY_TO_SHIP -> IN_TRANSIT -> ARRIVED`)와 상태 이력 기록을 반영했습니다.
- 출고 확정 시 재고 `reserved -> inTransit` 전이 로직과 창고 권한 검증을 추가했습니다.

<br><br>

## 🎯 작업 내용
- `WhOutboundService`, `WhOutboundController`, `WhOutboundDto` 신설
- API 추가  
  - `GET /api/warehouse/outbound`  
  - `GET /api/warehouse/outbound/{outboundNo}`  
  - `POST /api/warehouse/outbound/{outboundNo}/confirm`  
  - `POST /api/warehouse/outbound/{outboundNo}/arrive`
- 상태 전이/이력 처리  
  - confirm: `READY_TO_SHIP -> IN_TRANSIT` + 이력 저장  
  - arrive: `IN_TRANSIT -> ARRIVED` + 이력 저장
- 재고 반영  
  - `InventoryService.moveReservedToInTransit(...)` 추가  
  - `Inventory.moveReservedToInTransit(...)` 추가
- 권한/예외 처리  
  - 로그인 창고 범위 검증  
  - 출고 전이 관련 신규 에러코드 추가  
    - `OUTBOUND_NOT_FOUND(4705)`  
    - `OUTBOUND_INVALID_STATUS_TRANSITION(4706)`  
    - `OUTBOUND_SCOPE_FORBIDDEN(4707)`  
    - `OUTBOUND_RESERVED_STOCK_NOT_ENOUGH(4708)`
- 문서화  
  - 출고 도메인 구현내역 문서 추가

<br><br>

## ✔️ 참고 사항
- 연계 입고 요약(`inboundNo`, `inboundStatus`)을 출고 상세 응답에 포함했습니다.
- 테스트/검증은 보류 상태이며, 후속 턴에서 통합 시나리오 검증 예정입니다.

<br><br>

## ✔️ 관련 이슈

- Close #242 

<br><br>
