### PR TITLE
feat: 순환 재고 조회 페이지 페이징 처리

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
@@ -53,8 +53,26 @@ public class InventoryController {
     }
 
     @GetMapping("/circular")
-    public BaseResponse<List<InventoryDto.CircularInventoryRes>> getCircularInventories() {
-        return BaseResponse.success(inventoryService.findCircularInventories());
+    public BaseResponse<InventoryDto.CircularInventoryPageRes> getCircularInventories(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(defaultValue = "skuCode,asc") String sort,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) List<String> warehouseCodes,
+            @RequestParam(required = false) String materialGroup,
+            @RequestParam(required = false) String materialName,
+            @RequestParam(required = false) Integer minRatio
+    ) {
+        return BaseResponse.success(inventoryService.findCircularInventories(
+                page,
+                size,
+                sort,
+                keyword,
+                warehouseCodes,
+                materialGroup,
+                materialName,
+                minRatio
+        ));
     }
 
     @PostMapping("/circular-candidates/convert")

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
@@ -48,8 +48,26 @@ public class InventoryController {
     }
 
     @GetMapping("/circular-candidates")
-    public BaseResponse<List<InventoryDto.CircularCandidateRes>> getCircularCandidates() {
-        return BaseResponse.success(inventoryService.findCircularCandidates());
+    public BaseResponse<InventoryDto.CircularCandidatePageRes> getCircularCandidates(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(defaultValue = "convertibleStock,desc") String sort,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) List<String> warehouseCodes,
+            @RequestParam(required = false) List<Integer> conditionCodes
+    ) {
+        return BaseResponse.success(inventoryService.findCircularCandidates(
+                page,
+                size,
+                sort,
+                keyword,
+                parentCategory,
+                childCategory,
+                warehouseCodes,
+                conditionCodes
+        ));
     }
 
     @GetMapping("/circular")

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -22,6 +22,9 @@ import org.example.stockitbe.hq.product.model.Material;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductMaterialType;
 import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -654,9 +657,31 @@ public class InventoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<InventoryDto.CircularInventoryRes> findCircularInventories() {
+    public InventoryDto.CircularInventoryPageRes findCircularInventories(Integer page,
+                                                                         Integer size,
+                                                                         String sort,
+                                                                         String keyword,
+                                                                         List<String> warehouseCodes,
+                                                                         String materialGroup,
+                                                                         String materialName,
+                                                                         Integer minRatio) {
+        int safePage = Math.max(0, page == null ? 0 : page);
+        int safeSize = normalizePageSize(size);
+        Sort sortSpec = parseCircularSort(sort);
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        Set<String> warehouseCodeSet = (warehouseCodes == null ? List.<String>of() : warehouseCodes).stream()
+                .filter(Objects::nonNull)
+                .map(value -> value.trim().toUpperCase(Locale.ROOT))
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.toSet());
+        String safeMaterialGroup = materialGroup == null ? "" : materialGroup.trim();
+        String safeMaterialName = materialName == null ? "" : normalizeMaterialName(materialName.trim());
+        int safeMinRatio = Math.max(0, minRatio == null ? 0 : minRatio);
+
         List<Inventory> circularInventories = inventoryRepository.findAllByInventoryStatus(InventoryStatus.CIRCULAR);
-        if (circularInventories.isEmpty()) return List.of();
+        if (circularInventories.isEmpty()) {
+            return buildCircularInventoryPage(List.of(), safePage, safeSize, 0);
+        }
 
         Map<Long, Infrastructure> warehouseById = infrastructureRepository.findAll().stream()
                 .filter(i -> i.getLocationType() == LocationType.WAREHOUSE)
@@ -664,7 +689,9 @@ public class InventoryService {
         List<Inventory> warehouseCirculars = circularInventories.stream()
                 .filter(inv -> warehouseById.containsKey(inv.getLocationId()))
                 .toList();
-        if (warehouseCirculars.isEmpty()) return List.of();
+        if (warehouseCirculars.isEmpty()) {
+            return buildCircularInventoryPage(List.of(), safePage, safeSize, 0);
+        }
 
         Set<Long> skuIds = warehouseCirculars.stream().map(Inventory::getSkuId).collect(Collectors.toSet());
         Map<Long, ProductSku> skuById = productSkuRepository.findAllById(skuIds).stream()
@@ -680,7 +707,7 @@ public class InventoryService {
         Map<Long, Category> categoryById = categories.stream().collect(Collectors.toMap(Category::getId, Function.identity()));
         Map<String, Integer> materialPriceByCode = loadActiveMaterialPriceByCode();
 
-        return warehouseCirculars.stream()
+        List<InventoryDto.CircularInventoryRes> rows = warehouseCirculars.stream()
                 .map(inv -> {
                     ProductSku sku = skuById.get(inv.getSkuId());
                     if (sku == null) return null;
@@ -723,8 +750,141 @@ public class InventoryService {
                             .build();
                 })
                 .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(InventoryDto.CircularInventoryRes::getSkuCode))
                 .toList();
+
+        List<InventoryDto.CircularInventoryRes> filtered = rows.stream()
+                .filter(row -> matchesCircularKeyword(row, safeKeyword))
+                .filter(row -> matchesWarehouseCodes(row, warehouseCodeSet))
+                .filter(row -> matchesMaterialFilter(row, safeMaterialGroup, safeMaterialName, safeMinRatio))
+                .sorted(buildCircularComparator(sortSpec))
+                .toList();
+
+        return buildCircularInventoryPage(filtered, safePage, safeSize, filtered.size());
+    }
+
+    private InventoryDto.CircularInventoryPageRes buildCircularInventoryPage(List<InventoryDto.CircularInventoryRes> rows,
+                                                                             int page,
+                                                                             int size,
+                                                                             int totalElements) {
+        int from = Math.min(page * size, totalElements);
+        int to = Math.min(from + size, totalElements);
+        List<InventoryDto.CircularInventoryRes> content = rows.subList(from, to);
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
+        PageImpl<InventoryDto.CircularInventoryRes> result = new PageImpl<>(content, pageable, totalElements);
+
+        return InventoryDto.CircularInventoryPageRes.builder()
+                .content(result.getContent())
+                .page(result.getNumber())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .hasNext(result.hasNext())
+                .hasPrevious(result.hasPrevious())
+                .build();
+    }
+
+    private int normalizePageSize(Integer size) {
+        int requested = size == null ? 20 : size;
+        if (requested == 50 || requested == 100) return requested;
+        return 20;
+    }
+
+    private Sort parseCircularSort(String sort) {
+        String normalized = sort == null ? "" : sort.trim();
+        if (normalized.isBlank()) return Sort.by(Sort.Order.asc("skuCode"));
+        String[] split = normalized.split(",");
+        String field = split.length > 0 ? split[0].trim() : "skuCode";
+        String direction = split.length > 1 ? split[1].trim().toLowerCase(Locale.ROOT) : "asc";
+        Sort.Direction dir = "desc".equals(direction) ? Sort.Direction.DESC : Sort.Direction.ASC;
+        if (!Set.of("skuCode", "quantity", "materialKgPrice", "circularSalePrice", "weight").contains(field)) {
+            field = "skuCode";
+            dir = Sort.Direction.ASC;
+        }
+        return Sort.by(new Sort.Order(dir, field));
+    }
+
+    private Comparator<InventoryDto.CircularInventoryRes> buildCircularComparator(Sort sortSpec) {
+        Sort.Order order = sortSpec.stream().findFirst().orElse(Sort.Order.asc("skuCode"));
+        Comparator<InventoryDto.CircularInventoryRes> comparator;
+        String property = order.getProperty();
+        switch (property) {
+            case "quantity":
+                comparator = Comparator.comparing(row -> n(row.getAvailableQuantity()));
+                break;
+            case "materialKgPrice":
+                comparator = Comparator.comparing(row -> n(row.getMaterialKgPrice()));
+                break;
+            case "circularSalePrice":
+                comparator = Comparator.comparing(row -> row.getCircularSalePrice() == null ? 0L : row.getCircularSalePrice());
+                break;
+            case "weight":
+                comparator = Comparator.comparing(row -> row.getTotalWeightKg() == null ? 0d : row.getTotalWeightKg());
+                break;
+            case "skuCode":
+            default:
+                comparator = Comparator.comparing(row -> row.getSkuCode() == null ? "" : row.getSkuCode(), Comparator.naturalOrder());
+                break;
+        }
+        if (order.getDirection() == Sort.Direction.DESC) {
+            comparator = comparator.reversed();
+        }
+        return comparator.thenComparing(row -> row.getSkuCode() == null ? "" : row.getSkuCode());
+    }
+
+    private boolean matchesCircularKeyword(InventoryDto.CircularInventoryRes row, String keyword) {
+        if (keyword == null || keyword.isBlank()) return true;
+        String materialDetail = row.getMaterialCompositions() == null
+                ? ""
+                : row.getMaterialCompositions().stream()
+                .map(comp -> (comp.getMaterialNameKo() == null ? "" : comp.getMaterialNameKo()) + " " + n(comp.getRatio()) + "%")
+                .collect(Collectors.joining(" + "));
+        String searchable = String.join(" ",
+                safeText(row.getItemCode()),
+                safeText(row.getItemName()),
+                materialDetail
+        ).toLowerCase(Locale.ROOT);
+        return searchable.contains(keyword);
+    }
+
+    private boolean matchesWarehouseCodes(InventoryDto.CircularInventoryRes row, Set<String> warehouseCodes) {
+        if (warehouseCodes == null || warehouseCodes.isEmpty()) return true;
+        return warehouseCodes.contains(safeText(row.getWarehouseCode()).toUpperCase(Locale.ROOT));
+    }
+
+    private boolean matchesMaterialFilter(InventoryDto.CircularInventoryRes row,
+                                          String materialGroup,
+                                          String materialName,
+                                          int minRatio) {
+        if (materialGroup == null || materialGroup.isBlank()) return true;
+        if (!materialGroup.equals(safeText(row.getMaterialType()))) return false;
+        if (materialName == null || materialName.isBlank()) return true;
+        if (row.getMaterialCompositions() == null || row.getMaterialCompositions().isEmpty()) return false;
+
+        return row.getMaterialCompositions().stream().anyMatch(comp ->
+                materialName.equals(normalizeMaterialName(safeText(comp.getMaterialNameKo())))
+                        && (minRatio <= 0 || n(comp.getRatio()) >= minRatio)
+        );
+    }
+
+    private String safeText(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String normalizeMaterialName(String value) {
+        String normalized = value == null ? "" : value.trim();
+        String lower = normalized.toLowerCase(Locale.ROOT);
+        return switch (lower) {
+            case "코튼", "cotton" -> "면";
+            case "폴리", "polyester" -> "폴리에스터";
+            case "acrylic" -> "아크릴";
+            case "polyamide", "nylon" -> "나일론";
+            case "elastane", "스판", "spandex" -> "스판덱스";
+            case "wool" -> "울";
+            case "cashmere" -> "캐시미어";
+            case "silk" -> "실크";
+            case "linen" -> "리넨";
+            default -> normalized;
+        };
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -585,9 +585,34 @@ public class InventoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<InventoryDto.CircularCandidateRes> findCircularCandidates() {
+    public InventoryDto.CircularCandidatePageRes findCircularCandidates(Integer page,
+                                                                         Integer size,
+                                                                         String sort,
+                                                                         String keyword,
+                                                                         String parentCategory,
+                                                                         String childCategory,
+                                                                         List<String> warehouseCodes,
+                                                                         List<Integer> conditionCodes) {
+        int safePage = Math.max(0, page == null ? 0 : page);
+        int safeSize = normalizePageSize(size);
+        Sort sortSpec = parseCandidateSort(sort);
+        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        String safeParentCategory = parentCategory == null ? "" : parentCategory.trim();
+        String safeChildCategory = childCategory == null ? "" : childCategory.trim();
+        Set<String> warehouseCodeSet = (warehouseCodes == null ? List.<String>of() : warehouseCodes).stream()
+                .filter(Objects::nonNull)
+                .map(code -> code.trim().toUpperCase(Locale.ROOT))
+                .filter(code -> !code.isBlank())
+                .collect(Collectors.toSet());
+        Set<Integer> conditionCodeSet = (conditionCodes == null ? List.<Integer>of() : conditionCodes).stream()
+                .filter(Objects::nonNull)
+                .filter(code -> code >= 1 && code <= 3)
+                .collect(Collectors.toSet());
+
         List<Inventory> candidates = inventoryRepository.findAllByInventoryStatus(InventoryStatus.CIRCULAR_CANDIDATE);
-        if (candidates.isEmpty()) return List.of();
+        if (candidates.isEmpty()) {
+            return buildCircularCandidatePage(List.of(), safePage, safeSize, 0);
+        }
 
         Map<Long, Infrastructure> warehouseById = infrastructureRepository.findAll().stream()
                 .filter(i -> i.getLocationType() == LocationType.WAREHOUSE)
@@ -595,7 +620,9 @@ public class InventoryService {
         List<Inventory> warehouseCandidates = candidates.stream()
                 .filter(inv -> warehouseById.containsKey(inv.getLocationId()))
                 .toList();
-        if (warehouseCandidates.isEmpty()) return List.of();
+        if (warehouseCandidates.isEmpty()) {
+            return buildCircularCandidatePage(List.of(), safePage, safeSize, 0);
+        }
 
         Set<Long> skuIds = warehouseCandidates.stream().map(Inventory::getSkuId).collect(Collectors.toSet());
         Map<Long, ProductSku> skuById = productSkuRepository.findAllById(skuIds).stream()
@@ -617,7 +644,7 @@ public class InventoryService {
                         Collectors.mapping(InventoryCandidateCondition::getConditionCode, Collectors.toList())
                 ));
 
-        return warehouseCandidates.stream()
+        List<InventoryDto.CircularCandidateRes> rows = warehouseCandidates.stream()
                 .map(inv -> {
                     ProductSku sku = skuById.get(inv.getSkuId());
                     if (sku == null) return null;
@@ -652,8 +679,17 @@ public class InventoryService {
                             .build();
                 })
                 .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(InventoryDto.CircularCandidateRes::getSkuCode))
                 .toList();
+
+        List<InventoryDto.CircularCandidateRes> filtered = rows.stream()
+                .filter(row -> matchesCandidateKeyword(row, safeKeyword))
+                .filter(row -> matchesCandidateCategory(row, safeParentCategory, safeChildCategory))
+                .filter(row -> matchesCandidateWarehouse(row, warehouseCodeSet))
+                .filter(row -> matchesCandidateConditionCodes(row, conditionCodeSet))
+                .sorted(buildCandidateComparator(sortSpec))
+                .toList();
+
+        return buildCircularCandidatePage(filtered, safePage, safeSize, filtered.size());
     }
 
     @Transactional(readOnly = true)
@@ -783,6 +819,27 @@ public class InventoryService {
                 .build();
     }
 
+    private InventoryDto.CircularCandidatePageRes buildCircularCandidatePage(List<InventoryDto.CircularCandidateRes> rows,
+                                                                              int page,
+                                                                              int size,
+                                                                              int totalElements) {
+        int from = Math.min(page * size, totalElements);
+        int to = Math.min(from + size, totalElements);
+        List<InventoryDto.CircularCandidateRes> content = rows.subList(from, to);
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
+        PageImpl<InventoryDto.CircularCandidateRes> result = new PageImpl<>(content, pageable, totalElements);
+
+        return InventoryDto.CircularCandidatePageRes.builder()
+                .content(result.getContent())
+                .page(result.getNumber())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .hasNext(result.hasNext())
+                .hasPrevious(result.hasPrevious())
+                .build();
+    }
+
     private int normalizePageSize(Integer size) {
         int requested = size == null ? 20 : size;
         if (requested == 50 || requested == 100) return requested;
@@ -799,6 +856,20 @@ public class InventoryService {
         if (!Set.of("skuCode", "quantity", "materialKgPrice", "circularSalePrice", "weight").contains(field)) {
             field = "skuCode";
             dir = Sort.Direction.ASC;
+        }
+        return Sort.by(new Sort.Order(dir, field));
+    }
+
+    private Sort parseCandidateSort(String sort) {
+        String normalized = sort == null ? "" : sort.trim();
+        if (normalized.isBlank()) return Sort.by(Sort.Order.desc("convertibleStock"));
+        String[] split = normalized.split(",");
+        String field = split.length > 0 ? split[0].trim() : "convertibleStock";
+        String direction = split.length > 1 ? split[1].trim().toLowerCase(Locale.ROOT) : "desc";
+        Sort.Direction dir = "asc".equals(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        if (!Set.of("skuCode", "availableStock", "convertibleStock", "updatedAt").contains(field)) {
+            field = "convertibleStock";
+            dir = Sort.Direction.DESC;
         }
         return Sort.by(new Sort.Order(dir, field));
     }
@@ -831,6 +902,28 @@ public class InventoryService {
         return comparator.thenComparing(row -> row.getSkuCode() == null ? "" : row.getSkuCode());
     }
 
+    private Comparator<InventoryDto.CircularCandidateRes> buildCandidateComparator(Sort sortSpec) {
+        Sort.Order order = sortSpec.stream().findFirst().orElse(Sort.Order.desc("convertibleStock"));
+        Comparator<InventoryDto.CircularCandidateRes> comparator;
+        switch (order.getProperty()) {
+            case "skuCode":
+                comparator = Comparator.comparing(row -> safeText(row.getSkuCode()));
+                break;
+            case "availableStock":
+                comparator = Comparator.comparing(row -> n(row.getAvailableStock()));
+                break;
+            case "updatedAt":
+                comparator = Comparator.comparing(row -> row.getUpdatedAt() == null ? new Date(0) : row.getUpdatedAt());
+                break;
+            case "convertibleStock":
+            default:
+                comparator = Comparator.comparing(row -> n(row.getConvertibleStock()));
+                break;
+        }
+        if (order.getDirection() == Sort.Direction.DESC) comparator = comparator.reversed();
+        return comparator.thenComparing(row -> safeText(row.getSkuCode()));
+    }
+
     private boolean matchesCircularKeyword(InventoryDto.CircularInventoryRes row, String keyword) {
         if (keyword == null || keyword.isBlank()) return true;
         String materialDetail = row.getMaterialCompositions() == null
@@ -849,6 +942,37 @@ public class InventoryService {
     private boolean matchesWarehouseCodes(InventoryDto.CircularInventoryRes row, Set<String> warehouseCodes) {
         if (warehouseCodes == null || warehouseCodes.isEmpty()) return true;
         return warehouseCodes.contains(safeText(row.getWarehouseCode()).toUpperCase(Locale.ROOT));
+    }
+
+    private boolean matchesCandidateKeyword(InventoryDto.CircularCandidateRes row, String keyword) {
+        if (keyword == null || keyword.isBlank()) return true;
+        String searchable = String.join(" ",
+                safeText(row.getSkuCode()),
+                safeText(row.getItemCode()),
+                safeText(row.getItemName())
+        ).toLowerCase(Locale.ROOT);
+        return searchable.contains(keyword);
+    }
+
+    private boolean matchesCandidateCategory(InventoryDto.CircularCandidateRes row, String parentCategory, String childCategory) {
+        if (parentCategory != null && !parentCategory.isBlank() && !parentCategory.equals(safeText(row.getParentCategory()))) {
+            return false;
+        }
+        if (childCategory != null && !childCategory.isBlank() && !childCategory.equals(safeText(row.getChildCategory()))) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean matchesCandidateWarehouse(InventoryDto.CircularCandidateRes row, Set<String> warehouseCodes) {
+        if (warehouseCodes == null || warehouseCodes.isEmpty()) return true;
+        return warehouseCodes.contains(safeText(row.getWarehouseCode()).toUpperCase(Locale.ROOT));
+    }
+
+    private boolean matchesCandidateConditionCodes(InventoryDto.CircularCandidateRes row, Set<Integer> conditionCodes) {
+        if (conditionCodes == null || conditionCodes.isEmpty()) return true;
+        List<Integer> matched = row.getMatchedConditionCodes() == null ? List.of() : row.getMatchedConditionCodes();
+        return conditionCodes.stream().allMatch(matched::contains);
     }
 
     private boolean matchesMaterialFilter(InventoryDto.CircularInventoryRes row,

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
@@ -80,6 +80,19 @@ public class InventoryDto {
     @Getter
     @Builder
     @AllArgsConstructor
+    public static class CircularCandidatePageRes {
+        private List<CircularCandidateRes> content;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
     public static class CircularCandidateRefreshRes {
         private Integer scannedCount;
         private Integer convertedCount;
@@ -138,6 +151,19 @@ public class InventoryDto {
         private Double unitWeightKg;
         private Double totalWeightKg;
         private Long circularSalePrice;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CircularInventoryPageRes {
+        private List<CircularInventoryRes> content;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
     }
 
     @Getter


### PR DESCRIPTION
## 📌 요약
- 순환 재고 조회 및 순환 재고 후보 조회 API를 리스트 응답에서 페이지 응답으로 확장했습니다.
- 서버 측에서 필터/정렬/페이지 슬라이싱을 처리해 대용량에서도 일관된 조회 결과를 반환하도록 변경했습니다.

<br><br>

## 🎯 작업 내용
- `GET /api/hq/inventories/circular`에 `page/size/sort/keyword/warehouseCodes/materialGroup/materialName/minRatio` 파라미터 지원
- `GET /api/hq/inventories/circular-candidates`에 `page/size/sort/keyword/parentCategory/childCategory/warehouseCodes/conditionCodes` 파라미터 지원
- 응답 DTO 추가 및 전환
  - `CircularInventoryPageRes`
  - `CircularCandidatePageRes`
- `InventoryService`에서 기존 도메인 계산 로직 유지한 채 서버 필터/정렬 후 `PageImpl` 기반 페이지 메타 생성
- 후보 조건코드 필터는 기존 의미 유지(다중 선택 AND: 선택한 코드 모두 포함)

<br><br>

## ✔️ 참고 사항
- 컴파일 검증 완료: `./gradlew --no-daemon compileJava` 성공
- 이번 범위는 조회 API 계약/응답 확장 중심이며, 전환 API(`POST /circular-candidates/convert`) 계약 변경 없음

<br><br>

## ✔️ 관련 이슈

- Close #239

<br><br>
