### PR TITLE
refactor: 매장 발주 배치 처리 안정화 및 입/출고 응답 상태 수정

### DIFF
--- a/docs/codex/order-ob-ib/02-implementation/수동배치_부분성공_안정화_FE-BE_반영_2026-05-10.md
+++ b/docs/codex/order-ob-ib/02-implementation/수동배치_부분성공_안정화_FE-BE_반영_2026-05-10.md
@@ -1,0 +1,36 @@
+﻿# 수동배치 부분성공 안정화 + FE 반영 (2026-05-10)
+
+## 1. 개요
+- 목표: 수동 배치 승인에서 일부 주문 실패(예: 4611 재고 부족) 시 전체 요청이 500으로 터지지 않고, 성공 건은 커밋/실패 건은 집계되는 부분 성공 정책을 안정화한다.
+- 범위: BE 배치 트랜잭션 경계 분리 + FE 배치 실행 결과/오류 피드백 보강.
+
+## 2. BE 변경
+- 주문 1건 단위 전용 서비스 신설
+  - 파일: `src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveItemService.java`
+  - 내용: `@Transactional(propagation = REQUIRES_NEW)`로 `approveOne(...)` 수행
+- 배치 서비스 수정
+  - 파일: `src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java`
+  - 내용:
+    - `runManual`, `runAutoDaily`의 외곽 트랜잭션 제거
+    - 루프 내부 호출을 `storeOrderService.approveByBatch(...)` -> `batchApproveItemService.approveOne(...)`로 전환
+    - 결과 집계(success/fail/results)는 기존 구조 유지
+
+## 3. FE 변경
+- 배치 화면 오류/결과 메시지 보강
+  - 파일: `src/views/hq/store-order-batch/HqStoreOrderBatchApproveView.vue`
+  - 내용:
+    - `4611` 코드 사용자 메시지 추가
+    - 전체/매장 실행 시 `failCount > 0`이면 "부분 성공" 안내
+    - 전건 성공일 때만 완료 처리(완료 마킹) 수행
+- 인증 처리 정책 확인
+  - axios 인터셉터는 401 전용 로그아웃 흐름이므로, 업무 실패/500은 로그아웃 트리거 대상이 아님
+
+## 4. 검증
+- FE: `npm run build` 성공
+- BE: 환경/프로젝트 상태 이슈로 컴파일 확인 실패
+  - 증상: 다수 패키지 미인식 컴파일 에러
+  - 비고: 현재 수정 파일 문법 자체가 아닌 로컬 소스셋 인식 문제로 보이며, 동일 브랜치 기준 소스/빌드 설정 점검 필요
+
+## 5. 기대 효과
+- 배치 중 일부 주문 실패 시에도 전체 요청이 `UnexpectedRollbackException`으로 실패하지 않고 결과 집계 응답을 안정 반환
+- FE에서 부분 성공/실패 메시지를 명확히 안내하여 "로그아웃된 것처럼 보이는" 혼란 감소

--- a/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
@@ -24,7 +24,9 @@ import org.example.stockitbe.store.order.repository.StoreOrderStatusHistoryRepos
 import org.example.stockitbe.user.model.AuthUserDetails;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
 import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHistory;
 import org.example.stockitbe.warehouse.outbound.repository.WhOutboundHeaderRepository;
+import org.example.stockitbe.warehouse.outbound.repository.WhOutboundStatusHistoryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +50,7 @@ public class StoreInboundService {
     private final StoreOrderHeaderRepository storeOrderHeaderRepository;
     private final StoreOrderStatusHistoryRepository storeOrderStatusHistoryRepository;
     private final WhOutboundHeaderRepository whOutboundHeaderRepository;
+    private final WhOutboundStatusHistoryRepository whOutboundStatusHistoryRepository;
     private final InfrastructureRepository infrastructureRepository;
     private final InventoryService inventoryService;
 
@@ -193,6 +196,9 @@ public class StoreInboundService {
         List<StoreInboundStatusHistory> history = inboundStatusHistoryRepository
                 .findAllByInboundHeaderIdOrderByChangedAtAscIdAsc(inbound.getId());
         WhOutboundHeader outbound = whOutboundHeaderRepository.findByOutboundNo(inbound.getOutboundNo()).orElse(null);
+        List<WhOutboundStatusHistory> outboundHistory = outbound == null
+                ? List.of()
+                : whOutboundStatusHistoryRepository.findAllByOutboundHeaderIdOrderByChangedAtAscIdAsc(outbound.getId());
 
         StoreInboundDto.OutboundSummaryRes outboundSummary = outbound == null ? null :
                 StoreInboundDto.OutboundSummaryRes.builder()
@@ -200,7 +206,7 @@ public class StoreInboundService {
                         .outboundStatus(outbound.getStatus())
                         .build();
 
-        return StoreInboundDto.DetailRes.of(inbound, items, history, outboundSummary);
+        return StoreInboundDto.DetailRes.of(inbound, items, history, outboundSummary, outboundHistory);
     }
 
     // 로그인 사용자 매장 ID 해석

--- a/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
@@ -15,24 +15,28 @@ import org.example.stockitbe.store.inbound.model.entity.StoreInboundStatusHistor
 import org.example.stockitbe.store.inbound.repository.StoreInboundHeaderRepository;
 import org.example.stockitbe.store.inbound.repository.StoreInboundItemRepository;
 import org.example.stockitbe.store.inbound.repository.StoreInboundStatusHistoryRepository;
-import org.example.stockitbe.store.order.repository.StoreOrderHeaderRepository;
-import org.example.stockitbe.store.order.repository.StoreOrderStatusHistoryRepository;
 import org.example.stockitbe.store.order.model.StoreOrderHistoryType;
 import org.example.stockitbe.store.order.model.StoreOrderStatus;
 import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
 import org.example.stockitbe.store.order.model.entity.StoreOrderStatusHistory;
+import org.example.stockitbe.store.order.repository.StoreOrderHeaderRepository;
+import org.example.stockitbe.store.order.repository.StoreOrderStatusHistoryRepository;
 import org.example.stockitbe.user.model.AuthUserDetails;
-import org.example.stockitbe.warehouse.outbound.repository.WhOutboundHeaderRepository;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
 import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
+import org.example.stockitbe.warehouse.outbound.repository.WhOutboundHeaderRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -61,12 +65,19 @@ public class StoreInboundService {
         Date toDateExclusive = to == null ? null : Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         // 3) 매장 소속 입고건을 조회 후 필터링하여 응답 DTO로 변환한다.
-        return inboundHeaderRepository.findAllByStoreIdOrderByRequestedAtDescIdDesc(myStoreId).stream()
+        List<StoreInboundHeader> filteredHeaders = inboundHeaderRepository.findAllByStoreIdOrderByRequestedAtDescIdDesc(myStoreId).stream()
                 .filter(h -> statusFilter == null || h.getStatus() == statusFilter)
                 .filter(h -> fromDate == null || !h.getRequestedAt().before(fromDate))
                 .filter(h -> toDateExclusive == null || h.getRequestedAt().before(toDateExclusive))
                 .filter(h -> matchesKeyword(h, safeKeyword))
-                .map(StoreInboundDto.ListRes::from)
+                .toList();
+
+        // 4) outboundNo 기준 출고 상태를 일괄 조회한다.
+        Map<String, OutboundStatus> outboundStatusByNo = loadOutboundStatusMap(filteredHeaders);
+
+        // 5) 목록 DTO를 조합한다.
+        return filteredHeaders.stream()
+                .map(h -> StoreInboundDto.ListRes.from(h, outboundStatusByNo.get(h.getOutboundNo())))
                 .toList();
     }
 
@@ -88,25 +99,23 @@ public class StoreInboundService {
     // 동일 트랜잭션 내에서 재고 반영, 입고 상태 전이/이력, 발주 완료 전이를 원자적으로 수행한다.
     @Transactional
     public StoreInboundDto.DetailRes confirm(AuthUserDetails me, String inboundNo, String reason) {
-        // 1) 로그인 사용자 매장 범위를 확인한다.
+        // 1) 매장 범위와 대상 입고건을 확인한다.
         Long myStoreId = resolveStoreId(me);
-
-        // 2) 입고번호로 대상 건을 찾고 소유 범위를 검증한다.
         StoreInboundHeader inbound = findOwnedInbound(inboundNo, myStoreId);
 
-        // 3) PENDING_RECEIPT 상태에서만 확정이 가능하다.
+        // 2) PENDING_RECEIPT 상태에서만 확정이 가능하다.
         if (inbound.getStatus() != StoreInboundStatus.PENDING_RECEIPT) {
             throw BaseException.from(BaseResponseStatus.INVALID_INBOUND_STATUS_TRANSITION);
         }
 
-        // 4) 이 입고와 연결된 출고가 ARRIVED 상태인지 검증한다.
+        // 3) 이 입고와 연결된 출고가 배송 완료(ARRIVED)인지 확인한다.
         WhOutboundHeader outbound = whOutboundHeaderRepository.findByOutboundNo(inbound.getOutboundNo())
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_NOT_FOUND));
         if (outbound.getStatus() != OutboundStatus.ARRIVED) {
             throw BaseException.from(BaseResponseStatus.INBOUND_NOT_CONFIRMABLE);
         }
 
-        // 5) 입고 라인 기준으로 매장 NORMAL 재고를 증가시킨다.
+        // 4) 입고 품목 수량만큼 매장 NORMAL 재고를 반영한다.
         List<StoreInboundItem> inboundItems = inboundItemRepository.findAllByInboundHeaderIdOrderByIdAsc(inbound.getId());
         for (StoreInboundItem item : inboundItems) {
             inventoryService.increaseOnHandAndAvailable(
@@ -116,7 +125,7 @@ public class StoreInboundService {
             );
         }
 
-        // 5) 입고 헤더를 RECEIVED로 전이하고 확정자/시각을 기록한다.
+        // 5) 입고 헤더 상태를 RECEIVED로 전이하고 이력을 남긴다.
         Date now = new Date();
         String actorMemberId = me == null ? null : me.getEmployeeCode();
         String actorName = me == null ? null : me.getName();
@@ -134,10 +143,10 @@ public class StoreInboundService {
                         .build()
         );
 
-        // 7) 같은 발주의 연계 입고가 모두 RECEIVED면 발주를 COMPLETED로 자동 전이한다.
+        // 6) 같은 발주의 연결 입고가 전부 RECEIVED면 발주를 COMPLETED로 전이한다.
         completeOrderWhenAllInboundReceived(inbound.getSourceRefNo(), actorMemberId, actorName);
 
-        // 8) 최신 상태 기준 상세 응답을 반환한다.
+        // 7) 최신 상세 응답을 반환한다.
         return buildDetailRes(inbound);
     }
 
@@ -236,5 +245,23 @@ public class StoreInboundService {
         String search = (header.getInboundNo() + " " + header.getSourceRefNo() + " " + header.getOutboundNo())
                 .toLowerCase(Locale.ROOT);
         return search.contains(safeKeyword);
+    }
+
+    // [출고 상태 맵 조회] 목록 건들의 outboundNo를 기준으로 출고 상태를 일괄 조회한다.
+    private Map<String, OutboundStatus> loadOutboundStatusMap(List<StoreInboundHeader> headers) {
+        if (headers == null || headers.isEmpty()) return Collections.emptyMap();
+
+        List<String> outboundNos = headers.stream()
+                .map(StoreInboundHeader::getOutboundNo)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (outboundNos.isEmpty()) return Collections.emptyMap();
+
+        Map<String, OutboundStatus> result = new HashMap<>();
+        for (WhOutboundHeader outbound : whOutboundHeaderRepository.findAllByOutboundNoIn(outboundNos)) {
+            result.put(outbound.getOutboundNo(), outbound.getStatus());
+        }
+        return result;
     }
 }

--- a/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/StoreInboundService.java
@@ -35,10 +35,12 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -77,10 +79,15 @@ public class StoreInboundService {
 
         // 4) outboundNo 기준 출고 상태를 일괄 조회한다.
         Map<String, OutboundStatus> outboundStatusByNo = loadOutboundStatusMap(filteredHeaders);
+        Map<Long, String> warehouseNameById = loadWarehouseNameMap(filteredHeaders);
 
         // 5) 목록 DTO를 조합한다.
         return filteredHeaders.stream()
-                .map(h -> StoreInboundDto.ListRes.from(h, outboundStatusByNo.get(h.getOutboundNo())))
+                .map(h -> StoreInboundDto.ListRes.from(
+                        h,
+                        outboundStatusByNo.get(h.getOutboundNo()),
+                        warehouseNameById.get(h.getFromWarehouseId())
+                ))
                 .toList();
     }
 
@@ -206,7 +213,11 @@ public class StoreInboundService {
                         .outboundStatus(outbound.getStatus())
                         .build();
 
-        return StoreInboundDto.DetailRes.of(inbound, items, history, outboundSummary, outboundHistory);
+        String fromWarehouseName = infrastructureRepository.findById(inbound.getFromWarehouseId())
+                .map(Infrastructure::getName)
+                .orElse(null);
+
+        return StoreInboundDto.DetailRes.of(inbound, items, history, fromWarehouseName, outboundSummary, outboundHistory);
     }
 
     // 로그인 사용자 매장 ID 해석
@@ -267,6 +278,25 @@ public class StoreInboundService {
         Map<String, OutboundStatus> result = new HashMap<>();
         for (WhOutboundHeader outbound : whOutboundHeaderRepository.findAllByOutboundNoIn(outboundNos)) {
             result.put(outbound.getOutboundNo(), outbound.getStatus());
+        }
+        return result;
+    }
+
+    // [출고지 창고명 맵 조회] 목록 건들의 fromWarehouseId를 기준으로 창고명을 일괄 조회한다.
+    private Map<Long, String> loadWarehouseNameMap(List<StoreInboundHeader> headers) {
+        if (headers == null || headers.isEmpty()) return Collections.emptyMap();
+
+        Set<Long> warehouseIds = new HashSet<>();
+        for (StoreInboundHeader header : headers) {
+            if (header.getFromWarehouseId() != null) {
+                warehouseIds.add(header.getFromWarehouseId());
+            }
+        }
+        if (warehouseIds.isEmpty()) return Collections.emptyMap();
+
+        Map<Long, String> result = new HashMap<>();
+        for (Infrastructure infra : infrastructureRepository.findAllById(warehouseIds)) {
+            result.put(infra.getId(), infra.getName());
         }
         return result;
     }

--- a/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
@@ -20,17 +20,19 @@ public class StoreInboundDto {
         private String inboundNo;
         private String sourceRefNo;
         private String outboundNo;
+        private OutboundStatus outboundStatus;
         private Long fromWarehouseId;
         private StoreInboundStatus status;
         private Date expectedArrivalAt;
         private Integer totalExpectedQuantity;
         private Date requestedAt;
 
-        public static ListRes from(StoreInboundHeader header) {
+        public static ListRes from(StoreInboundHeader header, OutboundStatus outboundStatus) {
             return ListRes.builder()
                     .inboundNo(header.getInboundNo())
                     .sourceRefNo(header.getSourceRefNo())
                     .outboundNo(header.getOutboundNo())
+                    .outboundStatus(outboundStatus)
                     .fromWarehouseId(header.getFromWarehouseId())
                     .status(header.getStatus())
                     .expectedArrivalAt(header.getExpectedArrivalAt())

--- a/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
@@ -7,6 +7,7 @@ import org.example.stockitbe.store.inbound.model.entity.StoreInboundHeader;
 import org.example.stockitbe.store.inbound.model.entity.StoreInboundItem;
 import org.example.stockitbe.store.inbound.model.entity.StoreInboundStatusHistory;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHistory;
 
 import java.util.Date;
 import java.util.List;
@@ -65,6 +66,7 @@ public class StoreInboundDto {
         private String deliveryGroupNo;
         private String memo;
         private OutboundSummaryRes outbound;
+        private List<OutboundStatusHistoryRes> outboundStatusHistory;
         private List<ItemRes> items;
         private List<StatusHistoryRes> statusHistory;
 
@@ -72,7 +74,8 @@ public class StoreInboundDto {
                 StoreInboundHeader header,
                 List<StoreInboundItem> items,
                 List<StoreInboundStatusHistory> history,
-                OutboundSummaryRes outbound
+                OutboundSummaryRes outbound,
+                List<WhOutboundStatusHistory> outboundHistory
         ) {
             return DetailRes.builder()
                     .inboundNo(header.getInboundNo())
@@ -94,6 +97,7 @@ public class StoreInboundDto {
                     .deliveryGroupNo(header.getDeliveryGroupNo())
                     .memo(header.getMemo())
                     .outbound(outbound)
+                    .outboundStatusHistory(outboundHistory.stream().map(OutboundStatusHistoryRes::from).toList())
                     .items(items.stream().map(ItemRes::from).toList())
                     .statusHistory(history.stream().map(StatusHistoryRes::from).toList())
                     .build();
@@ -161,6 +165,28 @@ public class StoreInboundDto {
     public static class OutboundSummaryRes {
         private String outboundNo;
         private OutboundStatus outboundStatus;
+    }
+
+    @Getter
+    @Builder
+    public static class OutboundStatusHistoryRes {
+        private Long id;
+        private OutboundStatus status;
+        private Date changedAt;
+        private String changedByMemberId;
+        private String changedByName;
+        private String reason;
+
+        public static OutboundStatusHistoryRes from(WhOutboundStatusHistory history) {
+            return OutboundStatusHistoryRes.builder()
+                    .id(history.getId())
+                    .status(history.getStatus())
+                    .changedAt(history.getChangedAt())
+                    .changedByMemberId(history.getChangedByMemberId())
+                    .changedByName(history.getChangedByName())
+                    .reason(history.getReason())
+                    .build();
+        }
     }
 }
 

--- a/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/model/dto/StoreInboundDto.java
@@ -23,18 +23,20 @@ public class StoreInboundDto {
         private String outboundNo;
         private OutboundStatus outboundStatus;
         private Long fromWarehouseId;
+        private String fromWarehouseName;
         private StoreInboundStatus status;
         private Date expectedArrivalAt;
         private Integer totalExpectedQuantity;
         private Date requestedAt;
 
-        public static ListRes from(StoreInboundHeader header, OutboundStatus outboundStatus) {
+        public static ListRes from(StoreInboundHeader header, OutboundStatus outboundStatus, String fromWarehouseName) {
             return ListRes.builder()
                     .inboundNo(header.getInboundNo())
                     .sourceRefNo(header.getSourceRefNo())
                     .outboundNo(header.getOutboundNo())
                     .outboundStatus(outboundStatus)
                     .fromWarehouseId(header.getFromWarehouseId())
+                    .fromWarehouseName(fromWarehouseName)
                     .status(header.getStatus())
                     .expectedArrivalAt(header.getExpectedArrivalAt())
                     .totalExpectedQuantity(header.getTotalExpectedQuantity())
@@ -53,6 +55,7 @@ public class StoreInboundDto {
         private String outboundNo;
         private Long storeId;
         private Long fromWarehouseId;
+        private String fromWarehouseName;
         private StoreInboundStatus status;
         private Integer totalSkuCount;
         private Integer totalExpectedQuantity;
@@ -74,6 +77,7 @@ public class StoreInboundDto {
                 StoreInboundHeader header,
                 List<StoreInboundItem> items,
                 List<StoreInboundStatusHistory> history,
+                String fromWarehouseName,
                 OutboundSummaryRes outbound,
                 List<WhOutboundStatusHistory> outboundHistory
         ) {
@@ -84,6 +88,7 @@ public class StoreInboundDto {
                     .outboundNo(header.getOutboundNo())
                     .storeId(header.getStoreId())
                     .fromWarehouseId(header.getFromWarehouseId())
+                    .fromWarehouseName(fromWarehouseName)
                     .status(header.getStatus())
                     .totalSkuCount(header.getTotalSkuCount())
                     .totalExpectedQuantity(header.getTotalExpectedQuantity())

--- a/src/main/java/org/example/stockitbe/store/inbound/repository/StoreInboundStatusHistoryRepository.java
+++ b/src/main/java/org/example/stockitbe/store/inbound/repository/StoreInboundStatusHistoryRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface StoreInboundStatusHistoryRepository extends JpaRepository<StoreInboundStatusHistory, Long> {
     List<StoreInboundStatusHistory> findAllByInboundHeaderIdOrderByChangedAtAscIdAsc(Long inboundHeaderId);
+    boolean existsByInboundHeaderIdAndStatus(Long inboundHeaderId, org.example.stockitbe.store.inbound.model.StoreInboundStatus status);
 }
 

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveItemService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveItemService.java
@@ -1,0 +1,23 @@
+package org.example.stockitbe.store.order;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.store.order.model.dto.StoreOrderDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreOrderBatchApproveItemService {
+
+    private final StoreOrderService storeOrderService;
+
+    /**
+     * Approve one order in an isolated transaction so failures do not mark the outer batch flow rollback-only.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public StoreOrderDto.ApproveRes approveOne(String orderNo, String actorId, String actorName, String reason) {
+        return storeOrderService.approveByBatch(orderNo, actorId, actorName, reason);
+    }
+}
+

--- a/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/StoreOrderBatchApproveService.java
@@ -37,10 +37,9 @@ public class StoreOrderBatchApproveService {
 
     private final StoreOrderHeaderRepository headerRepository;
     private final InfrastructureRepository infrastructureRepository;
-    private final StoreOrderService storeOrderService;
+    private final StoreOrderBatchApproveItemService batchApproveItemService;
 
     // 발주 수동 배치
-    @Transactional
     public StoreOrderBatchDto.RunRes runManual(StoreOrderBatchDto.RunReq req, AuthUserDetails me) {
         StoreOrderBatchScope scope = req == null || req.getMode() == null ? StoreOrderBatchScope.ALL : req.getMode();
         String runId = UUID.randomUUID().toString();
@@ -67,7 +66,7 @@ public class StoreOrderBatchApproveService {
         int success = 0;
         for (StoreOrderHeader header : targets) {
             try {
-                storeOrderService.approveByBatch(
+                batchApproveItemService.approveOne(
                         header.getOrderNo(),
                         actorId,
                         actorName,
@@ -110,7 +109,6 @@ public class StoreOrderBatchApproveService {
     }
 
     // 발주 자동 배치
-    @Transactional
     public StoreOrderBatchDto.RunRes runAutoDaily() {
         String runId = UUID.randomUUID().toString();
         Date[] range = previousDayRange();
@@ -126,7 +124,7 @@ public class StoreOrderBatchApproveService {
         int success = 0;
         for (StoreOrderHeader header : targets) {
             try {
-                storeOrderService.approveByBatch(
+                batchApproveItemService.approveOne(
                         header.getOrderNo(),
                         "SYSTEM_BATCH",
                         "SYSTEM_BATCH",

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
@@ -3,6 +3,8 @@ package org.example.stockitbe.warehouse.outbound;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.circularbuyer.CircularBuyerRepository;
+import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
@@ -13,6 +15,7 @@ import org.example.stockitbe.store.inbound.model.entity.StoreInboundStatusHistor
 import org.example.stockitbe.store.inbound.repository.StoreInboundHeaderRepository;
 import org.example.stockitbe.store.inbound.repository.StoreInboundStatusHistoryRepository;
 import org.example.stockitbe.user.model.AuthUserDetails;
+import org.example.stockitbe.warehouse.outbound.model.OutboundDestinationType;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
 import org.example.stockitbe.warehouse.outbound.model.dto.WhOutboundDto;
 import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
@@ -27,8 +30,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +47,7 @@ public class WhOutboundService {
     private final StoreInboundHeaderRepository inboundHeaderRepository;
     private final StoreInboundStatusHistoryRepository inboundStatusHistoryRepository;
     private final InfrastructureRepository infrastructureRepository;
+    private final CircularBuyerRepository circularBuyerRepository;
     private final InventoryService inventoryService;
 
     // 출고 목록 조회 함수
@@ -59,6 +67,7 @@ public class WhOutboundService {
         // 3) 응답 표시에 필요한 창고 정보를 조회한다.
         Infrastructure myWarehouse = infrastructureRepository.findById(myWarehouseId)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.OUTBOUND_NOT_FOUND));
+        Map<Long, String> destinationNameById = loadDestinationNameMap(headers);
 
         // 4) 상태/기간/키워드 필터를 적용해 목록 DTO를 구성한다.
         return headers.stream()
@@ -66,7 +75,12 @@ public class WhOutboundService {
                 .filter(h -> fromDate == null || !h.getRequestedAt().before(fromDate))
                 .filter(h -> toDateExclusive == null || h.getRequestedAt().before(toDateExclusive))
                 .filter(h -> safeKeyword.isBlank() || matchesKeyword(h, safeKeyword))
-                .map(h -> WhOutboundDto.toListRes(h, myWarehouse.getCode(), myWarehouse.getName()))
+                .map(h -> WhOutboundDto.toListRes(
+                        h,
+                        myWarehouse.getCode(),
+                        myWarehouse.getName(),
+                        destinationNameById.get(h.getDestinationId())
+                ))
                 .toList();
     }
 
@@ -83,6 +97,7 @@ public class WhOutboundService {
         List<WhOutboundItem> items = outboundItemRepository.findAllByOutboundHeaderIdOrderByIdAsc(header.getId());
         List<WhOutboundStatusHistory> history = outboundStatusHistoryRepository.findAllByOutboundHeaderIdOrderByChangedAtAscIdAsc(header.getId());
         StoreInboundHeader inbound = inboundHeaderRepository.findByOutboundNo(header.getOutboundNo()).orElse(null);
+        String destinationName = resolveDestinationName(header.getDestinationType(), header.getDestinationId());
 
         // 3) 상세 응답 DTO를 조합해 반환한다.
         return WhOutboundDto.DetailRes.builder()
@@ -96,6 +111,7 @@ public class WhOutboundService {
                 .warehouseName(warehouse.getName())
                 .destinationType(header.getDestinationType().name())
                 .destinationId(header.getDestinationId())
+                .destinationName(destinationName)
                 .status(header.getStatus())
                 .totalRequestedQuantity(header.getTotalRequestedQuantity())
                 .requestedAt(header.getRequestedAt())
@@ -240,5 +256,48 @@ public class WhOutboundService {
         String text = (header.getOutboundNo() + " " + header.getSourceRefNo() + " " + header.getDestinationType().name())
                 .toLowerCase(Locale.ROOT);
         return text.contains(safeKeyword);
+    }
+
+    // [출고 목적지명 맵 조회] destinationType/destinationId 기준으로 목적지명을 조회한다.
+    private Map<Long, String> loadDestinationNameMap(List<WhOutboundHeader> headers) {
+        if (headers == null || headers.isEmpty()) return Map.of();
+
+        Set<Long> infraDestinationIds = new HashSet<>();
+        Set<Long> buyerDestinationIds = new HashSet<>();
+        for (WhOutboundHeader header : headers) {
+            if (header.getDestinationId() == null || header.getDestinationType() == null) continue;
+            if (header.getDestinationType() == OutboundDestinationType.STORE
+                    || header.getDestinationType() == OutboundDestinationType.WAREHOUSE) {
+                infraDestinationIds.add(header.getDestinationId());
+            } else if (header.getDestinationType() == OutboundDestinationType.CIRCULAR_BUYER) {
+                buyerDestinationIds.add(header.getDestinationId());
+            }
+        }
+
+        Map<Long, String> nameById = new HashMap<>();
+        if (!infraDestinationIds.isEmpty()) {
+            for (Infrastructure infra : infrastructureRepository.findAllById(infraDestinationIds)) {
+                nameById.put(infra.getId(), infra.getName());
+            }
+        }
+        if (!buyerDestinationIds.isEmpty()) {
+            for (CircularBuyer buyer : circularBuyerRepository.findAllById(buyerDestinationIds)) {
+                nameById.put(buyer.getId(), buyer.getCompanyName());
+            }
+        }
+        return nameById;
+    }
+
+    // [목적지명 단건 조회] destinationType에 따라 인프라/거래처에서 이름을 조회한다.
+    private String resolveDestinationName(OutboundDestinationType destinationType, Long destinationId) {
+        if (destinationType == null || destinationId == null) return null;
+
+        if (destinationType == OutboundDestinationType.STORE || destinationType == OutboundDestinationType.WAREHOUSE) {
+            return infrastructureRepository.findById(destinationId).map(Infrastructure::getName).orElse(null);
+        }
+        if (destinationType == OutboundDestinationType.CIRCULAR_BUYER) {
+            return circularBuyerRepository.findById(destinationId).map(CircularBuyer::getCompanyName).orElse(null);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
@@ -7,8 +7,11 @@ import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.inventory.InventoryService;
-import org.example.stockitbe.store.inbound.repository.StoreInboundHeaderRepository;
+import org.example.stockitbe.store.inbound.model.StoreInboundStatus;
 import org.example.stockitbe.store.inbound.model.entity.StoreInboundHeader;
+import org.example.stockitbe.store.inbound.model.entity.StoreInboundStatusHistory;
+import org.example.stockitbe.store.inbound.repository.StoreInboundHeaderRepository;
+import org.example.stockitbe.store.inbound.repository.StoreInboundStatusHistoryRepository;
 import org.example.stockitbe.user.model.AuthUserDetails;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
 import org.example.stockitbe.warehouse.outbound.model.dto.WhOutboundDto;
@@ -18,8 +21,8 @@ import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHis
 import org.example.stockitbe.warehouse.outbound.repository.WhOutboundHeaderRepository;
 import org.example.stockitbe.warehouse.outbound.repository.WhOutboundItemRepository;
 import org.example.stockitbe.warehouse.outbound.repository.WhOutboundStatusHistoryRepository;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -35,6 +38,7 @@ public class WhOutboundService {
     private final WhOutboundItemRepository outboundItemRepository;
     private final WhOutboundStatusHistoryRepository outboundStatusHistoryRepository;
     private final StoreInboundHeaderRepository inboundHeaderRepository;
+    private final StoreInboundStatusHistoryRepository inboundStatusHistoryRepository;
     private final InfrastructureRepository infrastructureRepository;
     private final InventoryService inventoryService;
 
@@ -176,6 +180,23 @@ public class WhOutboundService {
         );
 
         // 4) 최신 상세 정보를 반환한다.
+        inboundHeaderRepository.findByOutboundNo(header.getOutboundNo()).ifPresent(inbound -> {
+            boolean exists = inboundStatusHistoryRepository
+                    .existsByInboundHeaderIdAndStatus(inbound.getId(), StoreInboundStatus.PENDING_RECEIPT);
+            if (!exists) {
+                inboundStatusHistoryRepository.save(
+                        StoreInboundStatusHistory.builder()
+                                .inboundHeaderId(inbound.getId())
+                                .status(StoreInboundStatus.PENDING_RECEIPT)
+                                .changedAt(now)
+                                .changedByMemberId(me.getEmployeeCode())
+                                .changedByName(me.getName())
+                                .reason("OUTBOUND_ARRIVED")
+                                .build()
+                );
+            }
+        });
+
         return detail(me, outboundNo);
     }
 

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/model/dto/WhOutboundDto.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/model/dto/WhOutboundDto.java
@@ -38,6 +38,7 @@ public class WhOutboundDto {
         private String warehouseName;
         private String destinationType;
         private Long destinationId;
+        private String destinationName;
         private OutboundStatus status;
         private Integer totalRequestedQuantity;
         private Date requestedAt;
@@ -59,6 +60,7 @@ public class WhOutboundDto {
         private String warehouseName;
         private String destinationType;
         private Long destinationId;
+        private String destinationName;
         private OutboundStatus status;
         private Integer totalRequestedQuantity;
         private Date requestedAt;
@@ -142,7 +144,12 @@ public class WhOutboundDto {
         private StoreInboundStatus inboundStatus;
     }
 
-    public static ListRes toListRes(WhOutboundHeader header, String warehouseCode, String warehouseName) {
+    public static ListRes toListRes(
+            WhOutboundHeader header,
+            String warehouseCode,
+            String warehouseName,
+            String destinationName
+    ) {
         return ListRes.builder()
                 .outboundNo(header.getOutboundNo())
                 .sourceType(header.getSourceType().name())
@@ -153,6 +160,7 @@ public class WhOutboundDto {
                 .warehouseName(warehouseName)
                 .destinationType(header.getDestinationType().name())
                 .destinationId(header.getDestinationId())
+                .destinationName(destinationName)
                 .status(header.getStatus())
                 .totalRequestedQuantity(header.getTotalRequestedQuantity())
                 .requestedAt(header.getRequestedAt())

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/repository/WhOutboundHeaderRepository.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/repository/WhOutboundHeaderRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 public interface WhOutboundHeaderRepository extends JpaRepository<WhOutboundHeader, Long> {
     Optional<WhOutboundHeader> findByOutboundNo(String outboundNo);
+    List<WhOutboundHeader> findAllByOutboundNoIn(List<String> outboundNos);
     Optional<WhOutboundHeader> findBySourceTypeAndSourceRefNoAndSourceRefSeq(
             OutboundSourceType sourceType, String sourceRefNo, Integer sourceRefSeq
     );


### PR DESCRIPTION
## 📌 요약
- 매장 발주 배치 승인 처리 안정화를 위해 예외 전파/건별 결과 집계 흐름을 정리했습니다.
- 발주 승인 기반 출고/입고 오케스트레이션의 상태 이력 및 응답 상태 정합성을 보강했습니다.
- 출고/입고 조회 응답의 상태 필드 계약을 정리해 FE 표시/액션 조건과의 일관성을 높였습니다.

<br><br>

## 🎯 작업 내용
- 배치 승인(수동/자동) 처리 경로에서 일부 건 실패 시 전체 응답이 비정상 실패로 번지는 케이스를 방지하도록 예외 처리 경계를 정리하고, 건별 성공/실패 집계를 안정화했습니다. (중요)

> - 기존 문제: 배치에서 주문 N건을 처리할 때 1건에서 예외가 터지면, 그 예외가 배치 전체로 전파되어 전체 요청이 실패처럼 보이는 위험이 있었습니다.

> - 개선 핵심: 예외 처리 경계를 배치 전체가 아니라 주문 1건 단위로 분리해서, 실패 건은 실패로 기록하고 나머지 건은 계속 처리하도록 안정화했습니다.

> - 결과 집계: 최종 응답에서 성공 건수 / 실패 건수 / 건별 결과(사유 포함)를 명확히 내려주므로, 프론트/운영에서 어떤 건이 왜 실패했는지 바로 확인할 수 있습니다.

> - 효과: 재실행 시에도 실패 건만 추적하기 쉬워지고, 전체 배치가 불필요하게 실패 처리되는 운영 리스크가 줄어듭니다.

- 발주 승인 오케스트레이션 내 출고/입고 생성 및 상태 이력 기록 흐름을 점검하여 누락/중복 가능성을 줄이고, 상태 전이 타이밍을 도메인 규칙에 맞게 정리했습니다.
- 출고/입고 API 응답 DTO의 상태 관련 필드(출고 상태, 입고 상태, 연계 상태)를 정리하고, FE에서 조건 분기(확정 가능 여부, 진행 단계 표기)를 일관되게 해석할 수 있도록 계약을 맞췄습니다.

<br><br>

## ✔️ 참고 사항
- 이번 PR은 **BE 중심** 변경이며, FE 표시 개선은 별도 PR/커밋에서 연동했습니다.
- 배포 전 점검 권장: 배치 재실행 멱등, 상태 이력 누락 여부, 수동/자동 배치에서의 부분 실패 응답 형식, 권한 범위 검증.

<br><br>

## ✔️ 관련 이슈

- Close #250 

<br><br>
