### PR TITLE
feat: 물류창고간 재고이동 출고 연계 기능 구현

### DIFF
--- a/docs/codex/whTransfer-ob-ib/01-plan/재고이동_실행기반_WH_TRANSFER_출고연계_BE_설계보고서.md
+++ b/docs/codex/whTransfer-ob-ib/01-plan/재고이동_실행기반_WH_TRANSFER_출고연계_BE_설계보고서.md
@@ -1,0 +1,95 @@
+# 재고이동 실행기반 WH_TRANSFER 출고연계 BE 설계보고서
+
+## 1. 목적
+- 재고이동 실행 시점에 물류 출고 문서를 즉시 생성해 창고 출고 리스트와 연동한다.
+- 기존 매장발주 기반 출고 흐름과 충돌 없이 `WH_TRANSFER` 원천을 공존시킨다.
+- 재고이동 상태를 출고 상태와 동일한 3단계로 통일해 운영/조회 혼선을 제거한다.
+
+## 2. 범위
+- 포함
+  - 재고이동 실행 API 내부 오케스트레이션(Transfer -> Outbound)
+  - `sourceType=WAREHOUSE_TRANSFER` 출고 생성 규칙
+  - 멱등/중복 방지(사전조회 + 유니크 충돌 재조회)
+  - 출고 상태 전이 시 재고이동 상태 동기화
+  - 부분성공 응답 확장(실패 라우트 사유 분리)
+- 제외
+  - 입고 확정 오케스트레이션(후속 담당 연계)
+  - FE 화면 상세 개선(이번 문서는 BE 중심)
+
+## 3. 상태 정책
+- 재고이동 상태는 아래 3개만 사용한다.
+  - `READY_TO_SHIP`
+  - `IN_TRANSIT`
+  - `ARRIVED`
+- 미사용 상태(`REQUESTED`, `IN_PROGRESS`, `COMPLETED`, `CANCELED`)는 제거한다.
+- 상태 동기화 규칙
+  - 재고이동 실행 + 출고 생성 완료: `READY_TO_SHIP`
+  - 출고확정(`confirm`): `IN_TRANSIT`
+  - 배송완료(`arrive`): `ARRIVED`
+
+## 4. 오케스트레이션 설계
+### 4.1 실행 단위
+- 요청 라인은 `fromWarehouseCode -> toWarehouseCode` 라우트 단위로 그룹화한다.
+- 각 라우트는 독립 트랜잭션(`REQUIRES_NEW`)으로 처리한다.
+
+### 4.2 라우트 처리 순서
+1. 라우트 검증(창고 유효성, SKU 유효성, 가용수량)
+2. 재고이동 헤더/아이템 생성
+3. WH_TRANSFER 출고 헤더 생성
+4. WH_TRANSFER 출고 아이템 생성
+5. 출고 상태이력 `READY_TO_SHIP` 생성
+6. 재고이동 상태 `READY_TO_SHIP` 반영
+
+### 4.3 부분성공 정책
+- 성공 라우트는 커밋한다.
+- 실패 라우트는 롤백하고 실패 사유를 응답에 적재한다.
+- 배치 전체는 중단하지 않는다.
+
+## 5. 출고 생성 규칙
+- 헤더
+  - `sourceType = WAREHOUSE_TRANSFER`
+  - `sourceRefNo = transferNo`
+  - `sourceRefId = transferHeader.id`
+  - `sourceRefSeq = 1`
+  - `warehouseId = fromWarehouseId`
+  - `destinationType = WAREHOUSE`
+  - `destinationId = toWarehouseId`
+  - `status = READY_TO_SHIP`
+  - `outboundNo = WOB-YYYYMMDD-00001`
+- 아이템
+  - 원천: `warehouse_transfer_item`
+  - 매핑: `skuId/quantity/reason/memo`
+  - 스냅샷: `productSku/productMaster` 조회로 `skuCode/productCode/productName/color/size/unitPrice` 구성
+
+## 6. 멱등/중복 방지
+- 1차 방어: `(sourceType, sourceRefNo, sourceRefSeq)` 사전 조회
+- 2차 방어: DB 유니크 충돌(`DataIntegrityViolationException`) 시 재조회 후 기존건 재사용
+- 목표: 동일 transfer 재처리 또는 동시 요청에도 출고 중복 미생성
+
+## 7. 응답 계약
+- 기존 유지
+  - `lineResults`
+  - `createdTransfers`
+- 확장 추가
+  - `failedTransfers[]`
+    - `fromWarehouseCode`, `toWarehouseCode`
+    - `errorCode`, `errorMessage`
+    - `failedLines[]` (`lineId`, `skuCode`, `qty`, `reason`)
+
+## 8. 검증 시나리오
+1. 정상
+  - 단일 라우트 실행 시 transfer 1건 + outbound 1건 + 상태이력 1건 생성
+2. 부분성공
+  - 다중 라우트 중 일부 실패 시 성공 라우트만 커밋, 실패 라우트만 사유 반환
+3. 멱등
+  - 동일 transfer 재처리 시 outbound 중복 미생성
+4. 상태동기화
+  - outbound confirm 시 transfer `IN_TRANSIT`
+  - outbound arrive 시 transfer `ARRIVED`
+5. 회귀
+  - STORE_ORDER 출고/입고 오케스트레이션 영향 없음
+
+## 9. 후속 연계(TODO)
+- 입고 담당자 연계 시 `ARRIVED -> RECEIVED` 연결
+- 필요 시 transfer 상세 응답에 연계 outboundNo 추가
+- FE 히스토리 화면 상태 라벨(`IN_PROGRESS` 기준) 정비

--- a/docs/codex/whTransfer-ob-ib/02-implementation/재고이동_출고연계_오케스트레이션_BE_구현보고서.md
+++ b/docs/codex/whTransfer-ob-ib/02-implementation/재고이동_출고연계_오케스트레이션_BE_구현보고서.md
@@ -1,0 +1,125 @@
+# 재고이동 출고연계 오케스트레이션 BE 구현보고서
+
+## 1. 작업 개요
+- 작업 일자: 2026-05-11
+- 작업 목적:
+  - 재고이동 실행 시 `WH_TRANSFER` 출고를 즉시 생성하도록 오케스트레이션 연계
+  - 재고이동 상태를 출고 상태 흐름(`READY_TO_SHIP -> IN_TRANSIT -> ARRIVED`)과 정합화
+  - 부분성공/멱등/중복방지 정책 반영
+  - DTO 변환 책임을 DTO(`toEntity/from`)로 정리
+
+## 2. 구현 범위
+- 포함
+  - 재고이동 실행(`execute`) 시 transfer -> outbound 생성 오케스트레이션
+  - 출고 상태 이력(`READY_TO_SHIP`) 생성
+  - 출고 상태 전이(`confirm/arrive`) 시 transfer 상태 동기화
+  - 부분성공 응답(`failedTransfers`) 확장
+  - 이동번호 prefix 변경 `STF` -> `WTF`
+- 제외
+  - 입고 확정(`RECEIVED`) 오케스트레이션
+  - FE 상태 라벨/화면 정비
+
+## 3. 변경 파일
+- `src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java`
+- `src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java`
+- `src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferHeader.java`
+- `src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferStatus.java`
+- `src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java`
+- `docs/codex/whTransfer-ob-ib/01-plan/재고이동_실행기반_WH_TRANSFER_출고연계_BE_설계보고서.md`
+
+## 4. 핵심 구현 내용
+### 4.1 재고이동 실행 -> 출고 생성 오케스트레이션
+- `WarehouseTransferService.execute`를 라우트(`fromWarehouseCode -> toWarehouseCode`) 단위로 그룹 처리
+- 라우트 단위 `REQUIRES_NEW` 트랜잭션 적용:
+  - 성공 라우트 커밋
+  - 실패 라우트 롤백 + 실패사유 수집
+- 라우트 성공 처리 순서:
+  1. transfer header 생성
+  2. transfer item 생성
+  3. outbound header 생성(멱등 upsert)
+  4. outbound item 생성
+  5. outbound status history(`READY_TO_SHIP`) 생성
+  6. transfer 상태 `READY_TO_SHIP` 동기화
+
+### 4.2 WH_TRANSFER 출고 생성 규칙
+- `sourceType = WAREHOUSE_TRANSFER`
+- `sourceRefNo = transferNo`
+- `sourceRefId = transferHeader.id`
+- `sourceRefSeq = 1`
+- `warehouseId = fromWarehouseId`
+- `destinationType = WAREHOUSE`
+- `destinationId = toWarehouseId`
+- `status = READY_TO_SHIP`
+- `outboundNo = WOB-YYYYMMDD-00001`
+
+### 4.3 멱등/중복 방지
+- 1차: `(sourceType, sourceRefNo, sourceRefSeq)` 사전 조회
+- 2차: 유니크 충돌(`DataIntegrityViolationException`) 시 재조회 후 기존건 사용
+- 결과: 동일 transfer 재처리 시 outbound 중복 생성 방지
+
+### 4.4 상태 동기화
+- `WarehouseTransferStatus`를 3상태로 정리:
+  - `READY_TO_SHIP`, `IN_TRANSIT`, `ARRIVED`
+- `WhOutboundService.confirm` 시 transfer `IN_TRANSIT` 반영
+- `WhOutboundService.arrive` 시 transfer `ARRIVED` 반영
+
+### 4.5 DTO 변환 리팩터링
+- `Req DTO`에서 `toEntity(...)` 적용
+  - `ExecuteReq.toEntity(ExecuteHeaderContext)`
+  - `ExecuteLineReq.toEntity(ExecuteLineContext)`
+- `Res DTO`에서 `from(...)` 적용
+  - `ExecuteRes/ExecuteLineResultRes/ExecuteTransferRes`
+  - `ExecuteFailedRouteRes/ExecuteLineFailureRes`
+  - `TransferListItemRes/TransferDetailRes/TransferLineRes`
+  - `WarehouseSkuDistributionRes`
+- 서비스의 수동 `builder()` 조립 코드를 DTO 변환 호출 중심으로 정리
+
+### 4.6 이동번호 정책 변경
+- transferNo 생성 prefix: `STF-` -> `WTF-`
+- 최종 정책: `WTF-YYYYMMDD-00001`
+
+## 5. 응답 계약 변경
+- `WarehouseTransferDto.ExecuteRes` 확장:
+  - 유지: `requestedCount`, `successCount`, `lineResults`, `createdTransfers`
+  - 추가: `failureCount`, `failedTransfers`
+- `failedTransfers` 구조:
+  - 라우트 식별: `fromWarehouseCode`, `toWarehouseCode`
+  - 실패 원인: `errorCode`, `errorMessage`
+  - 라인 상세: `failedLines[]`
+
+## 6. 데이터베이스 정합 이슈 및 조치
+- 이슈:
+  - 기존 `warehouse_transfer_header.status` enum이 구값(`REQUESTED/IN_PROGRESS/COMPLETED/CANCELED`) 기반
+  - 신규 상태 저장 시 truncation 오류 발생 가능
+- 조치:
+  - 테이블 재생성 후 enum을 아래로 정합화
+    - `ARRIVED`, `IN_TRANSIT`, `READY_TO_SHIP`
+- 확인 결과:
+  - `SHOW CREATE TABLE warehouse_transfer_header` 기준 신규 enum 반영 확인
+
+## 7. 검증 결과
+### 7.1 완료된 검증
+- 코드 레벨
+  - 오케스트레이션 경로(생성/상태동기화/부분성공/멱등) 반영 확인
+  - DTO 변환 구조(`toEntity/from`) 반영 확인
+  - 이동번호 정책(`WTF`) 반영 확인
+
+### 7.2 미완료 검증
+- 실행 컴파일/테스트
+  - 현재 작업 환경에서 `JAVA_HOME` 경로 이슈로 `gradlew compileJava` 미수행
+
+## 8. 남은 작업(TODO)
+1. 실행 검증
+  - 재고이동 실행 -> 출고 생성/이력 생성
+  - 출고 `confirm/arrive` -> transfer 상태 동기화
+  - 다중 라우트 부분성공 응답 검증
+2. FE 연동 확인
+  - 재고이동 내역 상태 라벨(`READY_TO_SHIP/IN_TRANSIT/ARRIVED`) 정합
+  - 출고 목록 타입 필터(`WH_TRANSFER`) 노출 확인
+3. 입고 담당 후속
+  - `ARRIVED -> RECEIVED` 입고 확정 오케스트레이션 연계
+
+## 9. 결론
+- BE 기준 재고이동-출고 연계 오케스트레이션 1차 구현은 완료되었다.
+- 현재 상태는 “입고 오케스트레이션 제외, 출고 연계 및 상태 동기화 완료” 단계이며,
+  FE 정합 및 실행 검증 완료 후 운영 반영 가능 상태로 판단한다.

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
@@ -497,11 +497,11 @@ public class WarehouseTransferService {
     }
 
     // 이동번호 생성
-    // 정책: STF-YYYYMMDD-00001
+    // 정책: WTF-YYYYMMDD-00001
     private String generateTransferNo(Date requestedAt) {
         LocalDate day = requestedAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         String dayToken = day.format(DAY_FORMAT);
-        String prefix = "STF-" + dayToken + "-";
+        String prefix = "WTF-" + dayToken + "-";
         int nextSeq = headerRepository.findTopByTransferNoStartingWithOrderByTransferNoDesc(prefix)
                 .map(WarehouseTransferHeader::getTransferNo)
                 .map(this::parseSeq)

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
@@ -7,7 +7,6 @@ import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.inventory.InventoryRepository;
-import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryStatusPolicy;
 import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.ProductSkuRepository;
@@ -89,16 +88,11 @@ public class WarehouseTransferService {
         }
 
         // 3) 성공/실패 라우트를 분리해 응답한다.
-        return WarehouseTransferDto.ExecuteRes.builder()
-                .requestedCount(lines.size())
-                .successCount(lineResults.size())
-                .failureCount(failedTransfers.size())
-                .lineResults(lineResults)
-                .createdTransfers(createdTransfers)
-                .failedTransfers(failedTransfers)
-                .build();
+        return WarehouseTransferDto.ExecuteRes.from(lines.size(), lineResults, createdTransfers, failedTransfers);
     }
 
+    // 라우트 단위 처리(신규 트랜잭션)
+    // 부분성공을 위해 각 라우트를 REQUIRES_NEW 경계에서 실행한다.
     private ExecuteGroupResult processRouteInNewTransaction(
             List<WarehouseTransferDto.ExecuteLineReq> groupLines,
             String requestedBy
@@ -109,6 +103,8 @@ public class WarehouseTransferService {
         return template.execute(status -> processRoute(groupLines, requestedBy));
     }
 
+    // 단일 라우트 처리
+    // transfer 생성 -> outbound 생성 -> 상태 동기화 순으로 처리한다.
     private ExecuteGroupResult processRoute(List<WarehouseTransferDto.ExecuteLineReq> groupLines, String requestedBy) {
         // 1) 라우트 검증 + 헤더 생성
         ExecuteGroupContext context = validateGroup(groupLines);
@@ -132,28 +128,18 @@ public class WarehouseTransferService {
             int fromBefore = context.fromAvailableBySkuId.getOrDefault(sku.getId(), 0);
             int toBefore = context.toAvailableBySkuId.getOrDefault(sku.getId(), 0);
 
-            items.add(WarehouseTransferItem.builder()
-                    .header(savedHeader)
-                    .skuId(sku.getId())
-                    .quantity(qty)
-                    .reason(trimToNull(line.getReason()))
-                    .memo(trimToNull(line.getMemo()))
-                    .fromAvailableBefore(fromBefore)
-                    .toAvailableBefore(toBefore)
-                    .fromAvailableAfter(Math.max(0, fromBefore - qty))
-                    .toAvailableAfter(toBefore + qty)
-                    .build());
+            items.add(line.toEntity(
+                    WarehouseTransferDto.ExecuteLineContext.builder()
+                            .header(savedHeader)
+                            .skuId(sku.getId())
+                            .fromAvailableBefore(fromBefore)
+                            .toAvailableBefore(toBefore)
+                            .fromAvailableAfter(Math.max(0, fromBefore - qty))
+                            .toAvailableAfter(toBefore + qty)
+                            .build()
+            ));
 
-            lineResults.add(WarehouseTransferDto.ExecuteLineResultRes.builder()
-                    .lineId(line.getLineId())
-                    .skuCode(line.getSkuCode())
-                    .fromWarehouseCode(line.getFromWarehouseCode())
-                    .toWarehouseCode(line.getToWarehouseCode())
-                    .qty(qty)
-                    .success(true)
-                    .message("SUCCESS")
-                    .transferNo(transferNo)
-                    .build());
+            lineResults.add(WarehouseTransferDto.ExecuteLineResultRes.from(line, transferNo, "SUCCESS"));
         }
         // 3) transfer item 저장 후 outbound를 생성/연계한다.
         List<WarehouseTransferItem> savedItems = itemRepository.saveAll(items);
@@ -161,19 +147,20 @@ public class WarehouseTransferService {
         // 4) 재고이동 상태를 출고 흐름의 시작 상태로 동기화한다.
         savedHeader.markReadyToShip();
 
-        WarehouseTransferDto.ExecuteTransferRes transferRes = WarehouseTransferDto.ExecuteTransferRes.builder()
-                .transferNo(transferNo)
-                .fromWarehouseCode(context.fromWarehouse.getCode())
-                .fromWarehouseName(context.fromWarehouse.getName())
-                .toWarehouseCode(context.toWarehouse.getCode())
-                .toWarehouseName(context.toWarehouse.getName())
-                .status(savedHeader.getStatus().name())
-                .skuCount(items.size())
-                .totalQty(totalQty)
-                .build();
+        WarehouseTransferDto.ExecuteTransferRes transferRes = WarehouseTransferDto.ExecuteTransferRes.from(
+                savedHeader,
+                context.fromWarehouse.getCode(),
+                context.fromWarehouse.getName(),
+                context.toWarehouse.getCode(),
+                context.toWarehouse.getName(),
+                items.size(),
+                totalQty
+        );
         return new ExecuteGroupResult(lineResults, transferRes);
     }
 
+    // 재고이동 내역 목록 조회
+    // 상태/기간/키워드 조건으로 헤더를 조회한 뒤 응답 DTO를 구성한다.
     @Transactional(readOnly = true)
     public List<WarehouseTransferDto.TransferListItemRes> findTransfers(
             WarehouseTransferStatus status,
@@ -191,6 +178,8 @@ public class WarehouseTransferService {
         return buildListItems(headers, keyword);
     }
 
+    // 재고이동 상세 조회
+    // transferNo 기준 헤더/라인 정보를 조합해 상세 응답을 반환한다.
     @Transactional(readOnly = true)
     public WarehouseTransferDto.TransferDetailRes findTransferDetail(String transferNo) {
         WarehouseTransferHeader header = headerRepository.findByTransferNo(transferNo)
@@ -198,6 +187,8 @@ public class WarehouseTransferService {
         return toDetail(header);
     }
 
+    // SKU 창고 분포 조회
+    // SKU 기준으로 창고별 on-hand/available/safety 지표를 계산해 반환한다.
     @Transactional(readOnly = true)
     public List<WarehouseTransferDto.WarehouseSkuDistributionRes> findSkuDistribution(String skuCode) {
         ProductSku sku = productSkuRepository.findBySkuCode(skuCode)
@@ -225,17 +216,17 @@ public class WarehouseTransferService {
                     int reserved = Math.max(0, onHand - available);
                     int safety = Math.max(0, nz(master.getWarehouseSafetyStock()));
                     String status = available <= 0 ? "품절" : (available < safety ? "부족" : "정상");
-                    return WarehouseTransferDto.WarehouseSkuDistributionRes.builder()
-                            .warehouseCode(warehouse.getCode())
-                            .warehouseName(warehouse.getName())
-                            .location(warehouse.getRegion())
-                            .onHandStock(onHand)
-                            .reservedStock(reserved)
-                            .availableStock(available)
-                            .safetyStock(safety)
-                            .status(status)
-                            .updatedAt(stock == null ? null : stock.updatedAt)
-                            .build();
+                    return WarehouseTransferDto.WarehouseSkuDistributionRes.from(
+                            warehouse.getCode(),
+                            warehouse.getName(),
+                            warehouse.getRegion(),
+                            onHand,
+                            reserved,
+                            available,
+                            safety,
+                            status,
+                            stock == null ? null : stock.updatedAt
+                    );
                 })
                 .sorted(Comparator.comparing(WarehouseTransferDto.WarehouseSkuDistributionRes::getWarehouseCode))
                 .toList();
@@ -247,6 +238,8 @@ public class WarehouseTransferService {
         private Date updatedAt;
     }
 
+    // 목록 응답 조합
+    // 헤더 목록에 대해 창고/라인/상품 정보를 결합하고 키워드 필터를 적용한다.
     private List<WarehouseTransferDto.TransferListItemRes> buildListItems(List<WarehouseTransferHeader> headers, String keyword) {
         if (headers.isEmpty()) return List.of();
 
@@ -274,6 +267,8 @@ public class WarehouseTransferService {
                 .toList();
     }
 
+    // 상세 응답 조합
+    // 단일 헤더의 창고/라인/상품 정보를 결합해 상세 DTO를 생성한다.
     private WarehouseTransferDto.TransferDetailRes toDetail(WarehouseTransferHeader header) {
         Map<Long, Infrastructure> infraById = infrastructureRepository.findAllById(
                 List.of(header.getFromWarehouseId(), header.getToWarehouseId())
@@ -287,46 +282,44 @@ public class WarehouseTransferService {
 
         Infrastructure from = infraById.get(header.getFromWarehouseId());
         Infrastructure to = infraById.get(header.getToWarehouseId());
-        return WarehouseTransferDto.TransferDetailRes.builder()
-                .transferNo(header.getTransferNo())
-                .fromWarehouseCode(from == null ? "" : from.getCode())
-                .fromWarehouseName(from == null ? "" : from.getName())
-                .toWarehouseCode(to == null ? "" : to.getCode())
-                .toWarehouseName(to == null ? "" : to.getName())
-                .requestedBy(header.getRequestedBy())
-                .requestedAt(header.getRequestedAt())
-                .status(header.getStatus().name())
-                .lines(lines)
-                .skuCount(lines.size())
-                .totalQty(lines.stream().mapToInt(line -> safeQty(line.getQty())).sum())
-                .reasonCount((int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getReason).filter(s -> s != null && !s.isBlank()).distinct().count())
-                .memoCount((int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getMemo).filter(s -> s != null && !s.isBlank()).count())
-                .build();
+        return WarehouseTransferDto.TransferDetailRes.from(
+                header,
+                from == null ? "" : from.getCode(),
+                from == null ? "" : from.getName(),
+                to == null ? "" : to.getCode(),
+                to == null ? "" : to.getName(),
+                lines,
+                lines.size(),
+                lines.stream().mapToInt(line -> safeQty(line.getQty())).sum(),
+                (int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getReason).filter(s -> s != null && !s.isBlank()).distinct().count(),
+                (int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getMemo).filter(s -> s != null && !s.isBlank()).count()
+        );
     }
 
+    // 목록 행 조합
+    // 헤더와 계산된 라인 통계를 기반으로 리스트 1행 DTO를 구성한다.
     private WarehouseTransferDto.TransferListItemRes toListRow(
             WarehouseTransferHeader header,
             Infrastructure from,
             Infrastructure to,
             List<WarehouseTransferDto.TransferLineRes> lines
     ) {
-        return WarehouseTransferDto.TransferListItemRes.builder()
-                .transferNo(header.getTransferNo())
-                .fromWarehouseCode(from == null ? "" : from.getCode())
-                .fromWarehouseName(from == null ? "" : from.getName())
-                .toWarehouseCode(to == null ? "" : to.getCode())
-                .toWarehouseName(to == null ? "" : to.getName())
-                .requestedBy(header.getRequestedBy())
-                .requestedAt(header.getRequestedAt())
-                .status(header.getStatus().name())
-                .lines(lines)
-                .skuCount(lines.size())
-                .totalQty(lines.stream().mapToInt(line -> safeQty(line.getQty())).sum())
-                .reasonCount((int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getReason).filter(s -> s != null && !s.isBlank()).distinct().count())
-                .memoCount((int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getMemo).filter(s -> s != null && !s.isBlank()).count())
-                .build();
+        return WarehouseTransferDto.TransferListItemRes.from(
+                header,
+                from == null ? "" : from.getCode(),
+                from == null ? "" : from.getName(),
+                to == null ? "" : to.getCode(),
+                to == null ? "" : to.getName(),
+                lines,
+                lines.size(),
+                lines.stream().mapToInt(line -> safeQty(line.getQty())).sum(),
+                (int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getReason).filter(s -> s != null && !s.isBlank()).distinct().count(),
+                (int) lines.stream().map(WarehouseTransferDto.TransferLineRes::getMemo).filter(s -> s != null && !s.isBlank()).count()
+        );
     }
 
+    // 키워드 매칭
+    // 헤더/창고/라인 텍스트를 합쳐 포함 검색을 수행한다.
     private boolean matchesKeyword(WarehouseTransferDto.TransferListItemRes row, String keyword) {
         String joined = String.join(" ",
                 blankTo(row.getTransferNo()),
@@ -339,6 +332,8 @@ public class WarehouseTransferService {
         return joined.contains(keyword);
     }
 
+    // 헤더 기준 창고 맵 로드
+    // 출발/도착 창고 ID를 수집해 인프라 맵으로 조회한다.
     private Map<Long, Infrastructure> loadInfraMap(List<WarehouseTransferHeader> headers) {
         Set<Long> infraIds = new HashSet<>();
         for (WarehouseTransferHeader header : headers) {
@@ -349,6 +344,8 @@ public class WarehouseTransferService {
                 .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
     }
 
+    // 헤더 기준 아이템 그룹 맵 로드
+    // transfer header ID별 아이템 리스트를 그룹핑해 반환한다.
     private Map<Long, List<WarehouseTransferItem>> loadItemsMap(List<WarehouseTransferHeader> headers) {
         Set<Long> headerIds = headers.stream().map(WarehouseTransferHeader::getId).collect(Collectors.toSet());
         if (headerIds.isEmpty()) return Map.of();
@@ -356,6 +353,8 @@ public class WarehouseTransferService {
                 .collect(Collectors.groupingBy(item -> item.getHeader().getId()));
     }
 
+    // 상품 마스터 맵 로드
+    // SKU 컬렉션에서 productCode를 추출해 ProductMaster 맵을 구성한다.
     private Map<String, ProductMaster> loadMasterMap(Collection<ProductSku> skus) {
         Set<String> productCodes = skus.stream().map(ProductSku::getProductCode).collect(Collectors.toSet());
         if (productCodes.isEmpty()) return Map.of();
@@ -363,6 +362,8 @@ public class WarehouseTransferService {
                 .collect(Collectors.toMap(ProductMaster::getCode, Function.identity()));
     }
 
+    // 라인 DTO 변환
+    // transfer item과 SKU/마스터 스냅샷을 결합해 응답 라인으로 변환한다.
     private List<WarehouseTransferDto.TransferLineRes> toLines(
             List<WarehouseTransferItem> items,
             Map<Long, ProductSku> skuById,
@@ -371,23 +372,19 @@ public class WarehouseTransferService {
         return items.stream().map(item -> {
             ProductSku sku = skuById.get(item.getSkuId());
             ProductMaster master = sku == null ? null : masterByCode.get(sku.getProductCode());
-            return WarehouseTransferDto.TransferLineRes.builder()
-                    .skuCode(sku == null ? "" : sku.getSkuCode())
-                    .itemCode(master == null ? "" : master.getCode())
-                    .itemName(master == null ? "" : master.getName())
-                    .color(sku == null ? "" : sku.getColor())
-                    .size(sku == null ? "" : sku.getSize())
-                    .qty(item.getQuantity())
-                    .reason(item.getReason())
-                    .memo(item.getMemo())
-                    .fromStockBefore(item.getFromAvailableBefore())
-                    .toStockBefore(item.getToAvailableBefore())
-                    .fromStockAfter(item.getFromAvailableAfter())
-                    .toStockAfter(item.getToAvailableAfter())
-                    .build();
+            return WarehouseTransferDto.TransferLineRes.from(
+                    item,
+                    sku == null ? "" : sku.getSkuCode(),
+                    master == null ? "" : master.getCode(),
+                    master == null ? "" : master.getName(),
+                    sku == null ? "" : sku.getColor(),
+                    sku == null ? "" : sku.getSize()
+            );
         }).toList();
     }
 
+    // 라우트 검증
+    // 동일 라우트 강제, 수량 검증, SKU/가용수량 검증, 후속 매핑 컨텍스트를 구성한다.
     private ExecuteGroupContext validateGroup(List<WarehouseTransferDto.ExecuteLineReq> groupLines) {
         WarehouseTransferDto.ExecuteLineReq first = groupLines.get(0);
         Infrastructure fromWarehouse = loadWarehouse(first.getFromWarehouseCode());
@@ -434,6 +431,8 @@ public class WarehouseTransferService {
         );
     }
 
+    // 라우트 가용재고 합산
+    // 이동 가능 상태 재고만 대상으로 available 수량을 합산한다.
     private int sumAvailableForTransfer(Long skuId, Long locationId) {
         return inventoryRepository.findAllBySkuIdAndLocationId(skuId, locationId).stream()
                 .filter(inv -> InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inv.getInventoryStatus()))
@@ -441,11 +440,15 @@ public class WarehouseTransferService {
                 .sum();
     }
 
+    // 창고 조회
+    // 코드 + WAREHOUSE 타입으로 인프라를 조회한다.
     private Infrastructure loadWarehouse(String code) {
         return infrastructureRepository.findByCodeAndLocationType(code, LocationType.WAREHOUSE)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.WAREHOUSE_NOT_FOUND));
     }
 
+    // 이동번호 생성 재시도
+    // transferNo 중복 충돌을 피하기 위해 최대 5회 생성/검증을 수행한다.
     private String createTransferNoWithRetry(Date requestedAt) {
         for (int i = 0; i < 5; i++) {
             String transferNo = generateTransferNo(requestedAt);
@@ -456,6 +459,8 @@ public class WarehouseTransferService {
         throw BaseException.from(BaseResponseStatus.FAIL);
     }
 
+    // 재고이동 헤더 저장 재시도
+    // 번호 유니크 충돌 시 재시도하며 헤더를 저장한다.
     private WarehouseTransferHeader saveHeaderWithTransferNoRetry(
             ExecuteGroupContext context,
             String requestedBy,
@@ -466,17 +471,23 @@ public class WarehouseTransferService {
             Date now = new Date();
             String transferNo = createTransferNoWithRetry(now);
             try {
+                WarehouseTransferDto.ExecuteReq requestBridge = WarehouseTransferDto.ExecuteReq.builder()
+                        .requestedBy(requestedBy)
+                        .lines(List.of())
+                        .build();
                 return headerRepository.save(
-                        WarehouseTransferHeader.builder()
-                                .transferNo(transferNo)
-                                .fromWarehouseId(context.fromWarehouse.getId())
-                                .toWarehouseId(context.toWarehouse.getId())
-                                .status(WarehouseTransferStatus.READY_TO_SHIP)
-                                .requestedBy(requestedBy)
-                                .requestedAt(now)
-                                .reasonSummary(reasonSummary)
-                                .memoSummary(memoSummary)
-                                .build()
+                        requestBridge.toEntity(
+                                WarehouseTransferDto.ExecuteHeaderContext.builder()
+                                        .transferNo(transferNo)
+                                        .fromWarehouseId(context.fromWarehouse.getId())
+                                        .toWarehouseId(context.toWarehouse.getId())
+                                        .status(WarehouseTransferStatus.READY_TO_SHIP)
+                                        .requestedBy(requestedBy)
+                                        .requestedAt(now)
+                                        .reasonSummary(reasonSummary)
+                                        .memoSummary(memoSummary)
+                                        .build()
+                        )
                 );
             } catch (DataIntegrityViolationException ignore) {
                 // unique 충돌 시 재시도
@@ -485,6 +496,8 @@ public class WarehouseTransferService {
         throw BaseException.from(BaseResponseStatus.FAIL);
     }
 
+    // 이동번호 생성
+    // 정책: STF-YYYYMMDD-00001
     private String generateTransferNo(Date requestedAt) {
         LocalDate day = requestedAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         String dayToken = day.format(DAY_FORMAT);
@@ -496,6 +509,8 @@ public class WarehouseTransferService {
         return prefix + String.format("%05d", nextSeq);
     }
 
+    // 이동번호 시퀀스 파싱
+    // 번호 접미부를 정수로 파싱하며 실패 시 0을 반환한다.
     private int parseSeq(String transferNo) {
         try {
             return Integer.parseInt(transferNo.substring(transferNo.lastIndexOf('-') + 1));
@@ -504,14 +519,20 @@ public class WarehouseTransferService {
         }
     }
 
+    // 날짜 시작시각 변환
+    // LocalDate를 시스템 타임존 기준 00:00:00 Date로 변환한다.
     private Date atStart(LocalDate date) {
         return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
+    // 라우트 키 생성
+    // from/to 창고코드 조합으로 그룹핑 키를 만든다.
     private String routeKey(WarehouseTransferDto.ExecuteLineReq line) {
         return line.getFromWarehouseCode() + "=>" + line.getToWarehouseCode();
     }
 
+    // 사유 요약 생성
+    // 라인별 reason을 중복 제거해 헤더 요약 문자열로 만든다.
     private String buildReasonSummary(List<WarehouseTransferDto.ExecuteLineReq> lines) {
         Set<String> reasons = lines.stream().map(WarehouseTransferDto.ExecuteLineReq::getReason)
                 .map(this::trimToNull).filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
@@ -519,6 +540,8 @@ public class WarehouseTransferService {
         return String.join(", ", reasons);
     }
 
+    // 메모 요약 생성
+    // 라인 메모 개수를 "N건 메모" 형식으로 요약한다.
     private String buildMemoSummary(List<WarehouseTransferDto.ExecuteLineReq> lines) {
         List<String> memos = lines.stream().map(WarehouseTransferDto.ExecuteLineReq::getMemo)
                 .map(this::trimToNull).filter(Objects::nonNull).toList();
@@ -526,29 +549,41 @@ public class WarehouseTransferService {
         return memos.size() + "건 메모";
     }
 
+    // 기본값 보정
+    // 문자열이 비어 있으면 기본값을 반환한다.
     private String trimToDefault(String s, String def) {
         String t = trimToNull(s);
         return t == null ? def : t;
     }
 
+    // 문자열 정규화
+    // trim 후 빈 문자열을 null로 변환한다.
     private String trimToNull(String s) {
         if (s == null) return null;
         String t = s.trim();
         return t.isEmpty() ? null : t;
     }
 
+    // 수량 null-safe 변환
+    // null이면 0으로 보정한다.
     private int safeQty(Integer qty) {
         return qty == null ? 0 : qty;
     }
 
+    // 숫자 null-safe 변환
+    // null이면 0으로 보정한다.
     private int nz(Integer value) {
         return value == null ? 0 : value;
     }
 
+    // 문자열 null-safe 변환
+    // null이면 빈 문자열로 보정한다.
     private String blankTo(String s) {
         return s == null ? "" : s;
     }
 
+    // 재고이동 -> 출고 생성 오케스트레이션
+    // outbound header/item/history를 멱등하게 생성한다.
     private void createWhTransferOutbound(
             WarehouseTransferHeader transferHeader,
             List<WarehouseTransferItem> transferItems,
@@ -606,6 +641,8 @@ public class WarehouseTransferService {
         }
     }
 
+    // WH_TRANSFER 출고 헤더 멱등 upsert
+    // 사전조회 후 신규 생성, 유니크 충돌 시 재조회로 복구한다.
     private WhOutboundHeader upsertWhTransferOutboundHeader(
             WarehouseTransferHeader transferHeader,
             ExecuteGroupContext context,
@@ -650,18 +687,24 @@ public class WarehouseTransferService {
         }
     }
 
+    // transfer 아이템 총수량 계산
+    // 헤더 기준 라인 requestedQuantity 합계를 반환한다.
     private int transferItemsQuantity(Long transferHeaderId) {
         return itemRepository.findAllByHeader_IdOrderByIdAsc(transferHeaderId).stream()
                 .mapToInt(item -> Math.max(0, safeQty(item.getQuantity())))
                 .sum();
     }
 
+    // 출고번호 생성
+    // 정책: WOB-YYYYMMDD-00001
     private String generateOutboundNo(Long id, Date requestedAt) {
         // 출고번호 정책: WOB-YYYYMMDD-00001
         LocalDate day = requestedAt.toInstant().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
         return "WOB-" + day.format(DAY_FORMAT) + "-" + String.format("%05d", id);
     }
 
+    // 실패 라우트 DTO 변환
+    // 라우트 공통 오류와 라인별 실패 정보를 함께 매핑한다.
     private WarehouseTransferDto.ExecuteFailedRouteRes toFailedRoute(
             List<WarehouseTransferDto.ExecuteLineReq> groupLines,
             BaseResponseStatus status
@@ -669,20 +712,15 @@ public class WarehouseTransferService {
         // 라우트 실패를 라인 단위 상세와 함께 응답 DTO로 변환한다.
         WarehouseTransferDto.ExecuteLineReq first = groupLines.get(0);
         List<WarehouseTransferDto.ExecuteLineFailureRes> failedLines = groupLines.stream()
-                .map(line -> WarehouseTransferDto.ExecuteLineFailureRes.builder()
-                        .lineId(line.getLineId())
-                        .skuCode(line.getSkuCode())
-                        .qty(safeQty(line.getQty()))
-                        .reason(status.getMessage())
-                        .build())
+                .map(line -> WarehouseTransferDto.ExecuteLineFailureRes.from(line, status.getMessage()))
                 .toList();
-        return WarehouseTransferDto.ExecuteFailedRouteRes.builder()
-                .fromWarehouseCode(first.getFromWarehouseCode())
-                .toWarehouseCode(first.getToWarehouseCode())
-                .errorCode(status.getCode())
-                .errorMessage(status.getMessage())
-                .failedLines(failedLines)
-                .build();
+        return WarehouseTransferDto.ExecuteFailedRouteRes.from(
+                first.getFromWarehouseCode(),
+                first.getToWarehouseCode(),
+                status.getCode(),
+                status.getMessage(),
+                failedLines
+        );
     }
 
     private record ExecuteGroupResult(

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/WarehouseTransferService.java
@@ -17,9 +17,21 @@ import org.example.stockitbe.hq.warehousetransfer.model.WarehouseTransferDto;
 import org.example.stockitbe.hq.warehousetransfer.model.WarehouseTransferHeader;
 import org.example.stockitbe.hq.warehousetransfer.model.WarehouseTransferItem;
 import org.example.stockitbe.hq.warehousetransfer.model.WarehouseTransferStatus;
+import org.example.stockitbe.warehouse.outbound.model.OutboundDestinationType;
+import org.example.stockitbe.warehouse.outbound.model.OutboundSourceType;
+import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundItem;
+import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundStatusHistory;
+import org.example.stockitbe.warehouse.outbound.repository.WhOutboundHeaderRepository;
+import org.example.stockitbe.warehouse.outbound.repository.WhOutboundItemRepository;
+import org.example.stockitbe.warehouse.outbound.repository.WhOutboundStatusHistoryRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -40,9 +52,16 @@ public class WarehouseTransferService {
     private final ProductSkuRepository productSkuRepository;
     private final ProductMasterRepository productMasterRepository;
     private final InventoryRepository inventoryRepository;
+    private final WhOutboundHeaderRepository outboundHeaderRepository;
+    private final WhOutboundItemRepository outboundItemRepository;
+    private final WhOutboundStatusHistoryRepository outboundStatusHistoryRepository;
+    private final PlatformTransactionManager transactionManager;
 
+    // 재고이동 실행
+    // 라우트(출발/도착 창고) 단위로 독립 처리하며, 실패 라우트는 수집해 부분성공으로 반환한다.
     @Transactional
     public WarehouseTransferDto.ExecuteRes execute(WarehouseTransferDto.ExecuteReq request) {
+        // 1) 요청 라인 유효성을 검증한다.
         List<WarehouseTransferDto.ExecuteLineReq> lines = request.getLines() == null ? List.of() : request.getLines();
         if (lines.isEmpty()) throw BaseException.from(BaseResponseStatus.REQUEST_ERROR);
 
@@ -52,71 +71,107 @@ public class WarehouseTransferService {
 
         List<WarehouseTransferDto.ExecuteLineResultRes> lineResults = new ArrayList<>();
         List<WarehouseTransferDto.ExecuteTransferRes> createdTransfers = new ArrayList<>();
+        List<WarehouseTransferDto.ExecuteFailedRouteRes> failedTransfers = new ArrayList<>();
 
+        // 2) 라우트별 독립 트랜잭션으로 처리한다.
         for (List<WarehouseTransferDto.ExecuteLineReq> groupLines : grouped.values()) {
-            ExecuteGroupContext context = validateGroup(groupLines);
-            WarehouseTransferHeader savedHeader = saveHeaderWithTransferNoRetry(
-                    context,
-                    requestedBy,
-                    buildReasonSummary(groupLines),
-                    buildMemoSummary(groupLines)
-            );
-            String transferNo = savedHeader.getTransferNo();
-
-            List<WarehouseTransferItem> items = new ArrayList<>();
-            int totalQty = 0;
-            for (WarehouseTransferDto.ExecuteLineReq line : groupLines) {
-                int qty = safeQty(line.getQty());
-                totalQty += qty;
-
-                ProductSku sku = context.skuByCode.get(line.getSkuCode());
-                int fromBefore = context.fromAvailableBySkuId.getOrDefault(sku.getId(), 0);
-                int toBefore = context.toAvailableBySkuId.getOrDefault(sku.getId(), 0);
-
-                items.add(WarehouseTransferItem.builder()
-                        .header(savedHeader)
-                        .skuId(sku.getId())
-                        .quantity(qty)
-                        .reason(trimToNull(line.getReason()))
-                        .memo(trimToNull(line.getMemo()))
-                        .fromAvailableBefore(fromBefore)
-                        .toAvailableBefore(toBefore)
-                        .fromAvailableAfter(Math.max(0, fromBefore - qty))
-                        .toAvailableAfter(toBefore + qty)
-                        .build());
-
-                lineResults.add(WarehouseTransferDto.ExecuteLineResultRes.builder()
-                        .lineId(line.getLineId())
-                        .skuCode(line.getSkuCode())
-                        .fromWarehouseCode(line.getFromWarehouseCode())
-                        .toWarehouseCode(line.getToWarehouseCode())
-                        .qty(qty)
-                        .success(true)
-                        .message("SUCCESS")
-                        .transferNo(transferNo)
-                        .build());
+            try {
+                ExecuteGroupResult routeResult = processRouteInNewTransaction(groupLines, requestedBy);
+                lineResults.addAll(routeResult.lineResults());
+                createdTransfers.add(routeResult.transferRes());
+            } catch (BaseException e) {
+                // 도메인 예외는 상태코드/메시지를 그대로 노출한다.
+                failedTransfers.add(toFailedRoute(groupLines, e.getStatus()));
+            } catch (Exception e) {
+                // 비도메인 예외는 공통 실패 코드로 정규화한다.
+                failedTransfers.add(toFailedRoute(groupLines, BaseResponseStatus.FAIL));
             }
-            itemRepository.saveAll(items);
-
-            createdTransfers.add(WarehouseTransferDto.ExecuteTransferRes.builder()
-                    .transferNo(transferNo)
-                    .fromWarehouseCode(context.fromWarehouse.getCode())
-                    .fromWarehouseName(context.fromWarehouse.getName())
-                    .toWarehouseCode(context.toWarehouse.getCode())
-                    .toWarehouseName(context.toWarehouse.getName())
-                    .status(WarehouseTransferStatus.IN_PROGRESS.name())
-                    .skuCount(items.size())
-                    .totalQty(totalQty)
-                    .build());
         }
 
+        // 3) 성공/실패 라우트를 분리해 응답한다.
         return WarehouseTransferDto.ExecuteRes.builder()
                 .requestedCount(lines.size())
                 .successCount(lineResults.size())
-                .failureCount(0)
+                .failureCount(failedTransfers.size())
                 .lineResults(lineResults)
                 .createdTransfers(createdTransfers)
+                .failedTransfers(failedTransfers)
                 .build();
+    }
+
+    private ExecuteGroupResult processRouteInNewTransaction(
+            List<WarehouseTransferDto.ExecuteLineReq> groupLines,
+            String requestedBy
+    ) {
+        // 라우트 단위 부분성공을 위해 신규 트랜잭션으로 경계를 분리한다.
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template.execute(status -> processRoute(groupLines, requestedBy));
+    }
+
+    private ExecuteGroupResult processRoute(List<WarehouseTransferDto.ExecuteLineReq> groupLines, String requestedBy) {
+        // 1) 라우트 검증 + 헤더 생성
+        ExecuteGroupContext context = validateGroup(groupLines);
+        WarehouseTransferHeader savedHeader = saveHeaderWithTransferNoRetry(
+                context,
+                requestedBy,
+                buildReasonSummary(groupLines),
+                buildMemoSummary(groupLines)
+        );
+        String transferNo = savedHeader.getTransferNo();
+
+        // 2) 라우트 라인별 transfer item 및 결과 응답 라인을 구성한다.
+        List<WarehouseTransferItem> items = new ArrayList<>();
+        List<WarehouseTransferDto.ExecuteLineResultRes> lineResults = new ArrayList<>();
+        int totalQty = 0;
+        for (WarehouseTransferDto.ExecuteLineReq line : groupLines) {
+            int qty = safeQty(line.getQty());
+            totalQty += qty;
+
+            ProductSku sku = context.skuByCode.get(line.getSkuCode());
+            int fromBefore = context.fromAvailableBySkuId.getOrDefault(sku.getId(), 0);
+            int toBefore = context.toAvailableBySkuId.getOrDefault(sku.getId(), 0);
+
+            items.add(WarehouseTransferItem.builder()
+                    .header(savedHeader)
+                    .skuId(sku.getId())
+                    .quantity(qty)
+                    .reason(trimToNull(line.getReason()))
+                    .memo(trimToNull(line.getMemo()))
+                    .fromAvailableBefore(fromBefore)
+                    .toAvailableBefore(toBefore)
+                    .fromAvailableAfter(Math.max(0, fromBefore - qty))
+                    .toAvailableAfter(toBefore + qty)
+                    .build());
+
+            lineResults.add(WarehouseTransferDto.ExecuteLineResultRes.builder()
+                    .lineId(line.getLineId())
+                    .skuCode(line.getSkuCode())
+                    .fromWarehouseCode(line.getFromWarehouseCode())
+                    .toWarehouseCode(line.getToWarehouseCode())
+                    .qty(qty)
+                    .success(true)
+                    .message("SUCCESS")
+                    .transferNo(transferNo)
+                    .build());
+        }
+        // 3) transfer item 저장 후 outbound를 생성/연계한다.
+        List<WarehouseTransferItem> savedItems = itemRepository.saveAll(items);
+        createWhTransferOutbound(savedHeader, savedItems, context, requestedBy);
+        // 4) 재고이동 상태를 출고 흐름의 시작 상태로 동기화한다.
+        savedHeader.markReadyToShip();
+
+        WarehouseTransferDto.ExecuteTransferRes transferRes = WarehouseTransferDto.ExecuteTransferRes.builder()
+                .transferNo(transferNo)
+                .fromWarehouseCode(context.fromWarehouse.getCode())
+                .fromWarehouseName(context.fromWarehouse.getName())
+                .toWarehouseCode(context.toWarehouse.getCode())
+                .toWarehouseName(context.toWarehouse.getName())
+                .status(savedHeader.getStatus().name())
+                .skuCount(items.size())
+                .totalQty(totalQty)
+                .build();
+        return new ExecuteGroupResult(lineResults, transferRes);
     }
 
     @Transactional(readOnly = true)
@@ -342,6 +397,7 @@ public class WarehouseTransferService {
         }
 
         Map<String, ProductSku> skuByCode = new HashMap<>();
+        Map<Long, ProductSku> skuById = new HashMap<>();
         Map<Long, Integer> fromAvailableBySkuId = new HashMap<>();
         Map<Long, Integer> toAvailableBySkuId = new HashMap<>();
 
@@ -356,6 +412,7 @@ public class WarehouseTransferService {
             ProductSku sku = productSkuRepository.findBySkuCode(line.getSkuCode())
                     .orElseThrow(() -> BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND));
             skuByCode.put(line.getSkuCode(), sku);
+            skuById.put(sku.getId(), sku);
 
             int fromAvailable = sumAvailableForTransfer(sku.getId(), fromWarehouse.getId());
             int toAvailable = sumAvailableForTransfer(sku.getId(), toWarehouse.getId());
@@ -365,7 +422,16 @@ public class WarehouseTransferService {
             fromAvailableBySkuId.put(sku.getId(), Math.max(0, fromAvailable));
             toAvailableBySkuId.put(sku.getId(), Math.max(0, toAvailable));
         }
-        return new ExecuteGroupContext(fromWarehouse, toWarehouse, skuByCode, fromAvailableBySkuId, toAvailableBySkuId);
+        Map<String, ProductMaster> masterByCode = loadMasterMap(skuByCode.values());
+        return new ExecuteGroupContext(
+                fromWarehouse,
+                toWarehouse,
+                skuByCode,
+                skuById,
+                masterByCode,
+                fromAvailableBySkuId,
+                toAvailableBySkuId
+        );
     }
 
     private int sumAvailableForTransfer(Long skuId, Long locationId) {
@@ -405,7 +471,7 @@ public class WarehouseTransferService {
                                 .transferNo(transferNo)
                                 .fromWarehouseId(context.fromWarehouse.getId())
                                 .toWarehouseId(context.toWarehouse.getId())
-                                .status(WarehouseTransferStatus.IN_PROGRESS)
+                                .status(WarehouseTransferStatus.READY_TO_SHIP)
                                 .requestedBy(requestedBy)
                                 .requestedAt(now)
                                 .reasonSummary(reasonSummary)
@@ -483,10 +549,154 @@ public class WarehouseTransferService {
         return s == null ? "" : s;
     }
 
+    private void createWhTransferOutbound(
+            WarehouseTransferHeader transferHeader,
+            List<WarehouseTransferItem> transferItems,
+            ExecuteGroupContext context,
+            String requestedBy
+    ) {
+        // 1) 헤더를 멱등 upsert한다.
+        Date now = transferHeader.getRequestedAt() == null ? new Date() : transferHeader.getRequestedAt();
+        WhOutboundHeader outbound = upsertWhTransferOutboundHeader(transferHeader, context, requestedBy, now);
+
+        // 2) 기존 라인이 없을 때만 outbound item을 스냅샷으로 생성한다.
+        if (outboundItemRepository.findAllByOutboundHeaderIdOrderByIdAsc(outbound.getId()).isEmpty()) {
+            List<WhOutboundItem> outboundItems = new ArrayList<>();
+            for (WarehouseTransferItem transferItem : transferItems) {
+                ProductSku sku = context.skuById.get(transferItem.getSkuId());
+                if (sku == null) throw BaseException.from(BaseResponseStatus.PRODUCT_SKU_NOT_FOUND);
+                ProductMaster master = context.masterByCode.get(sku.getProductCode());
+                if (master == null) throw BaseException.from(BaseResponseStatus.PRODUCT_MASTER_NOT_FOUND);
+
+                outboundItems.add(WhOutboundItem.builder()
+                        .outboundHeaderId(outbound.getId())
+                        .sourceLineRefId(transferItem.getId())
+                        .skuId(transferItem.getSkuId())
+                        .skuCode(sku.getSkuCode())
+                        .productCode(master.getCode())
+                        .productName(master.getName())
+                        .mainCategory(master.getCategoryCode())
+                        .subCategory(master.getCategoryCode())
+                        .color(sku.getColor())
+                        .size(sku.getSize())
+                        .unitPrice(sku.getUnitPrice())
+                        .requestedQuantity(transferItem.getQuantity())
+                        .memo(transferItem.getMemo())
+                        .build());
+            }
+            outboundItemRepository.saveAll(outboundItems);
+        }
+
+        // 3) READY_TO_SHIP 최초 이력이 없으면 1건 생성한다.
+        boolean historyExists = outboundStatusHistoryRepository
+                .findAllByOutboundHeaderIdOrderByChangedAtAscIdAsc(outbound.getId())
+                .stream()
+                .anyMatch(h -> h.getStatus() == OutboundStatus.READY_TO_SHIP);
+        if (!historyExists) {
+            outboundStatusHistoryRepository.save(
+                    WhOutboundStatusHistory.builder()
+                            .outboundHeaderId(outbound.getId())
+                            .status(OutboundStatus.READY_TO_SHIP)
+                            .changedAt(now)
+                            .changedByMemberId(requestedBy)
+                            .changedByName(requestedBy)
+                            .reason("WAREHOUSE_TRANSFER_EXECUTE")
+                            .build()
+            );
+        }
+    }
+
+    private WhOutboundHeader upsertWhTransferOutboundHeader(
+            WarehouseTransferHeader transferHeader,
+            ExecuteGroupContext context,
+            String requestedBy,
+            Date now
+    ) {
+        // 1차 방어: 사전 조회
+        Optional<WhOutboundHeader> existing = outboundHeaderRepository.findBySourceTypeAndSourceRefNoAndSourceRefSeq(
+                OutboundSourceType.WAREHOUSE_TRANSFER,
+                transferHeader.getTransferNo(),
+                1
+        );
+        if (existing.isPresent()) return existing.get();
+
+        try {
+            // 2차 방어: 유니크 충돌 전까지 신규 생성 시도
+            WhOutboundHeader saved = outboundHeaderRepository.save(
+                    WhOutboundHeader.builder()
+                            .outboundNo("TEMP-" + UUID.randomUUID())
+                            .sourceType(OutboundSourceType.WAREHOUSE_TRANSFER)
+                            .sourceRefNo(transferHeader.getTransferNo())
+                            .sourceRefSeq(1)
+                            .sourceRefId(transferHeader.getId())
+                            .warehouseId(transferHeader.getFromWarehouseId())
+                            .destinationType(OutboundDestinationType.WAREHOUSE)
+                            .destinationId(transferHeader.getToWarehouseId())
+                            .status(OutboundStatus.READY_TO_SHIP)
+                            .totalRequestedQuantity(transferItemsQuantity(transferHeader.getId()))
+                            .requestedAt(now)
+                            .requestedByMemberId(requestedBy)
+                            .requestedByName(requestedBy)
+                            .memo(transferHeader.getMemoSummary())
+                            .build()
+            );
+            saved.assignOutboundNo(generateOutboundNo(saved.getId(), now));
+            return saved;
+        } catch (DataIntegrityViolationException e) {
+            // 동시성 충돌 시 재조회로 멱등 완료 처리
+            return outboundHeaderRepository.findBySourceTypeAndSourceRefNoAndSourceRefSeq(
+                            OutboundSourceType.WAREHOUSE_TRANSFER, transferHeader.getTransferNo(), 1)
+                    .orElseThrow(() -> BaseException.from(BaseResponseStatus.FAIL));
+        }
+    }
+
+    private int transferItemsQuantity(Long transferHeaderId) {
+        return itemRepository.findAllByHeader_IdOrderByIdAsc(transferHeaderId).stream()
+                .mapToInt(item -> Math.max(0, safeQty(item.getQuantity())))
+                .sum();
+    }
+
+    private String generateOutboundNo(Long id, Date requestedAt) {
+        // 출고번호 정책: WOB-YYYYMMDD-00001
+        LocalDate day = requestedAt.toInstant().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+        return "WOB-" + day.format(DAY_FORMAT) + "-" + String.format("%05d", id);
+    }
+
+    private WarehouseTransferDto.ExecuteFailedRouteRes toFailedRoute(
+            List<WarehouseTransferDto.ExecuteLineReq> groupLines,
+            BaseResponseStatus status
+    ) {
+        // 라우트 실패를 라인 단위 상세와 함께 응답 DTO로 변환한다.
+        WarehouseTransferDto.ExecuteLineReq first = groupLines.get(0);
+        List<WarehouseTransferDto.ExecuteLineFailureRes> failedLines = groupLines.stream()
+                .map(line -> WarehouseTransferDto.ExecuteLineFailureRes.builder()
+                        .lineId(line.getLineId())
+                        .skuCode(line.getSkuCode())
+                        .qty(safeQty(line.getQty()))
+                        .reason(status.getMessage())
+                        .build())
+                .toList();
+        return WarehouseTransferDto.ExecuteFailedRouteRes.builder()
+                .fromWarehouseCode(first.getFromWarehouseCode())
+                .toWarehouseCode(first.getToWarehouseCode())
+                .errorCode(status.getCode())
+                .errorMessage(status.getMessage())
+                .failedLines(failedLines)
+                .build();
+    }
+
+    private record ExecuteGroupResult(
+            List<WarehouseTransferDto.ExecuteLineResultRes> lineResults,
+            WarehouseTransferDto.ExecuteTransferRes transferRes
+    ) {
+    }
+
     private record ExecuteGroupContext(
             Infrastructure fromWarehouse,
             Infrastructure toWarehouse,
             Map<String, ProductSku> skuByCode,
+            Map<Long, ProductSku> skuById,
+            Map<String, ProductMaster> masterByCode,
             Map<Long, Integer> fromAvailableBySkuId,
             Map<Long, Integer> toAvailableBySkuId
     ) {

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
@@ -83,6 +83,32 @@ public class WarehouseTransferDto {
         private Integer failureCount;
         private List<ExecuteLineResultRes> lineResults;
         private List<ExecuteTransferRes> createdTransfers;
+        // 부분성공 지원: 실패 라우트 목록
+        private List<ExecuteFailedRouteRes> failedTransfers;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ExecuteFailedRouteRes {
+        // 실패한 라우트(출발/도착 창고) 식별값
+        private String fromWarehouseCode;
+        private String toWarehouseCode;
+        // 실패 사유 표준 코드/메시지
+        private Integer errorCode;
+        private String errorMessage;
+        // 라우트 내 실패 라인 상세
+        private List<ExecuteLineFailureRes> failedLines;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ExecuteLineFailureRes {
+        private String lineId;
+        private String skuCode;
+        private Integer qty;
+        private String reason;
     }
 
     @Getter

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public class WarehouseTransferDto {
 
+    // 재고이동 실행 요청 DTO (헤더 성격)
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -36,6 +37,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 요청 라인 DTO (SKU 단위)
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -73,6 +75,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 성공 라인 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -100,6 +103,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 성공 라우트(이동지시서) 요약 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -135,6 +139,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 종합 응답 DTO (성공/실패 집계)
     @Getter
     @Builder
     @AllArgsConstructor
@@ -164,6 +169,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 실패 라우트 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -194,6 +200,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 실행 실패 라인 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -213,6 +220,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 목록 1행 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -261,6 +269,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 상세 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -309,6 +318,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // 재고이동 상세/목록 공통 라인 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -351,6 +361,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // SKU 기준 창고별 재고 분포 응답 DTO
     @Getter
     @Builder
     @AllArgsConstructor
@@ -390,6 +401,7 @@ public class WarehouseTransferDto {
         }
     }
 
+    // ExecuteReq -> WarehouseTransferHeader 변환용 컨텍스트 DTO
     @Getter
     @AllArgsConstructor
     @Builder
@@ -404,6 +416,7 @@ public class WarehouseTransferDto {
         private String memoSummary;
     }
 
+    // ExecuteLineReq -> WarehouseTransferItem 변환용 컨텍스트 DTO
     @Getter
     @AllArgsConstructor
     @Builder

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferDto.java
@@ -21,6 +21,19 @@ public class WarehouseTransferDto {
         @Valid
         @NotEmpty
         private List<ExecuteLineReq> lines;
+
+        public WarehouseTransferHeader toEntity(ExecuteHeaderContext context) {
+            return WarehouseTransferHeader.builder()
+                    .transferNo(context.getTransferNo())
+                    .fromWarehouseId(context.getFromWarehouseId())
+                    .toWarehouseId(context.getToWarehouseId())
+                    .status(context.getStatus())
+                    .requestedBy(context.getRequestedBy())
+                    .requestedAt(context.getRequestedAt())
+                    .reasonSummary(context.getReasonSummary())
+                    .memoSummary(context.getMemoSummary())
+                    .build();
+        }
     }
 
     @Getter
@@ -44,6 +57,20 @@ public class WarehouseTransferDto {
 
         private String reason;
         private String memo;
+
+        public WarehouseTransferItem toEntity(ExecuteLineContext context) {
+            return WarehouseTransferItem.builder()
+                    .header(context.getHeader())
+                    .skuId(context.getSkuId())
+                    .quantity(this.qty)
+                    .reason(this.reason)
+                    .memo(this.memo)
+                    .fromAvailableBefore(context.getFromAvailableBefore())
+                    .toAvailableBefore(context.getToAvailableBefore())
+                    .fromAvailableAfter(context.getFromAvailableAfter())
+                    .toAvailableAfter(context.getToAvailableAfter())
+                    .build();
+        }
     }
 
     @Getter
@@ -58,6 +85,19 @@ public class WarehouseTransferDto {
         private Boolean success;
         private String message;
         private String transferNo;
+
+        public static ExecuteLineResultRes from(ExecuteLineReq req, String transferNo, String message) {
+            return ExecuteLineResultRes.builder()
+                    .lineId(req.getLineId())
+                    .skuCode(req.getSkuCode())
+                    .fromWarehouseCode(req.getFromWarehouseCode())
+                    .toWarehouseCode(req.getToWarehouseCode())
+                    .qty(req.getQty())
+                    .success(true)
+                    .message(message)
+                    .transferNo(transferNo)
+                    .build();
+        }
     }
 
     @Getter
@@ -72,6 +112,27 @@ public class WarehouseTransferDto {
         private String status;
         private Integer skuCount;
         private Integer totalQty;
+
+        public static ExecuteTransferRes from(
+                WarehouseTransferHeader header,
+                String fromWarehouseCode,
+                String fromWarehouseName,
+                String toWarehouseCode,
+                String toWarehouseName,
+                Integer skuCount,
+                Integer totalQty
+        ) {
+            return ExecuteTransferRes.builder()
+                    .transferNo(header.getTransferNo())
+                    .fromWarehouseCode(fromWarehouseCode)
+                    .fromWarehouseName(fromWarehouseName)
+                    .toWarehouseCode(toWarehouseCode)
+                    .toWarehouseName(toWarehouseName)
+                    .status(header.getStatus().name())
+                    .skuCount(skuCount)
+                    .totalQty(totalQty)
+                    .build();
+        }
     }
 
     @Getter
@@ -85,6 +146,22 @@ public class WarehouseTransferDto {
         private List<ExecuteTransferRes> createdTransfers;
         // 부분성공 지원: 실패 라우트 목록
         private List<ExecuteFailedRouteRes> failedTransfers;
+
+        public static ExecuteRes from(
+                Integer requestedCount,
+                List<ExecuteLineResultRes> lineResults,
+                List<ExecuteTransferRes> createdTransfers,
+                List<ExecuteFailedRouteRes> failedTransfers
+        ) {
+            return ExecuteRes.builder()
+                    .requestedCount(requestedCount)
+                    .successCount(lineResults == null ? 0 : lineResults.size())
+                    .failureCount(failedTransfers == null ? 0 : failedTransfers.size())
+                    .lineResults(lineResults)
+                    .createdTransfers(createdTransfers)
+                    .failedTransfers(failedTransfers)
+                    .build();
+        }
     }
 
     @Getter
@@ -99,6 +176,22 @@ public class WarehouseTransferDto {
         private String errorMessage;
         // 라우트 내 실패 라인 상세
         private List<ExecuteLineFailureRes> failedLines;
+
+        public static ExecuteFailedRouteRes from(
+                String fromWarehouseCode,
+                String toWarehouseCode,
+                Integer errorCode,
+                String errorMessage,
+                List<ExecuteLineFailureRes> failedLines
+        ) {
+            return ExecuteFailedRouteRes.builder()
+                    .fromWarehouseCode(fromWarehouseCode)
+                    .toWarehouseCode(toWarehouseCode)
+                    .errorCode(errorCode)
+                    .errorMessage(errorMessage)
+                    .failedLines(failedLines)
+                    .build();
+        }
     }
 
     @Getter
@@ -109,6 +202,15 @@ public class WarehouseTransferDto {
         private String skuCode;
         private Integer qty;
         private String reason;
+
+        public static ExecuteLineFailureRes from(ExecuteLineReq req, String reason) {
+            return ExecuteLineFailureRes.builder()
+                    .lineId(req.getLineId())
+                    .skuCode(req.getSkuCode())
+                    .qty(req.getQty())
+                    .reason(reason)
+                    .build();
+        }
     }
 
     @Getter
@@ -128,6 +230,35 @@ public class WarehouseTransferDto {
         private Integer totalQty;
         private Integer reasonCount;
         private Integer memoCount;
+
+        public static TransferListItemRes from(
+                WarehouseTransferHeader header,
+                String fromWarehouseCode,
+                String fromWarehouseName,
+                String toWarehouseCode,
+                String toWarehouseName,
+                List<TransferLineRes> lines,
+                Integer skuCount,
+                Integer totalQty,
+                Integer reasonCount,
+                Integer memoCount
+        ) {
+            return TransferListItemRes.builder()
+                    .transferNo(header.getTransferNo())
+                    .fromWarehouseCode(fromWarehouseCode)
+                    .fromWarehouseName(fromWarehouseName)
+                    .toWarehouseCode(toWarehouseCode)
+                    .toWarehouseName(toWarehouseName)
+                    .requestedBy(header.getRequestedBy())
+                    .requestedAt(header.getRequestedAt())
+                    .status(header.getStatus().name())
+                    .lines(lines)
+                    .skuCount(skuCount)
+                    .totalQty(totalQty)
+                    .reasonCount(reasonCount)
+                    .memoCount(memoCount)
+                    .build();
+        }
     }
 
     @Getter
@@ -147,6 +278,35 @@ public class WarehouseTransferDto {
         private Integer totalQty;
         private Integer reasonCount;
         private Integer memoCount;
+
+        public static TransferDetailRes from(
+                WarehouseTransferHeader header,
+                String fromWarehouseCode,
+                String fromWarehouseName,
+                String toWarehouseCode,
+                String toWarehouseName,
+                List<TransferLineRes> lines,
+                Integer skuCount,
+                Integer totalQty,
+                Integer reasonCount,
+                Integer memoCount
+        ) {
+            return TransferDetailRes.builder()
+                    .transferNo(header.getTransferNo())
+                    .fromWarehouseCode(fromWarehouseCode)
+                    .fromWarehouseName(fromWarehouseName)
+                    .toWarehouseCode(toWarehouseCode)
+                    .toWarehouseName(toWarehouseName)
+                    .requestedBy(header.getRequestedBy())
+                    .requestedAt(header.getRequestedAt())
+                    .status(header.getStatus().name())
+                    .lines(lines)
+                    .skuCount(skuCount)
+                    .totalQty(totalQty)
+                    .reasonCount(reasonCount)
+                    .memoCount(memoCount)
+                    .build();
+        }
     }
 
     @Getter
@@ -165,6 +325,30 @@ public class WarehouseTransferDto {
         private Integer toStockBefore;
         private Integer fromStockAfter;
         private Integer toStockAfter;
+
+        public static TransferLineRes from(
+                WarehouseTransferItem item,
+                String skuCode,
+                String itemCode,
+                String itemName,
+                String color,
+                String size
+        ) {
+            return TransferLineRes.builder()
+                    .skuCode(skuCode)
+                    .itemCode(itemCode)
+                    .itemName(itemName)
+                    .color(color)
+                    .size(size)
+                    .qty(item.getQuantity())
+                    .reason(item.getReason())
+                    .memo(item.getMemo())
+                    .fromStockBefore(item.getFromAvailableBefore())
+                    .toStockBefore(item.getToAvailableBefore())
+                    .fromStockAfter(item.getFromAvailableAfter())
+                    .toStockAfter(item.getToAvailableAfter())
+                    .build();
+        }
     }
 
     @Getter
@@ -180,5 +364,55 @@ public class WarehouseTransferDto {
         private Integer safetyStock;
         private String status;
         private Date updatedAt;
+
+        public static WarehouseSkuDistributionRes from(
+                String warehouseCode,
+                String warehouseName,
+                String location,
+                Integer onHandStock,
+                Integer reservedStock,
+                Integer availableStock,
+                Integer safetyStock,
+                String status,
+                Date updatedAt
+        ) {
+            return WarehouseSkuDistributionRes.builder()
+                    .warehouseCode(warehouseCode)
+                    .warehouseName(warehouseName)
+                    .location(location)
+                    .onHandStock(onHandStock)
+                    .reservedStock(reservedStock)
+                    .availableStock(availableStock)
+                    .safetyStock(safetyStock)
+                    .status(status)
+                    .updatedAt(updatedAt)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ExecuteHeaderContext {
+        private String transferNo;
+        private Long fromWarehouseId;
+        private Long toWarehouseId;
+        private WarehouseTransferStatus status;
+        private String requestedBy;
+        private Date requestedAt;
+        private String reasonSummary;
+        private String memoSummary;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ExecuteLineContext {
+        private WarehouseTransferHeader header;
+        private Long skuId;
+        private Integer fromAvailableBefore;
+        private Integer toAvailableBefore;
+        private Integer fromAvailableAfter;
+        private Integer toAvailableAfter;
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferHeader.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferHeader.java
@@ -58,10 +58,25 @@ public class WarehouseTransferHeader extends BaseEntity {
         this.transferNo = transferNo;
         this.fromWarehouseId = fromWarehouseId;
         this.toWarehouseId = toWarehouseId;
-        this.status = status == null ? WarehouseTransferStatus.REQUESTED : status;
+        this.status = status == null ? WarehouseTransferStatus.READY_TO_SHIP : status;
         this.requestedBy = requestedBy;
         this.requestedAt = requestedAt == null ? new Date() : requestedAt;
         this.reasonSummary = reasonSummary;
         this.memoSummary = memoSummary;
+    }
+
+    // 재고이동 실행 직후 출고 준비 상태로 전환한다.
+    public void markReadyToShip() {
+        this.status = WarehouseTransferStatus.READY_TO_SHIP;
+    }
+
+    // 출고 확정 시점에 배송중 상태로 전환한다.
+    public void markInTransit() {
+        this.status = WarehouseTransferStatus.IN_TRANSIT;
+    }
+
+    // 배송 완료 시점에 도착 상태로 전환한다.
+    public void markArrived() {
+        this.status = WarehouseTransferStatus.ARRIVED;
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferStatus.java
+++ b/src/main/java/org/example/stockitbe/hq/warehousetransfer/model/WarehouseTransferStatus.java
@@ -1,8 +1,7 @@
 package org.example.stockitbe.hq.warehousetransfer.model;
 
 public enum WarehouseTransferStatus {
-    REQUESTED,
-    IN_PROGRESS,
-    COMPLETED,
-    CANCELED
+    READY_TO_SHIP,
+    IN_TRANSIT,
+    ARRIVED
 }

--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
@@ -8,6 +8,8 @@ import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.warehousetransfer.WarehouseTransferHeaderRepository;
+import org.example.stockitbe.hq.warehousetransfer.model.WarehouseTransferHeader;
 import org.example.stockitbe.hq.inventory.InventoryService;
 import org.example.stockitbe.store.inbound.model.StoreInboundStatus;
 import org.example.stockitbe.store.inbound.model.entity.StoreInboundHeader;
@@ -17,6 +19,7 @@ import org.example.stockitbe.store.inbound.repository.StoreInboundStatusHistoryR
 import org.example.stockitbe.user.model.AuthUserDetails;
 import org.example.stockitbe.warehouse.outbound.model.OutboundDestinationType;
 import org.example.stockitbe.warehouse.outbound.model.OutboundStatus;
+import org.example.stockitbe.warehouse.outbound.model.OutboundSourceType;
 import org.example.stockitbe.warehouse.outbound.model.dto.WhOutboundDto;
 import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundHeader;
 import org.example.stockitbe.warehouse.outbound.model.entity.WhOutboundItem;
@@ -49,6 +52,7 @@ public class WhOutboundService {
     private final InfrastructureRepository infrastructureRepository;
     private final CircularBuyerRepository circularBuyerRepository;
     private final InventoryService inventoryService;
+    private final WarehouseTransferHeaderRepository warehouseTransferHeaderRepository;
 
     // 출고 목록 조회 함수
     @Transactional(readOnly = true)
@@ -164,6 +168,7 @@ public class WhOutboundService {
                         .reason(reason == null || reason.isBlank() ? "OUTBOUND_CONFIRM" : reason)
                         .build()
         );
+        syncTransferStatusFromOutbound(header, OutboundStatus.IN_TRANSIT);
 
         // 5) 최신 상세 정보를 반환한다.
         return detail(me, outboundNo);
@@ -194,6 +199,7 @@ public class WhOutboundService {
                         .reason(reason == null || reason.isBlank() ? "OUTBOUND_ARRIVED" : reason)
                         .build()
         );
+        syncTransferStatusFromOutbound(header, OutboundStatus.ARRIVED);
 
         // 4) 최신 상세 정보를 반환한다.
         inboundHeaderRepository.findByOutboundNo(header.getOutboundNo()).ifPresent(inbound -> {
@@ -214,6 +220,25 @@ public class WhOutboundService {
         });
 
         return detail(me, outboundNo);
+    }
+
+    // 매장발주/순환판매 출고는 제외하고, 재고이동 원천만 상태를 동기화한다.
+    private void syncTransferStatusFromOutbound(WhOutboundHeader header, OutboundStatus toStatus) {
+        if (header.getSourceType() != OutboundSourceType.WAREHOUSE_TRANSFER) return;
+        warehouseTransferHeaderRepository.findByTransferNo(header.getSourceRefNo()).ifPresent(transfer -> {
+            applyTransferStatus(transfer, toStatus);
+        });
+    }
+
+    // outbound 상태 전이를 transfer 상태로 미러링한다.
+    private void applyTransferStatus(WarehouseTransferHeader transfer, OutboundStatus toStatus) {
+        if (toStatus == OutboundStatus.IN_TRANSIT) {
+            transfer.markInTransit();
+            return;
+        }
+        if (toStatus == OutboundStatus.ARRIVED) {
+            transfer.markArrived();
+        }
     }
 
     // 로그인 사용자 기준 창고 ID 해석 함수


### PR DESCRIPTION
## 📌 요약
- 재고이동 실행 시 WH_TRANSFER 출고를 동기 오케스트레이션으로 즉시 생성하도록 구현했습니다.
- 출고 상태 전이에 맞춰 재고이동 상태를 `READY_TO_SHIP -> IN_TRANSIT -> ARRIVED`로 동기화했습니다.
- 다건 실행 시 부분성공/부분실패를 지원하고 멱등(중복 생성 방지)을 보강했습니다.

<br><br>

## 🎯 작업 내용
- 재고이동 실행 플로우에 라우트 단위 처리 경계를 적용해, 성공 라우트는 커밋하고 실패 라우트는 사유를 분리 반환하도록 구현
- WH_TRANSFER 출고 생성 규칙 반영  
  (`sourceType=WAREHOUSE_TRANSFER`, `sourceRefNo/sourceRefId/sourceRefSeq`, `destinationType=WAREHOUSE`, `destinationId=toWarehouseId`)
- 출고 생성 시 초기 상태/이력(`READY_TO_SHIP`) 보장, 출고 `confirm/arrive` 전이 시 transfer 상태 동기화
- 멱등 이중 방어 적용(사전 조회 + 유니크 충돌 재조회 처리)
- transfer 상태 enum/코드 정비(`READY_TO_SHIP`, `IN_TRANSIT`, `ARRIVED`)
- 이동번호 prefix 정책 변경(`WTF-...`)
- DTO 변환 패턴 정리(req `toEntity`, res `from`) 및 서비스 코드 구조 정리/주석 보강

<br><br>

## ✔️ 참고 사항
- 이번 PR 범위는 **출고 연계까지**이며, `RECEIVED(입고완료)` 실상태 전이는 입고 담당자 후속 연동 범위입니다.
- 기존 `STORE_ORDER` 출고/상태전이 흐름과 충돌하지 않도록 분기 처리로 회귀 영향을 최소화했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #253