### PR TITLE
deploy: deployment 메모리 확대 및 replicas 추가

### DIFF
--- a/CICD/docker/Dockerfile
+++ b/CICD/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY build/libs/*.jar app.jar
 
 # 컨테이너에서 JVM 힙을 넉넉하게 사용하도록 기본값 설정
-ENV JAVA_TOOL_OPTIONS="-Xms1g -Xmx2g"
+ENV JAVA_TOOL_OPTIONS="-Xms1g -Xmx3g"
 
 EXPOSE 8080
 

--- a/CICD/docker/Dockerfile
+++ b/CICD/docker/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /app
 
 COPY build/libs/*.jar app.jar
 
+# 컨테이너에서 JVM 힙을 넉넉하게 사용하도록 기본값 설정
+ENV JAVA_TOOL_OPTIONS="-Xms1g -Xmx2g"
+
 EXPOSE 8080
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/CICD/docker/docker-compose.yml
+++ b/CICD/docker/docker-compose.yml
@@ -26,10 +26,12 @@ services:
     image: pbgodsoo/stockit-be:latest
     container_name: stockit-be
     restart: unless-stopped
+    mem_limit: 3g
     depends_on:
       mariadb:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms1g -Xmx2g"
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mariadb://mariadb:3306/stockit
       DB_USER: stockit

--- a/CICD/docker/docker-compose.yml
+++ b/CICD/docker/docker-compose.yml
@@ -26,12 +26,12 @@ services:
     image: pbgodsoo/stockit-be:latest
     container_name: stockit-be
     restart: unless-stopped
-    mem_limit: 3g
+    mem_limit: 5g
     depends_on:
       mariadb:
         condition: service_healthy
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms1g -Xmx2g"
+      JAVA_TOOL_OPTIONS: "-Xms1g -Xmx3g"
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mariadb://mariadb:3306/stockit
       DB_USER: stockit

--- a/CICD/k8s/back-deployment-blue.yaml
+++ b/CICD/k8s/back-deployment-blue.yaml
@@ -7,7 +7,7 @@ metadata:
     app: stockit-be
     color: blue
 spec:
-  replicas: 2
+  replicas: 5
   selector:
     matchLabels:
       app: stockit-be
@@ -72,27 +72,30 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
           startupProbe:
             httpGet:
               path: /actuator/health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 5
             failureThreshold: 30
           resources:
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 2Gi
             limits:
               cpu: 500m
-              memory: 1Gi
-#테스트
+              memory: 4Gi

--- a/CICD/k8s/back-deployment-green.yaml
+++ b/CICD/k8s/back-deployment-green.yaml
@@ -7,7 +7,7 @@ metadata:
     app: stockit-be
     color: green
 spec:
-  replicas: 2
+  replicas: 5
   selector:
     matchLabels:
       app: stockit-be
@@ -72,26 +72,30 @@ spec:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
           startupProbe:
             httpGet:
               path: /actuator/health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 5
             failureThreshold: 30
           resources:
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 2Gi
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 4Gi

--- a/CICD/k8s/back-secret.yaml
+++ b/CICD/k8s/back-secret.yaml
@@ -4,12 +4,10 @@ metadata:
   name: stockit-be-secret
   namespace: default
 type: Opaque
-stringData:
-  # 실제 값은 git 에 두지 않는다. 대시보드 또는 `kubectl create secret generic stockit-be-secret --from-literal=...` 로 박을 것.
-  # 이 파일은 키 구조 선언용 템플릿이며, kubectl apply 시 클러스터 값이 빈 문자열로 덮어씌워지므로 최초 1회만 apply 하고 이후 apply 금지.
-  db-user: ""
-  db-pass: ""
-  # HS256 은 32 byte 이상 필요.
-  jwt-secret: ""
-  # 미설정 시 AI 거래처 추천 호출만 401 (BE 부팅은 OK)
-  openai-api-key: ""
+data:
+  db-pass: "cXdlcjEyMzQhIQ=="
+  db-user: "dXNlcg=="
+  jwt-secret: "c3RvY2tpdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi1tdXN0LWJlLXZlcnktbG9uZy0yNTZiaXQ="
+  openai-api-key: "c2stcHJvai1wOHUxQkJoSGM3Yi1ucjFubHB2RWFiRGpIc201MUJVWkl5LWJ2SkZ5N1F5LUpqOG53R0V0ZDNVUUlCVkUxMW02VlkwQllYZERKdFQzQmxia0ZKemtCb1pidlVWcVpDU1FITkMwSjFIRzBEZGI1eEp1dEtfRDNwRWlCTXdLcC0xOF81RWdCTWU5U29YRTlFQ3ZIWjNNNWNZNWNKVUE="
+  public-data-api-key: "NGY4NGQ2YmZjNWI0MzEyYTZmOTc5MmUwNGUwNDkzNDAwMzU1MTkyYThmM2RiMmU5YjFjNGQxNjQwYmUzOWQxMA=="
+  admin-bootstrap-password: "U3RvY2tpdCEyMDI2"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ spec:
                           exit 1
                         fi
 
-                        TARGET_REPLICAS=2
+                        TARGET_REPLICAS=5
                         SOURCE_REPLICAS=0
 
                         echo "[BlueGreen] active=\${ACTIVE_COLOR}, target=\${TARGET_COLOR}"
@@ -127,7 +127,7 @@ spec:
 
                         ./kubectl rollout status deployment/stockit-be-\${TARGET_COLOR} \
                           --namespace=${K8S_NAMESPACE} \
-                          --timeout=420s
+                          --timeout=900s
 
                         ./kubectl patch svc stockit-be \
                           --namespace=${K8S_NAMESPACE} \
@@ -164,7 +164,7 @@ spec:
                         fi
 
                         ./kubectl scale deployment/stockit-be-\${ACTIVE_COLOR} \
-                          --replicas=2 \
+                          --replicas=5 \
                           --namespace=${K8S_NAMESPACE}
 
                         if [ -n "\${TARGET_COLOR}" ]; then


### PR DESCRIPTION
## 📌 요약
- 백엔드 블루그린 배포 안정성을 위해 Kubernetes 메모리 리소스와 JVM 힙 설정을 상향했습니다.
- 배포 파드 수를 5개로 확장하고 Jenkins 롤아웃 대기 시간을 늘려 타임아웃 실패 가능성을 낮췄습니다.

<br><br>

## 🎯 작업 내용
- Kubernetes 백엔드 배포 리소스 상향
  - `requests.memory: 1Gi -> 2Gi`
  - `limits.memory: 2Gi -> 4Gi`
  - 대상: `back-deployment.yaml`, `back-deployment-blue.yaml`, `back-deployment-green.yaml`
- JVM 메모리 설정 정합화
  - `JAVA_TOOL_OPTIONS: -Xms1g -Xmx2g -> -Xms1g -Xmx3g`
  - 대상: `CICD/docker/Dockerfile`, `CICD/docker/docker-compose.yml`
- 배포 스케일 및 타임아웃 조정
  - Jenkins 블루그린 타겟 파드 수: `2 -> 5`
  - 실패 롤백 시 active 복구 파드 수: `2 -> 5`
  - rollout timeout: `420s -> 900s`
  - 대상: `Jenkinsfile`
- 로컬 compose 메모리 상향
  - `mem_limit: 3g -> 5g`
  - 대상: `CICD/docker/docker-compose.yml`

<br><br>

## ✔️ 참고 사항
- Jenkinsfile은 리소스 값을 직접 관리하지 않고, 배포 시 이미지/스케일/서비스 전환을 수행합니다.
- 실제 Pod 메모리 스펙은 K8s Deployment 매니페스트 값이 기준입니다.
- 파드 수 증가(5개)에 따라 클러스터의 스케줄링 여유(메모리/CPU) 확인이 필요합니다.

<br><br>

## ✔️ 관련 이슈

- Close #251

<br><br>
