### PR TITLE
refactor: 유저 자동 생성 사원 번호, 이름 변경

### DIFF
--- a/src/main/java/org/example/stockitbe/user/AdminBootstrapRunner.java
+++ b/src/main/java/org/example/stockitbe/user/AdminBootstrapRunner.java
@@ -43,13 +43,13 @@ public class AdminBootstrapRunner implements CommandLineRunner {
         String encoded = passwordEncoder.encode(adminPassword);
         LocalDateTime now = LocalDateTime.now();
 
-        createIfMissing("HQ-A0001", "hq-admin@stockit.com", "본사 관리자",
+        createIfMissing("hq0001", "hq-admin@stockit.com", "김본사",
                 "01000000001", "HQ-CENTER", "본사 본부",
                 UserRole.HQ, encoded, now);
-        createIfMissing("ST-A0001", "store-admin@stockit.com", "매장 관리자",
+        createIfMissing("st0001", "store-admin@stockit.com", "김매장",
                 "01000000002", "ST-SL-0001", "강남 플래그십점",
                 UserRole.STORE, encoded, now);
-        createIfMissing("WH-A0001", "warehouse-admin@stockit.com", "창고 관리자",
+        createIfMissing("wh0001", "warehouse-admin@stockit.com", "김창고",
                 "01000000003", "WH-SL-0001", "서울 도심 풀필먼트 허브",
                 UserRole.WAREHOUSE, encoded, now);
     }


### PR DESCRIPTION
## 📌 요약
- 개발용 부트스트랩 관리자 계정의 사원번호/이름 규칙을 신규 포맷으로 정리했습니다.
- 계정 승인 시 사번 파싱 오류를 유발하던 기존 `*-A0001` 형식 의존을 줄이기 위한 선행 정비입니다.

<br><br>

## 🎯 작업 내용
- `AdminBootstrapRunner`의 HQ/STORE/WAREHOUSE 기본 사원번호를 `hq0001`, `st0001`, `wh0001`로 변경
- `AdminBootstrapRunner`의 기본 이름을 `김본사`, `김매장`, `김창고`로 변경
- 기존 부트스트랩 계정 생성 흐름(역할/위치코드/상태/비밀번호 주입 방식)은 유지

<br><br>

## ✔️ 참고 사항
- 기존 DB에 `HQ-A0001` 등 구 포맷 계정이 남아 있으면 신규 코드 계정이 자동 생성되지 않을 수 있습니다.
- 로컬 테스트 시 필요하면 기존 구 포맷 계정 정리 후 재기동이 필요합니다.

<br><br>

## ✔️ 관련 이슈

- Close #277

<br><br>
