### PR TITLE
refactor(purchase-order): 발주 목록 조회에 Pageable 도입

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderController.java
@@ -6,12 +6,15 @@ import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderDto;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
 import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/hq/purchase-orders")
@@ -21,12 +24,13 @@ public class PurchaseOrderController {
     private final PurchaseOrderService service;
 
     @GetMapping
-    public BaseResponse<List<PurchaseOrderDto.ListRes>> list(
+    public BaseResponse<Page<PurchaseOrderDto.ListRes>> list(
             @RequestParam(required = false) String vendorCode,
             @RequestParam(required = false) PurchaseOrderStatus status,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
-        return BaseResponse.success(service.findAll(vendorCode, status, from, to));
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return BaseResponse.success(service.findAll(vendorCode, status, from, to, pageable));
     }
 
     @GetMapping("/{code}")

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderRepository.java
@@ -2,6 +2,8 @@ package org.example.stockitbe.hq.purchaseorder;
 
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrder;
 import org.example.stockitbe.hq.purchaseorder.model.PurchaseOrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,6 +24,10 @@ public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Lo
     @Override
     @EntityGraph(attributePaths = {"vendor", "warehouse"})
     List<PurchaseOrder> findAll(Specification<PurchaseOrder> spec);
+
+    @Override
+    @EntityGraph(attributePaths = {"vendor", "warehouse"})
+    Page<PurchaseOrder> findAll(Specification<PurchaseOrder> spec, Pageable pageable);
 
     long countByCodeStartingWith(String prefix);
 

--- a/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
+++ b/src/main/java/org/example/stockitbe/hq/purchaseorder/PurchaseOrderService.java
@@ -21,6 +21,8 @@ import org.example.stockitbe.hq.vendor.VendorRepository;
 import org.example.stockitbe.hq.vendor.model.Vendor;
 import org.example.stockitbe.hq.vendor.model.VendorProduct;
 import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,8 +56,8 @@ public class PurchaseOrderService {
     private final InventoryService inventoryService;
 
     @Transactional(readOnly = true)
-    public List<PurchaseOrderDto.ListRes> findAll(String vendorCode, PurchaseOrderStatus status,
-                                                    LocalDate from, LocalDate to) {
+    public Page<PurchaseOrderDto.ListRes> findAll(String vendorCode, PurchaseOrderStatus status,
+                                                    LocalDate from, LocalDate to, Pageable pageable) {
         Long vendorIdFilter = null;
         if (vendorCode != null && !vendorCode.isBlank()) {
             Vendor vendor = lookupVendor(vendorCode);
@@ -64,12 +66,12 @@ public class PurchaseOrderService {
 
         Specification<PurchaseOrder> spec = buildSpec(vendorIdFilter, status, from, to);
         // @EntityGraph(vendor, warehouse) — 단일 LEFT JOIN 으로 fetch.
-        List<PurchaseOrder> orders = purchaseOrderRepository.findAll(spec);
-        if (orders.isEmpty()) {
-            return List.of();
+        Page<PurchaseOrder> pagePo = purchaseOrderRepository.findAll(spec, pageable);
+        if (pagePo.isEmpty()) {
+            return Page.empty(pageable);
         }
 
-        Set<Long> orderIds = orders.stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
+        Set<Long> orderIds = pagePo.getContent().stream().map(PurchaseOrder::getId).collect(Collectors.toSet());
         // batch 1회 조회 결과를 itemCountMap + productNamesMap 두 가지로 활용 (쿼리 0추가)
         List<PurchaseOrderItem> allItems = itemRepository.findAllByPurchaseOrderIdIn(orderIds);
         Map<Long, Long> itemCountMap = allItems.stream()
@@ -79,13 +81,11 @@ public class PurchaseOrderService {
                         it -> it.getPurchaseOrder().getId(),
                         Collectors.mapping(PurchaseOrderItem::getProductName, Collectors.toList())));
 
-        return orders.stream()
-                .map(po -> {
-                    int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
-                    List<String> names = productNamesMap.getOrDefault(po.getId(), List.of());
-                    return PurchaseOrderDto.ListRes.from(po, po.getVendor(), po.getWarehouse().getCode(), count, names);
-                })
-                .toList();
+        return pagePo.map(po -> {
+            int count = itemCountMap.getOrDefault(po.getId(), 0L).intValue();
+            List<String> names = productNamesMap.getOrDefault(po.getId(), List.of());
+            return PurchaseOrderDto.ListRes.from(po, po.getVendor(), po.getWarehouse().getCode(), count, names);
+        });
     }
 
     @Transactional(readOnly = true)
@@ -479,7 +479,7 @@ public class PurchaseOrderService {
                 Date toDate = Date.from(to.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
                 predicates.add(cb.lessThan(root.get("createdAt"), toDate));
             }
-            query.orderBy(cb.desc(root.get("createdAt")));
+            // 정렬은 Pageable.sort 가 결정 (Controller @PageableDefault). Spec 안에 박지 마라 — count query 와 충돌·외부 sort 무력화.
             return cb.and(predicates.toArray(new Predicate[0]));
         };
     }


### PR DESCRIPTION
## 📌 요약
- 본사 발주 목록 조회 (`GET /api/hq/purchase-orders`) 가 List 전체 반환이라 발주 누적 시 BE 응답 + FE 렌더링이 모두 느려지던 문제. `Pageable` 도입으로 page 단위로 자른다.

<br><br>

## 🎯 작업 내용
- `PurchaseOrderController.list` 응답 `BaseResponse<List<ListRes>>` → `BaseResponse<Page<ListRes>>`, `@PageableDefault(size=20, sort=createdAt,desc) Pageable` 추가
- `PurchaseOrderRepository` 에 `Page<PurchaseOrder> findAll(Specification, Pageable)` `@EntityGraph(vendor, warehouse)` 오버라이드 추가 (N+1 회피)
- `PurchaseOrderService.findAll` 시그니처에 `Pageable` 추가 + `pagePo.map(...)` 변환, 빈 페이지 `Page.empty(pageable)` 분기
- `buildSpec` 안의 `query.orderBy(cb.desc("createdAt"))` 제거 — Pageable.sort 가 정렬 결정이라 spec 에 박힌 정렬은 count query 와 충돌하고 외부 sort 호출도 무력화
- 기존 `List<PurchaseOrder> findAll(Specification)` 오버라이드는 `DashboardService` 호출처가 있어 그대로 둔다

<br><br>

## ✔️ 참고 사항
- 응답 형태 `List → Page` 는 의도된 break change. FE 동기화는 별 사이클 / 별 PR 로 분리 진행
- 카탈로그(`/catalog`) 도 동일 진단으로 페이징 누락이지만 검색·facet·정렬 모두 server-side 로 옮겨야 의미 있어 별 phase 로 분리

<br><br>

## ✔️ 관련 이슈

- Close #283

<br><br>
