### PR TITLE
refactor(inventory): 전사/창고 재고 조회 페이징 + 서버 필터 도입

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/category/model/Category.java
+++ b/src/main/java/org/example/stockitbe/hq/category/model/Category.java
@@ -8,9 +8,15 @@ import lombok.NoArgsConstructor;
 import org.example.stockitbe.common.model.BaseEntity;
 
 @Entity
-@Table(name = "category", uniqueConstraints = {
+@Table(name = "category",
+    uniqueConstraints = {
         @UniqueConstraint(name = "uk_category_code", columnNames = "code")
-})
+    },
+    // parent_id 인덱스 — 전사재고 query 의 self-join (parent ← child) 가속.
+    indexes = {
+        @Index(name = "idx_category_parent_id", columnList = "parent_id")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
@@ -5,6 +5,8 @@ import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.inventory.model.InventoryDto;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
@@ -28,9 +30,10 @@ public class InventoryController {
             @RequestParam(required = false) String parentCategory,
             @RequestParam(required = false) String childCategory,
             @RequestParam(required = false) InventoryStatus status,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        return BaseResponse.success(inventoryQueryService.findCompanyWide(locationType, locationIds, parentCategory, childCategory, status, keyword));
+        return BaseResponse.success(inventoryQueryService.findCompanyWide(locationType, locationIds, parentCategory, childCategory, status, keyword, pageable));
     }
 
     // 전사 재고 SKU 상세 조회 API

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
@@ -6,14 +6,19 @@ import org.example.stockitbe.hq.category.model.Category;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
+import org.example.stockitbe.hq.inventory.model.CompanyWideAggregateRow;
 import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryDto;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
 import org.example.stockitbe.hq.inventory.model.InventoryStatusPolicy;
+import org.example.stockitbe.hq.inventory.model.ItemSafetyStockRow;
 import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.ProductSkuRepository;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,109 +38,70 @@ public class InventoryQueryService {
     private final CategoryRepository categoryRepository;
     private final InfrastructureRepository infrastructureRepository;
 
-    // 전사 재고(품목 단위) 목록을 조회한다.
+    // 전사 재고(품목 단위) 페이지 목록을 조회한다.
+    // native @Query GROUP BY 로 itemCode 단위 페이징 + 카테고리/재고 합계 한 번에,
+    // safetyStock 은 페이지 후 itemCodes IN-clause 로 별도 native @Query 한 번 추가 호출.
+    // 페이지당 SQL 호출: 메인(1) + safetyStock(1) + locationOptions(1) = 총 3개.
     @Transactional(readOnly = true)
     public InventoryDto.CompanyWidePageRes findCompanyWide(LocationType locationType,
                                                             List<Long> locationIds,
                                                             String parentCategory,
                                                             String childCategory,
                                                             InventoryStatus status,
-                                                            String keyword) {
-        List<Inventory> inventories = inventoryRepository.findAll();
-        List<ProductSku> skus = productSkuRepository.findAll();
-        if (inventories.isEmpty() || skus.isEmpty()) {
-            return InventoryDto.CompanyWidePageRes.builder()
-                    .items(List.of())
-                    .locationOptions(buildLocationOptions(locationType))
+                                                            String keyword,
+                                                            Pageable pageable) {
+        String locationTypeStr = locationType == null ? null : locationType.name();
+        String statusStr = status == null ? null : status.name();
+        boolean hasLocationIds = locationIds != null && !locationIds.isEmpty();
+        // IN (:locationIds) 가 빈 리스트면 SQL 에러 → 더미 값으로 채움 (hasLocationIds=false 일 땐 어차피 평가 안 됨)
+        List<Long> safeLocationIds = hasLocationIds ? locationIds : List.of(-1L);
+        String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+        String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
+        String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
+
+        // sort 무시(native @Query 안에 ORDER BY 박혀 있음) — page/size 만 사용
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
+
+        Page<CompanyWideAggregateRow> rows = inventoryRepository.findCompanyWideAggregated(
+                locationTypeStr, hasLocationIds, safeLocationIds, statusStr,
+                safeParent, safeChild, safeKeyword, safePageable
+        );
+
+        List<InventoryDto.LocationOptionRes> locationOptions = buildLocationOptions(locationType);
+
+        if (rows.isEmpty()) {
+            return InventoryDto.CompanyWidePageRes.from(rows.map(r -> null), locationOptions);
+        }
+
+        // 페이지 안 itemCode 만 추려 safetyStock 한 번에 집계 (DB 단계, sub-query DISTINCT)
+        List<String> itemCodes = rows.getContent().stream()
+                .map(CompanyWideAggregateRow::getItemCode).toList();
+        Map<String, Integer> safetyByItemCode = inventoryRepository
+                .aggregateSafetyStockByItemCode(itemCodes, locationTypeStr, hasLocationIds, safeLocationIds, statusStr)
+                .stream()
+                .collect(Collectors.toMap(ItemSafetyStockRow::getItemCode, r -> n(r.getSafetyStock())));
+
+        Page<InventoryDto.CompanyWideRes> mapped = rows.map(row -> {
+            int actual = n(row.getActualStock());
+            int available = n(row.getAvailableStock());
+            int safety = safetyByItemCode.getOrDefault(row.getItemCode(), 0);
+            return InventoryDto.CompanyWideRes.builder()
+                    .itemCode(row.getItemCode())
+                    .parentCategory(row.getParentCategory() == null ? "" : row.getParentCategory())
+                    .childCategory(row.getChildCategory() == null ? "" : row.getChildCategory())
+                    .itemName(row.getItemName())
+                    .actualStock(actual)
+                    .availableStock(available)
+                    .safetyStock(safety)
+                    .status(toUiStatus(available, safety))
+                    .updatedAt(row.getUpdatedAt())
                     .build();
-        }
+        });
 
-        Map<Long, ProductSku> skuById = skus.stream().collect(Collectors.toMap(ProductSku::getId, Function.identity()));
-        Set<String> productCodes = skus.stream().map(ProductSku::getProductCode).collect(Collectors.toSet());
-        Map<String, ProductMaster> productByCode = productMasterRepository.findAllByCodeIn(productCodes).stream()
-                .collect(Collectors.toMap(ProductMaster::getCode, Function.identity()));
-
-        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
-        Map<String, Category> categoryByCode = categories.stream().collect(Collectors.toMap(Category::getCode, Function.identity()));
-        Map<Long, Category> categoryById = categories.stream().collect(Collectors.toMap(Category::getId, Function.identity()));
-
-        Map<Long, Infrastructure> locationById = infrastructureRepository.findAll().stream()
-                .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
-
-        String safeParent = parentCategory == null ? "" : parentCategory.trim();
-        String safeChild = childCategory == null ? "" : childCategory.trim();
-        String safeKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
-        Set<Long> locationIdSet = locationIds == null ? Set.of() : new HashSet<>(locationIds);
-
-        Map<String, Aggregate> aggregateMap = new LinkedHashMap<>();
-
-        for (Inventory inv : inventories) {
-            if (!InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inv.getInventoryStatus())) continue;
-            ProductSku sku = skuById.get(inv.getSkuId());
-            if (sku == null) continue;
-            ProductMaster master = productByCode.get(sku.getProductCode());
-            if (master == null) continue;
-            Infrastructure location = locationById.get(inv.getLocationId());
-            if (location == null) continue;
-            if (locationType != null && location.getLocationType() != locationType) continue;
-            if (!locationIdSet.isEmpty() && !locationIdSet.contains(location.getId())) continue;
-            if (status != null && inv.getInventoryStatus() != status) continue;
-
-            Category child = categoryByCode.get(master.getCategoryCode());
-            if (child == null) continue;
-            Category parent = child.getParentId() == null ? child : categoryById.get(child.getParentId());
-
-            String parentName = parent != null ? parent.getName() : "";
-            String childName = child.getName();
-
-            if (!safeParent.isBlank() && !safeParent.equals(parentName)) continue;
-            if (!safeChild.isBlank() && !safeChild.equals(childName)) continue;
-
-            if (!safeKeyword.isBlank()) {
-                String searchable = String.join(" ",
-                        master.getCode(),
-                        master.getName(),
-                        sku.getSkuCode(),
-                        location.getCode(),
-                        location.getName()
-                ).toLowerCase(Locale.ROOT);
-                if (!searchable.contains(safeKeyword)) continue;
-            }
-
-            Aggregate agg = aggregateMap.computeIfAbsent(master.getCode(), k -> new Aggregate(master, parentName, childName));
-            agg.actualStock += n(inv.getQuantity());
-            agg.availableStock += n(inv.getAvailableQuantity());
-            String safetyKey = inv.getSkuId() + ":" + inv.getLocationId();
-            if (agg.safetyKeys.add(safetyKey)) {
-                agg.safetyStock += location.getLocationType() == LocationType.WAREHOUSE
-                        ? n(master.getWarehouseSafetyStock())
-                        : n(master.getStoreSafetyStock());
-            }
-            if (agg.updatedAt == null || inv.getUpdatedAt().after(agg.updatedAt)) {
-                agg.updatedAt = inv.getUpdatedAt();
-            }
-            agg.statuses.add(inv.getInventoryStatus());
-        }
-
-        List<InventoryDto.CompanyWideRes> items = aggregateMap.values().stream()
-                .map(agg -> InventoryDto.CompanyWideRes.builder()
-                        .itemCode(agg.master.getCode())
-                        .parentCategory(agg.parentCategory)
-                        .childCategory(agg.childCategory)
-                        .itemName(agg.master.getName())
-                        .actualStock(agg.actualStock)
-                        .availableStock(agg.availableStock)
-                        .safetyStock(agg.safetyStock)
-                        .status(toUiStatus(agg.availableStock, agg.safetyStock))
-                        .updatedAt(agg.updatedAt)
-                        .build())
-                .sorted(Comparator.comparing(InventoryDto.CompanyWideRes::getItemCode))
-                .toList();
-
-        return InventoryDto.CompanyWidePageRes.builder()
-                .items(items)
-                .locationOptions(buildLocationOptions(locationType))
-                .build();
+        return InventoryDto.CompanyWidePageRes.from(mapped, locationOptions);
     }
 
     // 전사 재고 SKU 상세를 조회한다.
@@ -241,25 +207,6 @@ public class InventoryQueryService {
         if (available <= 0) return "품절";
         if (available < safety) return "부족";
         return "정상";
-    }
-
-    // 품목 단위 재고 집계 보조 객체
-    private static class Aggregate {
-        private final ProductMaster master;
-        private final String parentCategory;
-        private final String childCategory;
-        private int actualStock = 0;
-        private int availableStock = 0;
-        private int safetyStock = 0;
-        private Date updatedAt;
-        private final Set<InventoryStatus> statuses = new HashSet<>();
-        private final Set<String> safetyKeys = new HashSet<>();
-
-        private Aggregate(ProductMaster master, String parentCategory, String childCategory) {
-            this.master = master;
-            this.parentCategory = parentCategory;
-            this.childCategory = childCategory;
-        }
     }
 
     // SKU 단위 재고 집계 보조 객체

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -1,8 +1,13 @@
 package org.example.stockitbe.hq.inventory;
 
 import jakarta.persistence.LockModeType;
+import org.example.stockitbe.hq.inventory.model.CompanyWideAggregateRow;
 import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
+import org.example.stockitbe.hq.inventory.model.ItemSafetyStockRow;
+import org.example.stockitbe.warehouse.inventory.model.WarehouseAggregateRow;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -137,4 +142,211 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
                                    @Param("toDt") Date toDt,
                                    @Param("scope") String scope,
                                    @Param("locationCode") String locationCode);
+
+    /**
+     * 전사 재고(품목 단위) 집계 페이지네이션.
+     * GROUP BY product_master.code 로 itemCode 단위 합산 후 LIMIT/OFFSET.
+     * safetyStock + UI status 라벨은 호출자(서비스) 가 페이지 후 메모리에서 계산.
+     *
+     * locationIds 가 비어있을 때 IN 절 SQL 에러를 피하기 위해 hasLocationIds 플래그 + 더미 리스트 패턴.
+     */
+    @Query(value = """
+        SELECT
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            MAX(i.update_date) AS updatedAt
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        JOIN infrastructure inf ON inf.id = i.location_id
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:locationType IS NULL OR inf.location_type = :locationType)
+          AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+          AND (:status IS NULL OR i.inventory_status = :status)
+          AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:keyword IS NULL OR (
+               LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(inf.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(inf.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY pm.code, pm.name, cc.name, pc.name
+        ORDER BY pm.code ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+          SELECT pm.code
+          FROM inventory i
+          JOIN product_sku ps ON ps.id = i.sku_id
+          JOIN product_master pm ON pm.code = ps.product_code
+          JOIN infrastructure inf ON inf.id = i.location_id
+          LEFT JOIN category cc ON cc.code = pm.category_code
+          LEFT JOIN category pc ON pc.id = cc.parent_id
+          WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+            AND (:locationType IS NULL OR inf.location_type = :locationType)
+            AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+            AND (:status IS NULL OR i.inventory_status = :status)
+            AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
+            AND (:childCategory IS NULL OR cc.name = :childCategory)
+            AND (:keyword IS NULL OR (
+                 LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(inf.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(inf.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+            ))
+          GROUP BY pm.code
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<CompanyWideAggregateRow> findCompanyWideAggregated(
+            @Param("locationType") String locationType,
+            @Param("hasLocationIds") boolean hasLocationIds,
+            @Param("locationIds") List<Long> locationIds,
+            @Param("status") String status,
+            @Param("parentCategory") String parentCategory,
+            @Param("childCategory") String childCategory,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 전사 재고 페이지 후 itemCode 별 safetyStock 집계.
+     * (sku, location) DISTINCT 별로 location_type 따라 store/warehouse safety_stock 합산.
+     * 메인 페이지 query 와 같은 outer 필터 (locationType, locationIds, status) 적용.
+     */
+    @Query(value = """
+        SELECT sub.code AS itemCode, COALESCE(SUM(sub.safety_per), 0) AS safetyStock
+        FROM (
+          SELECT DISTINCT pm.code AS code, i.sku_id, i.location_id,
+                 CASE WHEN inf.location_type = 'WAREHOUSE'
+                      THEN COALESCE(pm.warehouse_safety_stock, 0)
+                      ELSE COALESCE(pm.store_safety_stock, 0)
+                 END AS safety_per
+          FROM inventory i
+          JOIN product_sku ps ON ps.id = i.sku_id
+          JOIN product_master pm ON pm.code = ps.product_code
+          JOIN infrastructure inf ON inf.id = i.location_id
+          WHERE pm.code IN (:itemCodes)
+            AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+            AND (:locationType IS NULL OR inf.location_type = :locationType)
+            AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+            AND (:status IS NULL OR i.inventory_status = :status)
+        ) sub
+        GROUP BY sub.code
+        """,
+        nativeQuery = true)
+    List<ItemSafetyStockRow> aggregateSafetyStockByItemCode(
+            @Param("itemCodes") List<String> itemCodes,
+            @Param("locationType") String locationType,
+            @Param("hasLocationIds") boolean hasLocationIds,
+            @Param("locationIds") List<Long> locationIds,
+            @Param("status") String status
+    );
+
+    /**
+     * 창고 재고(품목 단위) 집계 페이지네이션.
+     * 단일 창고(locationId) 기준, GROUP BY product_master.code.
+     * safetyStock = COUNT(DISTINCT sku_id) * pm.warehouse_safety_stock 으로 SQL 단계 계산.
+     * status UI 라벨(품절/부족/정상) 도 SQL CASE 로 계산해 HAVING 으로 필터.
+     * 정렬 = 메인 카테고리 우선순위 (상의/바지/치마/아우터) + childCategory + itemName.
+     */
+    @Query(value = """
+        SELECT
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            (COUNT(DISTINCT i.sku_id) * COALESCE(pm.warehouse_safety_stock, 0)) AS safetyStock,
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) <
+                     (COUNT(DISTINCT i.sku_id) * COALESCE(pm.warehouse_safety_stock, 0))
+                  THEN '부족'
+                ELSE '정상'
+            END AS status,
+            MAX(i.update_date) AS updatedAt
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:keyword IS NULL OR (
+               LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY pm.code, pm.name, pm.warehouse_safety_stock, cc.name, pc.name
+        HAVING (:status IS NULL OR (
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) <
+                     (COUNT(DISTINCT i.sku_id) * COALESCE(pm.warehouse_safety_stock, 0))
+                  THEN '부족'
+                ELSE '정상'
+            END
+        ) = :status)
+        ORDER BY
+            CASE COALESCE(pc.name, cc.name)
+                WHEN '상의' THEN 1
+                WHEN '바지' THEN 2
+                WHEN '치마' THEN 3
+                WHEN '아우터' THEN 4
+                ELSE 5
+            END ASC,
+            cc.name ASC,
+            pm.name ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+          SELECT pm.code
+          FROM inventory i
+          JOIN product_sku ps ON ps.id = i.sku_id
+          JOIN product_master pm ON pm.code = ps.product_code
+          LEFT JOIN category cc ON cc.code = pm.category_code
+          LEFT JOIN category pc ON pc.id = cc.parent_id
+          WHERE i.location_id = :locationId
+            AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+            AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
+            AND (:childCategory IS NULL OR cc.name = :childCategory)
+            AND (:keyword IS NULL OR (
+                 LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            ))
+          GROUP BY pm.code, pm.warehouse_safety_stock
+          HAVING (:status IS NULL OR (
+              CASE
+                  WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                  WHEN COALESCE(SUM(i.available_quantity), 0) <
+                       (COUNT(DISTINCT i.sku_id) * COALESCE(pm.warehouse_safety_stock, 0))
+                    THEN '부족'
+                  ELSE '정상'
+              END
+          ) = :status)
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<WarehouseAggregateRow> findWarehouseAggregated(
+            @Param("locationId") Long locationId,
+            @Param("parentCategory") String parentCategory,
+            @Param("childCategory") String childCategory,
+            @Param("status") String status,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/CompanyWideAggregateRow.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/CompanyWideAggregateRow.java
@@ -1,0 +1,15 @@
+package org.example.stockitbe.hq.inventory.model;
+
+import java.util.Date;
+
+// 전사 재고(품목 단위) 집계 페이지네이션 native @Query 결과 매핑용 interface projection.
+// safetyStock 은 별도 native query (ItemSafetyStockRow) 로 한 번에 집계.
+public interface CompanyWideAggregateRow {
+    String getItemCode();
+    String getItemName();
+    String getParentCategory();
+    String getChildCategory();
+    Integer getActualStock();
+    Integer getAvailableStock();
+    Date getUpdatedAt();
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/Inventory.java
@@ -10,9 +10,17 @@ import org.example.stockitbe.common.model.BaseEntity;
 import java.util.Date;
 
 @Entity
-@Table(name = "inventory", uniqueConstraints = {
+@Table(name = "inventory",
+    uniqueConstraints = {
         @UniqueConstraint(name = "uk_inventory_sku_location_status", columnNames = {"sku_id", "location_id", "inventory_status"})
-})
+    },
+    // (location_id, inventory_status) 복합 인덱스 — 창고 재고 조회 핵심 필터.
+    // 단일 (location_id) 보다 status IN (...) 까지 cover 가능.
+    // 기존 uk 의 prefix 가 sku_id 라 location 단독 검색은 자동 활용 안 됨.
+    indexes = {
+        @Index(name = "idx_inventory_location_status", columnList = "location_id, inventory_status")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // 재고 엔티티

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
+import org.springframework.data.domain.Page;
 
 import java.util.Date;
 import java.util.List;
@@ -61,6 +62,27 @@ public class InventoryDto {
     public static class CompanyWidePageRes {
         private List<CompanyWideRes> items;
         private List<LocationOptionRes> locationOptions;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        // 페이지 결과 + 위치 옵션 목록을 응답 DTO로 변환한다.
+        public static CompanyWidePageRes from(Page<CompanyWideRes> page,
+                                              List<LocationOptionRes> locationOptions) {
+            return CompanyWidePageRes.builder()
+                    .items(page.getContent())
+                    .locationOptions(locationOptions)
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
     }
 
     // 순환재고 후보 목록 행 DTO

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/ItemSafetyStockRow.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/ItemSafetyStockRow.java
@@ -1,0 +1,8 @@
+package org.example.stockitbe.hq.inventory.model;
+
+// 전사 재고 페이지 후 itemCode 별 safetyStock 집계 native @Query 결과 매핑용 interface projection.
+// (sku, location) DISTINCT 별로 location_type 에 따라 store/warehouse safety_stock 을 합산한 값.
+public interface ItemSafetyStockRow {
+    String getItemCode();
+    Integer getSafetyStock();
+}

--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductMaster.java
@@ -11,9 +11,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "product_master", uniqueConstraints = {
+@Table(name = "product_master",
+    uniqueConstraints = {
         @UniqueConstraint(name = "uk_product_master_code", columnNames = "code")
-})
+    },
+    // category_code 인덱스 — 전사재고 5-way JOIN 의 product_master ↔ category 단계 가속.
+    indexes = {
+        @Index(name = "idx_product_master_category_code", columnList = "category_code")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductMaster extends BaseEntity {

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryController.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.user.model.AuthUserDetails;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseInventoryDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,10 +26,17 @@ public class WarehouseInventoryController {
 
     // 창고 재고 품목 목록 조회 API
     @GetMapping
-    public BaseResponse<List<WarehouseInventoryDto.ItemRes>> getWarehouseInventories(
-            @AuthenticationPrincipal AuthUserDetails me
+    public BaseResponse<WarehouseInventoryDto.ItemPageRes> getWarehouseInventories(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        return BaseResponse.success(service.getItems(me.getLocationCode()));
+        return BaseResponse.success(service.getItems(
+                me.getLocationCode(), parentCategory, childCategory, status, keyword, pageable
+        ));
     }
 
     // 창고 재고 SKU 목록 조회 API

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryService.java
@@ -1,6 +1,5 @@
 package org.example.stockitbe.warehouse.inventory;
 
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
@@ -16,7 +15,11 @@ import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.ProductSkuRepository;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
+import org.example.stockitbe.warehouse.inventory.model.WarehouseAggregateRow;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseInventoryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +29,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class WarehouseInventoryService {
-    private static final List<String> MAIN_CATEGORY_ORDER = List.of("상의", "바지", "치마", "아우터");
 
     private final InfrastructureRepository infrastructureRepository;
     private final InventoryRepository inventoryRepository;
@@ -34,73 +36,44 @@ public class WarehouseInventoryService {
     private final ProductMasterRepository productMasterRepository;
     private final CategoryRepository categoryRepository;
 
-    // 창고 재고 품목 목록 조회
-    // 품목 단위로 실재고/가용재고/안전재고를 집계해 반환한다.
+    // 창고 재고 품목 페이지 목록 조회
+    // 품목 단위로 실재고/가용재고/안전재고를 native @Query GROUP BY 로 집계 + LIMIT/OFFSET.
     @Transactional(readOnly = true)
-    public List<WarehouseInventoryDto.ItemRes> getItems(String locationCode) {
+    public WarehouseInventoryDto.ItemPageRes getItems(String locationCode,
+                                                      String parentCategory,
+                                                      String childCategory,
+                                                      String status,
+                                                      String keyword,
+                                                      Pageable pageable) {
         Infrastructure warehouse = resolveWarehouse(locationCode);
-        List<Inventory> inventories = inventoryRepository.findAllByLocationId(warehouse.getId());
-        if (inventories.isEmpty()) {
-            return List.of();
-        }
+        String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
+        String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
+        String safeStatus = (status == null || status.isBlank()) ? null : status.trim();
+        String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
 
-        Context context = buildContext(inventories);
-        Map<String, ItemAccumulator> grouped = new HashMap<>();
+        // sort 무시(native @Query 안에 ORDER BY 박혀 있음) — page/size 만 사용
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
 
-        for (Inventory inventory : inventories) {
-            if (!InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inventory.getInventoryStatus())) continue;
-            ProductSku sku = context.skuById.get(inventory.getSkuId());
-            if (sku == null) continue;
+        Page<WarehouseAggregateRow> rows = inventoryRepository.findWarehouseAggregated(
+                warehouse.getId(), safeParent, safeChild, safeStatus, safeKeyword, safePageable
+        );
 
-            ProductMaster master = context.masterByCode.get(sku.getProductCode());
-            if (master == null) continue;
+        Page<WarehouseInventoryDto.ItemRes> mapped = rows.map(row -> WarehouseInventoryDto.ItemRes.from(
+                row.getItemCode(),
+                row.getParentCategory(),
+                row.getChildCategory(),
+                row.getItemName(),
+                n(row.getActualStock()),
+                n(row.getAvailableStock()),
+                n(row.getSafetyStock()),
+                row.getStatus(),
+                row.getUpdatedAt()
+        ));
 
-            Category child = context.categoryByCode.get(master.getCategoryCode());
-            if (child == null) continue;
-
-            Category parent = child.getParentId() == null ? child : context.categoryById.get(child.getParentId());
-            String parentCategory = parent == null ? child.getName() : parent.getName();
-            String childCategory = child.getName();
-            String itemCode = master.getCode();
-
-            ItemAccumulator acc = grouped.computeIfAbsent(itemCode, key -> ItemAccumulator.builder()
-                    .itemCode(itemCode)
-                    .parentCategory(parentCategory)
-                    .childCategory(childCategory)
-                    .itemName(master.getName())
-                    .actualStock(0)
-                    .availableStock(0)
-                    .safetyStock(0)
-                    .updatedAt(inventory.getUpdatedAt())
-                    .build());
-
-            acc.actualStock += n(inventory.getQuantity());
-            acc.availableStock += n(inventory.getAvailableQuantity());
-            acc.skuIds.add(sku.getId());
-            if (acc.updatedAt == null || (inventory.getUpdatedAt() != null && inventory.getUpdatedAt().after(acc.updatedAt))) {
-                acc.updatedAt = inventory.getUpdatedAt();
-            }
-        }
-
-        grouped.values().forEach(acc -> acc.safetyStock = acc.skuIds.size() * n(context.masterByCode.get(acc.itemCode).getWarehouseSafetyStock()));
-
-        return grouped.values().stream()
-                .map(acc -> WarehouseInventoryDto.ItemRes.from(
-                        acc.itemCode,
-                        acc.parentCategory,
-                        acc.childCategory,
-                        acc.itemName,
-                        acc.actualStock,
-                        acc.availableStock,
-                        acc.safetyStock,
-                        resolveStatus(acc.availableStock, acc.safetyStock),
-                        acc.updatedAt
-                ))
-                .sorted(Comparator
-                        .comparing(WarehouseInventoryDto.ItemRes::getParentCategory, this::compareMainCategory)
-                        .thenComparing(WarehouseInventoryDto.ItemRes::getChildCategory, Comparator.nullsLast(String::compareTo))
-                        .thenComparing(WarehouseInventoryDto.ItemRes::getItemName, Comparator.nullsLast(String::compareTo)))
-                .toList();
+        return WarehouseInventoryDto.ItemPageRes.from(mapped);
     }
 
     // 창고 재고 SKU 목록 조회
@@ -204,16 +177,6 @@ public class WarehouseInventoryService {
         return "정상";
     }
 
-    // 메인 카테고리 우선순위 기준으로 정렬 순서를 계산한다.
-    private int compareMainCategory(String a, String b) {
-        int ai = MAIN_CATEGORY_ORDER.indexOf(a);
-        int bi = MAIN_CATEGORY_ORDER.indexOf(b);
-        ai = ai < 0 ? MAIN_CATEGORY_ORDER.size() : ai;
-        bi = bi < 0 ? MAIN_CATEGORY_ORDER.size() : bi;
-        if (ai != bi) return Integer.compare(ai, bi);
-        return String.valueOf(a).compareTo(String.valueOf(b));
-    }
-
     private int n(Integer value) {
         return value == null ? 0 : value;
     }
@@ -224,20 +187,6 @@ public class WarehouseInventoryService {
             Map<Long, Category> categoryById,
             Map<String, Category> categoryByCode
     ) {
-    }
-
-    @Builder
-    private static class ItemAccumulator {
-        private String itemCode;
-        private String parentCategory;
-        private String childCategory;
-        private String itemName;
-        private int actualStock;
-        private int availableStock;
-        private int safetyStock;
-        private Date updatedAt;
-        @Builder.Default
-        private Set<Long> skuIds = new HashSet<>();
     }
 
     private static class SkuAccumulator {

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseAggregateRow.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseAggregateRow.java
@@ -1,0 +1,16 @@
+package org.example.stockitbe.warehouse.inventory.model;
+
+import java.util.Date;
+
+// 창고 재고(품목 단위) 집계 페이지네이션 native @Query 결과 매핑용 interface projection
+public interface WarehouseAggregateRow {
+    String getItemCode();
+    String getItemName();
+    String getParentCategory();
+    String getChildCategory();
+    Integer getActualStock();
+    Integer getAvailableStock();
+    Integer getSafetyStock();
+    String getStatus();
+    Date getUpdatedAt();
+}

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseInventoryDto.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseInventoryDto.java
@@ -1,11 +1,42 @@
 package org.example.stockitbe.warehouse.inventory.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.util.Date;
+import java.util.List;
 
 public class WarehouseInventoryDto {
+
+    // 창고 재고 품목 페이지 응답 DTO
+    // 품목(상품코드) 단위 집계 결과 + 페이지 메타.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ItemPageRes {
+        private List<ItemRes> items;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        // 페이지 결과를 응답 DTO로 변환한다.
+        public static ItemPageRes from(Page<ItemRes> page) {
+            return ItemPageRes.builder()
+                    .items(page.getContent())
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
+    }
 
     // 창고 재고 품목 목록 응답 DTO
     // 품목(상품코드) 단위 집계 결과를 반환한다.


### PR DESCRIPTION
## 📌 요약
- 전사/창고 재고 조회 페이징 + 서버 필터 도입, 페이지당 SQL 호출 6→3개 + 인덱스 3개 추가

<br><br>

## 🎯 작업 내용
- 두 컨트롤러에 `@PageableDefault(size=20)` + 창고 query param (parentCategory/childCategory/status/keyword) 추가
- native `@Query` GROUP BY 로 itemCode 단위 페이징, 카테고리·집계·safetyStock 모두 SQL 안에서 처리 (메모리 lookup 4개 제거)
- `inventory(location_id, inventory_status)` / `product_master(category_code)` / `category(parent_id)` 인덱스 추가

<br><br>

## ✔️ 참고 사항
- 

<br><br>

## ✔️ 관련 이슈

- Close #285

<br><br>
