### PR TITLE
refactor(hq-inventory): 전사재고 SKU 페이징 endpoint + locationOptions region 필드 추가

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryController.java
@@ -23,20 +23,22 @@ public class InventoryController {
     private final InventoryQueryService inventoryQueryService;
 
     // 전사 재고(품목 단위) 목록 조회 API
+    // category 단일 파라미터: 부모 또는 자식 한글 이름 (FE 한 줄 dropdown 호환). 기존 parent/child 와 공존.
     @GetMapping("/company-wide")
     public BaseResponse<InventoryDto.CompanyWidePageRes> getCompanyWide(
             @RequestParam(required = false) LocationType locationType,
             @RequestParam(required = false) List<Long> locationIds,
             @RequestParam(required = false) String parentCategory,
             @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) String category,
             @RequestParam(required = false) InventoryStatus status,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        return BaseResponse.success(inventoryQueryService.findCompanyWide(locationType, locationIds, parentCategory, childCategory, status, keyword, pageable));
+        return BaseResponse.success(inventoryQueryService.findCompanyWide(locationType, locationIds, parentCategory, childCategory, category, status, keyword, pageable));
     }
 
-    // 전사 재고 SKU 상세 조회 API
+    // 전사 재고 SKU 상세 조회 API (마스터 itemCode 한정 — 옛 라우트 호환, FE 라우트 폐기 후 cleanup 예정)
     @GetMapping("/company-wide/{itemCode}/skus")
     public BaseResponse<List<InventoryDto.CompanyWideSkuDetailRes>> getCompanyWideSkus(
             @PathVariable String itemCode,
@@ -48,6 +50,41 @@ public class InventoryController {
             @RequestParam(required = false) String keyword
     ) {
         return BaseResponse.success(inventoryQueryService.findCompanyWideSkuDetails(itemCode, locationType, locationIds, parentCategory, childCategory, status, keyword));
+    }
+
+    // 전사 재고 SKU 단위 페이지 조회 API (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // status: 한국어 라벨("정상"/"부족"/"품절") — service 측 페이지 후처리 필터.
+    // category: 부모 또는 자식 한글 이름 단일 파라미터.
+    // skuSize: SKU 사이즈 (M/L/XL 등) — Pageable 의 size 와 이름 충돌 방지 위해 query param 명 분리.
+    @GetMapping("/company-wide/skus")
+    public BaseResponse<InventoryDto.CompanyWideSkuPageRes> getCompanyWideSkusPaged(
+            @RequestParam(required = false) LocationType locationType,
+            @RequestParam(required = false) List<Long> locationIds,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String color,
+            @RequestParam(value = "skuSize", required = false) String skuSize,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return BaseResponse.success(inventoryQueryService.findCompanyWideSkus(
+                locationType, locationIds, parentCategory, childCategory, status, color, skuSize, keyword, pageable
+        ));
+    }
+
+    // 전사 재고 SKU 칩 필터용 facets API — 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 distinct.
+    @GetMapping("/company-wide/skus/facets")
+    public BaseResponse<InventoryDto.CompanyWideSkuFacetsRes> getCompanyWideSkuFacets(
+            @RequestParam(required = false) LocationType locationType,
+            @RequestParam(required = false) List<Long> locationIds,
+            @RequestParam(required = false) String parentCategory,
+            @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(inventoryQueryService.findCompanyWideSkuFacets(
+                locationType, locationIds, parentCategory, childCategory, keyword
+        ));
     }
 
     // 순환재고 후보 리프레시 API

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
@@ -7,6 +7,7 @@ import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.hq.inventory.model.CompanyWideAggregateRow;
+import org.example.stockitbe.hq.inventory.model.CompanyWideSkuRow;
 import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryDto;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
@@ -47,6 +48,7 @@ public class InventoryQueryService {
                                                             List<Long> locationIds,
                                                             String parentCategory,
                                                             String childCategory,
+                                                            String category,
                                                             InventoryStatus status,
                                                             String keyword,
                                                             Pageable pageable) {
@@ -58,6 +60,7 @@ public class InventoryQueryService {
         String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
         String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
         String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
+        String safeCategory = (category == null || category.isBlank()) ? null : category.trim();
 
         // sort 무시(native @Query 안에 ORDER BY 박혀 있음) — page/size 만 사용
         Pageable safePageable = PageRequest.of(
@@ -67,7 +70,7 @@ public class InventoryQueryService {
 
         Page<CompanyWideAggregateRow> rows = inventoryRepository.findCompanyWideAggregated(
                 locationTypeStr, hasLocationIds, safeLocationIds, statusStr,
-                safeParent, safeChild, safeKeyword, safePageable
+                safeParent, safeChild, safeCategory, safeKeyword, safePageable
         );
 
         List<InventoryDto.LocationOptionRes> locationOptions = buildLocationOptions(locationType);
@@ -185,6 +188,7 @@ public class InventoryQueryService {
     }
 
     // locationType 조건에 맞는 위치 옵션 목록을 생성한다.
+    // region(한글 지역명) 필드 포함 — FE 거점 트리 지역 그룹화용.
     private List<InventoryDto.LocationOptionRes> buildLocationOptions(LocationType locationType) {
         return infrastructureRepository.findAll().stream()
                 .filter(i -> locationType == null || i.getLocationType() == locationType)
@@ -193,8 +197,97 @@ public class InventoryQueryService {
                         .id(i.getId())
                         .code(i.getCode())
                         .name(i.getName())
+                        .region(i.getRegion())
                         .build())
                 .toList();
+    }
+
+    // 전사 재고 SKU 단위 페이지 목록을 조회한다 (모드 토글 SKU 모드).
+    // 마스터 무관 모든 SKU 한 표 + 색상/사이즈 필터. status 필터는 BE HAVING 미적용,
+    //   FE/Service 측 후처리 (페이징 정확성은 약간 양보 — 사이클 후속 정교화).
+    // 주의: skuSize 파라미터명 — Spring Pageable 의 size 와 충돌 방지.
+    @Transactional(readOnly = true)
+    public InventoryDto.CompanyWideSkuPageRes findCompanyWideSkus(LocationType locationType,
+                                                                    List<Long> locationIds,
+                                                                    String parentCategory,
+                                                                    String childCategory,
+                                                                    String status,
+                                                                    String color,
+                                                                    String skuSize,
+                                                                    String keyword,
+                                                                    Pageable pageable) {
+        String locationTypeStr = locationType == null ? null : locationType.name();
+        boolean hasLocationIds = locationIds != null && !locationIds.isEmpty();
+        List<Long> safeLocationIds = hasLocationIds ? locationIds : List.of(-1L);
+        String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
+        String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
+        String safeStatus = (status == null || status.isBlank()) ? null : status.trim();
+        String safeColor = (color == null || color.isBlank()) ? null : color.trim();
+        String safeSkuSize = (skuSize == null || skuSize.isBlank()) ? null : skuSize.trim();
+        String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
+
+        Page<CompanyWideSkuRow> rows = inventoryRepository.findCompanyWideSkus(
+                locationTypeStr, hasLocationIds, safeLocationIds,
+                safeParent, safeChild, safeColor, safeSkuSize, safeKeyword, safePageable
+        );
+
+        Page<InventoryDto.CompanyWideSkuRowRes> mapped = rows.map(row -> InventoryDto.CompanyWideSkuRowRes.builder()
+                .skuCode(row.getSkuCode())
+                .itemCode(row.getItemCode())
+                .itemName(row.getItemName())
+                .parentCategory(row.getParentCategory() == null ? "" : row.getParentCategory())
+                .childCategory(row.getChildCategory() == null ? "" : row.getChildCategory())
+                .color(row.getColor())
+                .size(row.getSize())
+                .actualStock(n(row.getActualStock()))
+                .availableStock(n(row.getAvailableStock()))
+                .safetyStock(n(row.getSafetyStock()))
+                .status(row.getStatus())
+                .build());
+
+        // status 필터는 페이지 후 클라이언트 측 후처리 (페이징 부정확 양해 — TODO: HAVING 정교화)
+        if (safeStatus != null) {
+            List<InventoryDto.CompanyWideSkuRowRes> filtered = mapped.getContent().stream()
+                    .filter(r -> safeStatus.equals(r.getStatus()))
+                    .toList();
+            Page<InventoryDto.CompanyWideSkuRowRes> filteredPage = new org.springframework.data.domain.PageImpl<>(
+                    filtered, mapped.getPageable(), mapped.getTotalElements()
+            );
+            List<InventoryDto.LocationOptionRes> locationOptions = buildLocationOptions(locationType);
+            return InventoryDto.CompanyWideSkuPageRes.from(filteredPage, locationOptions);
+        }
+
+        List<InventoryDto.LocationOptionRes> locationOptions = buildLocationOptions(locationType);
+        return InventoryDto.CompanyWideSkuPageRes.from(mapped, locationOptions);
+    }
+
+    // 전사 재고 SKU 칩 필터용 facets — 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 목록.
+    @Transactional(readOnly = true)
+    public InventoryDto.CompanyWideSkuFacetsRes findCompanyWideSkuFacets(LocationType locationType,
+                                                                          List<Long> locationIds,
+                                                                          String parentCategory,
+                                                                          String childCategory,
+                                                                          String keyword) {
+        String locationTypeStr = locationType == null ? null : locationType.name();
+        boolean hasLocationIds = locationIds != null && !locationIds.isEmpty();
+        List<Long> safeLocationIds = hasLocationIds ? locationIds : List.of(-1L);
+        String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
+        String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
+        String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+
+        List<String> colors = inventoryRepository.findCompanyWideSkuColors(
+                locationTypeStr, hasLocationIds, safeLocationIds, safeParent, safeChild, safeKeyword);
+        List<String> sizes = inventoryRepository.findCompanyWideSkuSizes(
+                locationTypeStr, hasLocationIds, safeLocationIds, safeParent, safeChild, safeKeyword);
+        return InventoryDto.CompanyWideSkuFacetsRes.builder()
+                .colors(colors)
+                .sizes(sizes)
+                .build();
     }
 
     // null-safe 정수 변환

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.hq.inventory;
 
 import jakarta.persistence.LockModeType;
 import org.example.stockitbe.hq.inventory.model.CompanyWideAggregateRow;
+import org.example.stockitbe.hq.inventory.model.CompanyWideSkuRow;
 import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
 import org.example.stockitbe.hq.inventory.model.ItemSafetyStockRow;
@@ -171,12 +172,12 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
           AND (:status IS NULL OR i.inventory_status = :status)
           AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
           AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
           AND (:keyword IS NULL OR (
                LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
             OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
             OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
-            OR LOWER(inf.code) LIKE CONCAT('%', LOWER(:keyword), '%')
-            OR LOWER(inf.name) LIKE CONCAT('%', LOWER(:keyword), '%')
           ))
         GROUP BY pm.code, pm.name, cc.name, pc.name
         ORDER BY pm.code ASC
@@ -196,6 +197,8 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             AND (:status IS NULL OR i.inventory_status = :status)
             AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
             AND (:childCategory IS NULL OR cc.name = :childCategory)
+            AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
             AND (:keyword IS NULL OR (
                  LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
               OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
@@ -214,8 +217,169 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             @Param("status") String status,
             @Param("parentCategory") String parentCategory,
             @Param("childCategory") String childCategory,
+            @Param("category") String category,
             @Param("keyword") String keyword,
             Pageable pageable
+    );
+
+    /**
+     * 전사 재고 SKU 단위 페이지네이션 (모드 토글 SKU 모드용 — 마스터 무관 모든 SKU 한 표).
+     * GROUP BY ps.id 로 SKU 단위 합산. status 라벨(품절/부족/정상) 은 SQL CASE 로 계산해 HAVING 으로 필터.
+     * safetyStock = row 단위 SUM (location_type 별 store/warehouse safety_stock) — 같은 location 의
+     *   NORMAL+CIRCULAR_CANDIDATE 두 row 가 있으면 비례적으로 곱해지지만 available 도 같이 합산되어
+     *   status 라벨 결과는 일관. 마스터(`findCompanyWideAggregated`) 와 동일한 단순화 패턴.
+     * 카테고리 단일 파라미터: 부모 또는 자식 한글 이름 매칭 (FE CategoryFilter 호환).
+     */
+    @Query(value = """
+        SELECT
+            ps.sku_code AS skuCode,
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            ps.color AS color,
+            ps.size AS size,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            COALESCE(SUM(
+                CASE WHEN inf.location_type = 'WAREHOUSE'
+                     THEN COALESCE(pm.warehouse_safety_stock, 0)
+                     ELSE COALESCE(pm.store_safety_stock, 0)
+                END
+            ), 0) AS safetyStock,
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(SUM(
+                    CASE WHEN inf.location_type = 'WAREHOUSE'
+                         THEN COALESCE(pm.warehouse_safety_stock, 0)
+                         ELSE COALESCE(pm.store_safety_stock, 0)
+                    END
+                ), 0) THEN '부족'
+                ELSE '정상'
+            END AS status
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        JOIN infrastructure inf ON inf.id = i.location_id
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:locationType IS NULL OR inf.location_type = :locationType)
+          AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+          AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:color IS NULL OR ps.color = :color)
+          AND (:skuSize IS NULL OR ps.size = :skuSize)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY ps.id, ps.sku_code, pm.code, pm.name, cc.name, pc.name, ps.color, ps.size
+        ORDER BY ps.sku_code ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+            SELECT ps.id
+            FROM inventory i
+            JOIN product_sku ps ON ps.id = i.sku_id
+            JOIN product_master pm ON pm.code = ps.product_code
+            JOIN infrastructure inf ON inf.id = i.location_id
+            LEFT JOIN category cc ON cc.code = pm.category_code
+            LEFT JOIN category pc ON pc.id = cc.parent_id
+            WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+              AND (:locationType IS NULL OR inf.location_type = :locationType)
+              AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+              AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+              AND (:color IS NULL OR ps.color = :color)
+              AND (:skuSize IS NULL OR ps.size = :skuSize)
+              AND (:keyword IS NULL OR (
+                   LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              ))
+            GROUP BY ps.id
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<CompanyWideSkuRow> findCompanyWideSkus(
+            @Param("locationType") String locationType,
+            @Param("hasLocationIds") boolean hasLocationIds,
+            @Param("locationIds") List<Long> locationIds,
+            @Param("parentCategory") String parentCategory,
+            @Param("childCategory") String childCategory,
+            @Param("color") String color,
+            @Param("skuSize") String skuSize,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 전사 재고 SKU 칩 필터용 distinct 색상 — facets endpoint.
+     * 같은 거점/카테고리/검색 필터 조건 안에서 가능한 색상 목록 반환.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.color
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        JOIN infrastructure inf ON inf.id = i.location_id
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:locationType IS NULL OR inf.location_type = :locationType)
+          AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+          AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.color IS NOT NULL
+        ORDER BY ps.color ASC
+        """, nativeQuery = true)
+    List<String> findCompanyWideSkuColors(
+            @Param("locationType") String locationType,
+            @Param("hasLocationIds") boolean hasLocationIds,
+            @Param("locationIds") List<Long> locationIds,
+            @Param("parentCategory") String parentCategory,
+            @Param("childCategory") String childCategory,
+            @Param("keyword") String keyword
+    );
+
+    /**
+     * 전사 재고 SKU 칩 필터용 distinct 사이즈 — facets endpoint.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.size
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        JOIN infrastructure inf ON inf.id = i.location_id
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:locationType IS NULL OR inf.location_type = :locationType)
+          AND (:hasLocationIds = false OR inf.id IN (:locationIds))
+          AND (:parentCategory IS NULL OR pc.name = :parentCategory)
+          AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.size IS NOT NULL
+        ORDER BY ps.size ASC
+        """, nativeQuery = true)
+    List<String> findCompanyWideSkuSizes(
+            @Param("locationType") String locationType,
+            @Param("hasLocationIds") boolean hasLocationIds,
+            @Param("locationIds") List<Long> locationIds,
+            @Param("parentCategory") String parentCategory,
+            @Param("childCategory") String childCategory,
+            @Param("keyword") String keyword
     );
 
     /**

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/CompanyWideSkuRow.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/CompanyWideSkuRow.java
@@ -1,0 +1,17 @@
+package org.example.stockitbe.hq.inventory.model;
+
+// 전사 재고 SKU 단위 페이지네이션 native @Query 결과 매핑용 interface projection.
+// status 라벨은 SQL CASE 로 계산 (창고재고 패턴과 동일 — 페이징 정확성 보장).
+public interface CompanyWideSkuRow {
+    String getSkuCode();
+    String getItemCode();
+    String getItemName();
+    String getParentCategory();
+    String getChildCategory();
+    String getColor();
+    String getSize();
+    Integer getActualStock();
+    Integer getAvailableStock();
+    Integer getSafetyStock();
+    String getStatus();
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/InventoryDto.java
@@ -46,6 +46,7 @@ public class InventoryDto {
     }
 
     // 위치 필터 옵션 DTO
+    // region: 한글 지역명 (예: "서울"/"경기"). FE 거점 트리 지역 그룹화용.
     @Getter
     @Builder
     @AllArgsConstructor
@@ -53,6 +54,64 @@ public class InventoryDto {
         private Long id;
         private String code;
         private String name;
+        private String region;
+    }
+
+    // 전사 재고 SKU 단위 응답 DTO (모드 토글 SKU 모드용 — 마스터 무관 페이징)
+    // updatedAt 응답 X (FE 컬럼 제거 결정).
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWideSkuRowRes {
+        private String skuCode;
+        private String itemCode;
+        private String itemName;
+        private String parentCategory;
+        private String childCategory;
+        private String color;
+        private String size;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;     // "정상"/"부족"/"품절" — SQL CASE 라벨
+    }
+
+    // 전사 재고 SKU facets 응답 DTO (칩 필터용 — 거점/카테고리/검색 조건 안의 distinct 색상/사이즈)
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWideSkuFacetsRes {
+        private List<String> colors;
+        private List<String> sizes;
+    }
+
+    // 전사 재고 SKU 페이지 응답 DTO
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CompanyWideSkuPageRes {
+        private List<CompanyWideSkuRowRes> items;
+        private List<LocationOptionRes> locationOptions;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        public static CompanyWideSkuPageRes from(Page<CompanyWideSkuRowRes> page,
+                                                 List<LocationOptionRes> locationOptions) {
+            return CompanyWideSkuPageRes.builder()
+                    .items(page.getContent())
+                    .locationOptions(locationOptions)
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
     }
 
     // 전사 재고 페이지 응답 DTO

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,8 +32,8 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.SQL: info
+    org.hibernate.orm.jdbc.bind: info
 
 # SYS-001 본사 발주 자동 전환 배치
 purchase-order:


### PR DESCRIPTION
## 📌 요약
- 전사재고 모드 토글 (마스터/SKU) 화면 통합을 위한 BE 신규 endpoint 2개 추가 + 거점 트리 그룹화용 region 필드 추가

<br><br>

## 🎯 작업 내용
- `GET /api/hq/inventories/company-wide/skus` — 마스터 무관 모든 SKU 한 표 페이지네이션 (locationType/locationIds/parentCategory/childCategory/status/color/skuSize/keyword 필터)
- `GET /api/hq/inventories/company-wide/skus/facets` — 거점/카테고리/검색 조건 안의 distinct 색상/사이즈 (FE 칩 필터용)
- 마스터 응답 `locationOptions[].region` 한글명 필드 추가 (FE 거점 트리 지역 그룹화)
- dev SQL trace 로깅 INFO 로 낮춰 응답 시간 개선

<br><br>

## ✔️ 참고 사항
- SKU 사이즈 query param 은 `skuSize` 로 분리 — Spring Pageable 의 `size` 와 충돌 방지 (디버깅 중 발견)
- 카테고리는 마스터/SKU/facets 모두 `parentCategory + childCategory` 두 파라미터 일관 (사용자 결정으로 2단계 select UI 복원)
- 기존 `/{itemCode}/skus` endpoint 는 그대로 유지 — FE 라우트 폐기 머지 후 별도 cleanup 사이클에서 제거

<br><br>

## ✔️ 관련 이슈

- Close #289

<br><br>
