### PR TITLE
refactor(warehouse-inventory): SKU 페이징 endpoint + facets + 마스터 category 단일 파라미터

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -7,6 +7,7 @@ import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
 import org.example.stockitbe.hq.inventory.model.ItemSafetyStockRow;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseAggregateRow;
+import org.example.stockitbe.warehouse.inventory.model.WarehouseSkuRow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Lock;
@@ -421,7 +422,9 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
      * 단일 창고(locationId) 기준, GROUP BY product_master.code.
      * safetyStock = COUNT(DISTINCT sku_id) * pm.warehouse_safety_stock 으로 SQL 단계 계산.
      * status UI 라벨(품절/부족/정상) 도 SQL CASE 로 계산해 HAVING 으로 필터.
+     * category 단일 파라미터: 부모/자식 한글 이름 매칭 (FE 호환). parentCategory/childCategory 와 공존.
      * 정렬 = 메인 카테고리 우선순위 (상의/바지/치마/아우터) + childCategory + itemName.
+     * updatedAt 응답 X (운영 추적용 DB 컬럼은 유지).
      */
     @Query(value = """
         SELECT
@@ -438,8 +441,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
                      (COUNT(DISTINCT i.sku_id) * COALESCE(pm.warehouse_safety_stock, 0))
                   THEN '부족'
                 ELSE '정상'
-            END AS status,
-            MAX(i.update_date) AS updatedAt
+            END AS status
         FROM inventory i
         JOIN product_sku ps ON ps.id = i.sku_id
         JOIN product_master pm ON pm.code = ps.product_code
@@ -449,6 +451,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
           AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
           AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
           AND (:childCategory IS NULL OR cc.name = :childCategory)
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
           AND (:keyword IS NULL OR (
                LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
             OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
@@ -487,6 +490,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
             AND (:parentCategory IS NULL OR COALESCE(pc.name, cc.name) = :parentCategory)
             AND (:childCategory IS NULL OR cc.name = :childCategory)
+            AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
             AND (:keyword IS NULL OR (
                  LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
               OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
@@ -509,8 +513,152 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             @Param("locationId") Long locationId,
             @Param("parentCategory") String parentCategory,
             @Param("childCategory") String childCategory,
+            @Param("category") String category,
             @Param("status") String status,
             @Param("keyword") String keyword,
             Pageable pageable
+    );
+
+    /**
+     * 창고 재고 SKU 단위 페이지네이션 (모드 토글 SKU 모드용 — 마스터 무관 모든 SKU 한 표).
+     * 단일 창고(locationId) 기준, GROUP BY ps.id.
+     * safetyStock = pm.warehouse_safety_stock (창고 단일이라 row 단위 SUM 불필요 — sku 마다 1 row).
+     * status UI 라벨(품절/부족/정상) 은 SQL CASE 로 계산해 HAVING 으로 필터.
+     * 카테고리 단일 파라미터: 부모 또는 자식 한글 이름 매칭 (FE CategoryFilter 호환).
+     */
+    @Query(value = """
+        SELECT
+            ps.sku_code AS skuCode,
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            ps.color AS color,
+            ps.size AS size,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            COALESCE(pm.warehouse_safety_stock, 0) AS safetyStock,
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.warehouse_safety_stock, 0) THEN '부족'
+                ELSE '정상'
+            END AS status
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:color IS NULL OR ps.color = :color)
+          AND (:skuSize IS NULL OR ps.size = :skuSize)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY ps.id, ps.sku_code, pm.code, pm.name, pm.warehouse_safety_stock, cc.name, pc.name, ps.color, ps.size
+        HAVING (:status IS NULL OR (
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.warehouse_safety_stock, 0) THEN '부족'
+                ELSE '정상'
+            END
+        ) = :status)
+        ORDER BY ps.sku_code ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+            SELECT ps.id
+            FROM inventory i
+            JOIN product_sku ps ON ps.id = i.sku_id
+            JOIN product_master pm ON pm.code = ps.product_code
+            LEFT JOIN category cc ON cc.code = pm.category_code
+            LEFT JOIN category pc ON pc.id = cc.parent_id
+            WHERE i.location_id = :locationId
+              AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+              AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+              AND (:color IS NULL OR ps.color = :color)
+              AND (:skuSize IS NULL OR ps.size = :skuSize)
+              AND (:keyword IS NULL OR (
+                   LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              ))
+            GROUP BY ps.id, pm.warehouse_safety_stock
+            HAVING (:status IS NULL OR (
+                CASE
+                    WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                    WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.warehouse_safety_stock, 0) THEN '부족'
+                    ELSE '정상'
+                END
+            ) = :status)
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<WarehouseSkuRow> findWarehouseSkus(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("status") String status,
+            @Param("color") String color,
+            @Param("skuSize") String skuSize,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 창고 재고 SKU 칩 필터용 distinct 색상 — facets endpoint.
+     * 같은 거점/카테고리/검색 필터 조건 안에서 가능한 색상 목록 반환.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.color
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.color IS NOT NULL
+        ORDER BY ps.color ASC
+        """, nativeQuery = true)
+    List<String> findWarehouseSkuColors(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("keyword") String keyword
+    );
+
+    /**
+     * 창고 재고 SKU 칩 필터용 distinct 사이즈 — facets endpoint.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.size
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.size IS NOT NULL
+        ORDER BY ps.size ASC
+        """, nativeQuery = true)
+    List<String> findWarehouseSkuSizes(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("keyword") String keyword
     );
 }

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryController.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryController.java
@@ -25,21 +25,54 @@ public class WarehouseInventoryController {
     private final WarehouseInventoryService service;
 
     // 창고 재고 품목 목록 조회 API
+    // category 단일 파라미터: 부모 또는 자식 한글 이름 (FE 한 줄 dropdown 호환). 기존 parent/child 와 공존.
     @GetMapping
     public BaseResponse<WarehouseInventoryDto.ItemPageRes> getWarehouseInventories(
             @AuthenticationPrincipal AuthUserDetails me,
             @RequestParam(required = false) String parentCategory,
             @RequestParam(required = false) String childCategory,
+            @RequestParam(required = false) String category,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         return BaseResponse.success(service.getItems(
-                me.getLocationCode(), parentCategory, childCategory, status, keyword, pageable
+                me.getLocationCode(), parentCategory, childCategory, category, status, keyword, pageable
         ));
     }
 
-    // 창고 재고 SKU 목록 조회 API
+    // 창고 재고 SKU 단위 페이지 조회 API (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // status: 한국어 라벨("정상"/"부족"/"품절") — SQL HAVING 으로 필터.
+    // category: 부모 또는 자식 한글 이름 단일 파라미터.
+    // skuSize: SKU 사이즈 (M/L/XL 등) — Pageable 의 size 와 이름 충돌 방지 위해 query param 명 분리.
+    @GetMapping("/skus")
+    public BaseResponse<WarehouseInventoryDto.SkuPageRes> getSkus(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String color,
+            @RequestParam(value = "skuSize", required = false) String skuSize,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return BaseResponse.success(service.findSkus(
+                me.getLocationCode(), category, status, color, skuSize, keyword, pageable
+        ));
+    }
+
+    // 창고 재고 SKU 칩 필터용 facets API — 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 distinct.
+    @GetMapping("/skus/facets")
+    public BaseResponse<WarehouseInventoryDto.SkuFacetsRes> getSkuFacets(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(service.findSkuFacets(
+                me.getLocationCode(), category, keyword
+        ));
+    }
+
+    // 창고 재고 SKU 목록 조회 API (옛 라우트 — FE 라우트 폐기 후 cleanup 예정)
     // 지정 품목(itemCode) 내 SKU 단위 재고를 반환한다.
     @GetMapping("/{itemCode}/skus")
     public BaseResponse<List<WarehouseInventoryDto.SkuRes>> getWarehouseInventorySkus(

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/WarehouseInventoryService.java
@@ -17,6 +17,7 @@ import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseAggregateRow;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseInventoryDto;
+import org.example.stockitbe.warehouse.inventory.model.WarehouseSkuRow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -42,14 +43,16 @@ public class WarehouseInventoryService {
     public WarehouseInventoryDto.ItemPageRes getItems(String locationCode,
                                                       String parentCategory,
                                                       String childCategory,
+                                                      String category,
                                                       String status,
                                                       String keyword,
                                                       Pageable pageable) {
         Infrastructure warehouse = resolveWarehouse(locationCode);
-        String safeParent = (parentCategory == null || parentCategory.isBlank()) ? null : parentCategory.trim();
-        String safeChild = (childCategory == null || childCategory.isBlank()) ? null : childCategory.trim();
-        String safeStatus = (status == null || status.isBlank()) ? null : status.trim();
-        String safeKeyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+        String safeParent = blankToNull(parentCategory);
+        String safeChild = blankToNull(childCategory);
+        String safeCategory = blankToNull(category);
+        String safeStatus = blankToNull(status);
+        String safeKeyword = blankToNull(keyword);
 
         // sort 무시(native @Query 안에 ORDER BY 박혀 있음) — page/size 만 사용
         Pageable safePageable = PageRequest.of(
@@ -58,7 +61,7 @@ public class WarehouseInventoryService {
         );
 
         Page<WarehouseAggregateRow> rows = inventoryRepository.findWarehouseAggregated(
-                warehouse.getId(), safeParent, safeChild, safeStatus, safeKeyword, safePageable
+                warehouse.getId(), safeParent, safeChild, safeCategory, safeStatus, safeKeyword, safePageable
         );
 
         Page<WarehouseInventoryDto.ItemRes> mapped = rows.map(row -> WarehouseInventoryDto.ItemRes.from(
@@ -69,15 +72,70 @@ public class WarehouseInventoryService {
                 n(row.getActualStock()),
                 n(row.getAvailableStock()),
                 n(row.getSafetyStock()),
-                row.getStatus(),
-                row.getUpdatedAt()
+                row.getStatus()
         ));
 
         return WarehouseInventoryDto.ItemPageRes.from(mapped);
     }
 
-    // 창고 재고 SKU 목록 조회
-    // 선택 품목(itemCode) 내 SKU 단위 재고를 조회한다.
+    // 창고 재고 SKU 단위 페이지 조회 (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // GROUP BY ps.id 로 SKU 단위 합산, status HAVING 으로 필터.
+    @Transactional(readOnly = true)
+    public WarehouseInventoryDto.SkuPageRes findSkus(String locationCode,
+                                                     String category,
+                                                     String status,
+                                                     String color,
+                                                     String skuSize,
+                                                     String keyword,
+                                                     Pageable pageable) {
+        Infrastructure warehouse = resolveWarehouse(locationCode);
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
+
+        Page<WarehouseSkuRow> rows = inventoryRepository.findWarehouseSkus(
+                warehouse.getId(),
+                blankToNull(category),
+                blankToNull(status),
+                blankToNull(color),
+                blankToNull(skuSize),
+                blankToNull(keyword),
+                safePageable
+        );
+
+        Page<WarehouseInventoryDto.SkuRowRes> mapped = rows.map(row -> WarehouseInventoryDto.SkuRowRes.from(
+                row.getSkuCode(),
+                row.getItemCode(),
+                row.getItemName(),
+                row.getParentCategory(),
+                row.getChildCategory(),
+                row.getColor(),
+                row.getSize(),
+                n(row.getActualStock()),
+                n(row.getAvailableStock()),
+                n(row.getSafetyStock()),
+                row.getStatus()
+        ));
+
+        return WarehouseInventoryDto.SkuPageRes.from(mapped);
+    }
+
+    // 창고 재고 SKU 칩 필터 facets — 같은 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 distinct.
+    @Transactional(readOnly = true)
+    public WarehouseInventoryDto.SkuFacetsRes findSkuFacets(String locationCode,
+                                                            String category,
+                                                            String keyword) {
+        Infrastructure warehouse = resolveWarehouse(locationCode);
+        String safeCategory = blankToNull(category);
+        String safeKeyword = blankToNull(keyword);
+        List<String> colors = inventoryRepository.findWarehouseSkuColors(warehouse.getId(), safeCategory, safeKeyword);
+        List<String> sizes = inventoryRepository.findWarehouseSkuSizes(warehouse.getId(), safeCategory, safeKeyword);
+        return new WarehouseInventoryDto.SkuFacetsRes(colors, sizes);
+    }
+
+    // 창고 재고 SKU 목록 조회 (옛 /{itemCode}/skus 라우트 호환용)
+    // 선택 품목(itemCode) 내 SKU 단위 재고를 조회한다. FE 라우트 폐기 PR 머지 후 cleanup 예정.
     @Transactional(readOnly = true)
     public List<WarehouseInventoryDto.SkuRes> getItemSkus(String locationCode, String itemCode) {
         Infrastructure warehouse = resolveWarehouse(locationCode);
@@ -179,6 +237,10 @@ public class WarehouseInventoryService {
 
     private int n(Integer value) {
         return value == null ? 0 : value;
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value.trim();
     }
 
     private record Context(

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseInventoryDto.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseInventoryDto.java
@@ -39,7 +39,7 @@ public class WarehouseInventoryDto {
     }
 
     // 창고 재고 품목 목록 응답 DTO
-    // 품목(상품코드) 단위 집계 결과를 반환한다.
+    // 품목(상품코드) 단위 집계 결과를 반환한다. updatedAt 은 응답에서 제외 (운영 추적용 DB 컬럼은 유지).
     @Getter
     @Builder
     public static class ItemRes {
@@ -51,7 +51,6 @@ public class WarehouseInventoryDto {
         private Integer availableStock;
         private Integer safetyStock;
         private String status;
-        private Date updatedAt;
 
         // 품목 집계 필드를 응답 DTO로 변환한다.
         public static ItemRes from(String itemCode,
@@ -61,8 +60,7 @@ public class WarehouseInventoryDto {
                                    int actualStock,
                                    int availableStock,
                                    int safetyStock,
-                                   String status,
-                                   Date updatedAt) {
+                                   String status) {
             return ItemRes.builder()
                     .itemCode(itemCode)
                     .parentCategory(parentCategory)
@@ -72,12 +70,11 @@ public class WarehouseInventoryDto {
                     .availableStock(availableStock)
                     .safetyStock(safetyStock)
                     .status(status)
-                    .updatedAt(updatedAt)
                     .build();
         }
     }
 
-    // 창고 재고 SKU 목록 응답 DTO
+    // 창고 재고 SKU 목록 응답 DTO (옛 /{itemCode}/skus 라우트 호환용 — FE 라우트 폐기 후 cleanup 예정)
     // 선택 품목 내 SKU 단위 집계 결과를 반환한다.
     @Getter
     @Builder
@@ -111,5 +108,84 @@ public class WarehouseInventoryDto {
                     .updatedAt(updatedAt)
                     .build();
         }
+    }
+
+    // 창고 재고 SKU 단위 페이지 응답 DTO (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // updatedAt 응답 X (전사재고 SKU 와 동일 정책).
+    @Getter
+    @Builder
+    public static class SkuRowRes {
+        private String skuCode;
+        private String itemCode;
+        private String itemName;
+        private String parentCategory;
+        private String childCategory;
+        private String color;
+        private String size;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+
+        public static SkuRowRes from(String skuCode,
+                                     String itemCode,
+                                     String itemName,
+                                     String parentCategory,
+                                     String childCategory,
+                                     String color,
+                                     String size,
+                                     int actualStock,
+                                     int availableStock,
+                                     int safetyStock,
+                                     String status) {
+            return SkuRowRes.builder()
+                    .skuCode(skuCode)
+                    .itemCode(itemCode)
+                    .itemName(itemName)
+                    .parentCategory(parentCategory)
+                    .childCategory(childCategory)
+                    .color(color)
+                    .size(size)
+                    .actualStock(actualStock)
+                    .availableStock(availableStock)
+                    .safetyStock(safetyStock)
+                    .status(status)
+                    .build();
+        }
+    }
+
+    // SKU 페이지 응답 DTO + 페이지 메타.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class SkuPageRes {
+        private List<SkuRowRes> items;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        public static SkuPageRes from(Page<SkuRowRes> page) {
+            return SkuPageRes.builder()
+                    .items(page.getContent())
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
+    }
+
+    // SKU 칩 필터용 facets 응답 DTO — 같은 거점/카테고리/검색 필터 조건 안에서 가능한 색상/사이즈 distinct.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class SkuFacetsRes {
+        private List<String> colors;
+        private List<String> sizes;
     }
 }

--- a/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseSkuRow.java
+++ b/src/main/java/org/example/stockitbe/warehouse/inventory/model/WarehouseSkuRow.java
@@ -1,11 +1,14 @@
 package org.example.stockitbe.warehouse.inventory.model;
 
-// 창고 재고(품목 단위) 집계 페이지네이션 native @Query 결과 매핑용 interface projection
-public interface WarehouseAggregateRow {
+// 창고 재고 SKU 단위 페이지네이션 native @Query 결과 매핑용 interface projection
+public interface WarehouseSkuRow {
+    String getSkuCode();
     String getItemCode();
     String getItemName();
     String getParentCategory();
     String getChildCategory();
+    String getColor();
+    String getSize();
     Integer getActualStock();
     Integer getAvailableStock();
     Integer getSafetyStock();


### PR DESCRIPTION
﻿## 📌 요약
창고재고 화면 모드 토글 + 마스터/SKU 통합을 위한 SKU 페이징 endpoint 신설 + 마스터 카테고리 단일 파라미터 통일.

## 🎯 작업 내용
- 신규 `GET /api/warehouse/inventories/skus` (페이징 + status HAVING + 색상/사이즈/검색)
- 신규 `GET /api/warehouse/inventories/skus/facets` (SKU 칩 필터용 distinct 색상/사이즈)
- 마스터 endpoint 에 `category` 단일 파라미터 추가 (parent/child 와 공존)
- `ItemRes` 응답에서 `updatedAt` 제거 (DB 컬럼은 운영 추적용 보존)
- `skuSize` 키로 SKU 사이즈 전송 (Pageable `size` 충돌 방지, 전사재고 패턴 동일)
- 옛 `GET /{itemCode}/skus` 보존 (FE 라우트 폐기 PR 머지 후 cleanup)

## ✔️ 참고 사항
- 

## ✔️ 관련 이슈
- Close #293
