### PR TITLE
refactor(store-inventory): 매장재고 페이징 + SKU 페이징 endpoint 신설

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -6,6 +6,8 @@ import org.example.stockitbe.hq.inventory.model.CompanyWideSkuRow;
 import org.example.stockitbe.hq.inventory.model.Inventory;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
 import org.example.stockitbe.hq.inventory.model.ItemSafetyStockRow;
+import org.example.stockitbe.store.inventory.model.StoreItemRow;
+import org.example.stockitbe.store.inventory.model.StoreSkuRow;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseAggregateRow;
 import org.example.stockitbe.warehouse.inventory.model.WarehouseSkuRow;
 import org.springframework.data.domain.Page;
@@ -657,6 +659,246 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
         ORDER BY ps.size ASC
         """, nativeQuery = true)
     List<String> findWarehouseSkuSizes(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("keyword") String keyword
+    );
+
+    /**
+     * 매장 재고(품목 단위) 집계 페이지네이션.
+     * 단일 매장(locationId) 기준, GROUP BY product_master.code.
+     * safetyStock = COUNT(DISTINCT sku_id) * pm.store_safety_stock 으로 SQL 단계 계산 (창고 패턴 차용 — pm.warehouse_safety_stock 만 store_safety_stock 으로 교체).
+     * status UI 라벨(품절/부족/정상) 도 SQL CASE 로 계산해 HAVING 으로 필터.
+     * category 단일 파라미터: 부모/자식 한글 이름 매칭 (FE 호환).
+     * 정렬 = 메인 카테고리 우선순위 (상의/바지/치마/아우터) + childCategory + itemName.
+     * updatedAt 응답 X (운영 추적용 DB 컬럼은 유지).
+     */
+    @Query(value = """
+        SELECT
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            (COUNT(DISTINCT i.sku_id) * COALESCE(pm.store_safety_stock, 0)) AS safetyStock,
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) <
+                     (COUNT(DISTINCT i.sku_id) * COALESCE(pm.store_safety_stock, 0))
+                  THEN '부족'
+                ELSE '정상'
+            END AS status
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:keyword IS NULL OR (
+               LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY pm.code, pm.name, pm.store_safety_stock, cc.name, pc.name
+        HAVING (:status IS NULL OR (
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) <
+                     (COUNT(DISTINCT i.sku_id) * COALESCE(pm.store_safety_stock, 0))
+                  THEN '부족'
+                ELSE '정상'
+            END
+        ) = :status)
+        ORDER BY
+            CASE COALESCE(pc.name, cc.name)
+                WHEN '상의' THEN 1
+                WHEN '바지' THEN 2
+                WHEN '치마' THEN 3
+                WHEN '아우터' THEN 4
+                ELSE 5
+            END ASC,
+            cc.name ASC,
+            pm.name ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+          SELECT pm.code
+          FROM inventory i
+          JOIN product_sku ps ON ps.id = i.sku_id
+          JOIN product_master pm ON pm.code = ps.product_code
+          LEFT JOIN category cc ON cc.code = pm.category_code
+          LEFT JOIN category pc ON pc.id = cc.parent_id
+          WHERE i.location_id = :locationId
+            AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+            AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+            AND (:keyword IS NULL OR (
+                 LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              OR LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            ))
+          GROUP BY pm.code, pm.store_safety_stock
+          HAVING (:status IS NULL OR (
+              CASE
+                  WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                  WHEN COALESCE(SUM(i.available_quantity), 0) <
+                       (COUNT(DISTINCT i.sku_id) * COALESCE(pm.store_safety_stock, 0))
+                    THEN '부족'
+                  ELSE '정상'
+              END
+          ) = :status)
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<StoreItemRow> findStoreAggregated(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("status") String status,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 매장 재고 SKU 단위 페이지네이션 (모드 토글 SKU 모드용 — 마스터 무관 모든 SKU 한 표).
+     * 단일 매장(locationId) 기준, GROUP BY ps.id.
+     * safetyStock = pm.store_safety_stock (매장 단일이라 row 단위 SUM 불필요 — sku 마다 1 row).
+     * status UI 라벨(품절/부족/정상) 은 SQL CASE 로 계산해 HAVING 으로 필터.
+     * 카테고리 단일 파라미터: 부모 또는 자식 한글 이름 매칭 (FE CategoryFilter 호환).
+     * skuSize 파라미터명 — Spring Pageable size 와 충돌 방지.
+     */
+    @Query(value = """
+        SELECT
+            ps.sku_code AS skuCode,
+            pm.code AS itemCode,
+            pm.name AS itemName,
+            COALESCE(pc.name, cc.name) AS parentCategory,
+            cc.name AS childCategory,
+            ps.color AS color,
+            ps.size AS size,
+            COALESCE(SUM(i.quantity), 0) AS actualStock,
+            COALESCE(SUM(i.available_quantity), 0) AS availableStock,
+            COALESCE(pm.store_safety_stock, 0) AS safetyStock,
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.store_safety_stock, 0) THEN '부족'
+                ELSE '정상'
+            END AS status
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:color IS NULL OR ps.color = :color)
+          AND (:skuSize IS NULL OR ps.size = :skuSize)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+        GROUP BY ps.id, ps.sku_code, pm.code, pm.name, pm.store_safety_stock, cc.name, pc.name, ps.color, ps.size
+        HAVING (:status IS NULL OR (
+            CASE
+                WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.store_safety_stock, 0) THEN '부족'
+                ELSE '정상'
+            END
+        ) = :status)
+        ORDER BY ps.sku_code ASC
+        """,
+        countQuery = """
+        SELECT COUNT(*) FROM (
+            SELECT ps.id
+            FROM inventory i
+            JOIN product_sku ps ON ps.id = i.sku_id
+            JOIN product_master pm ON pm.code = ps.product_code
+            LEFT JOIN category cc ON cc.code = pm.category_code
+            LEFT JOIN category pc ON pc.id = cc.parent_id
+            WHERE i.location_id = :locationId
+              AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+              AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+              AND (:color IS NULL OR ps.color = :color)
+              AND (:skuSize IS NULL OR ps.size = :skuSize)
+              AND (:keyword IS NULL OR (
+                   LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+                OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+              ))
+            GROUP BY ps.id, pm.store_safety_stock
+            HAVING (:status IS NULL OR (
+                CASE
+                    WHEN COALESCE(SUM(i.available_quantity), 0) <= 0 THEN '품절'
+                    WHEN COALESCE(SUM(i.available_quantity), 0) < COALESCE(pm.store_safety_stock, 0) THEN '부족'
+                    ELSE '정상'
+                END
+            ) = :status)
+        ) sub
+        """,
+        nativeQuery = true)
+    Page<StoreSkuRow> findStoreSkus(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("status") String status,
+            @Param("color") String color,
+            @Param("skuSize") String skuSize,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    /**
+     * 매장 재고 SKU 칩 필터용 distinct 색상 — facets endpoint.
+     * 같은 거점/카테고리/검색 필터 조건 안에서 가능한 색상 목록 반환.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.color
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.color IS NOT NULL
+        ORDER BY ps.color ASC
+        """, nativeQuery = true)
+    List<String> findStoreSkuColors(
+            @Param("locationId") Long locationId,
+            @Param("category") String category,
+            @Param("keyword") String keyword
+    );
+
+    /**
+     * 매장 재고 SKU 칩 필터용 distinct 사이즈 — facets endpoint.
+     */
+    @Query(value = """
+        SELECT DISTINCT ps.size
+        FROM inventory i
+        JOIN product_sku ps ON ps.id = i.sku_id
+        JOIN product_master pm ON pm.code = ps.product_code
+        LEFT JOIN category cc ON cc.code = pm.category_code
+        LEFT JOIN category pc ON pc.id = cc.parent_id
+        WHERE i.location_id = :locationId
+          AND i.inventory_status IN ('NORMAL', 'CIRCULAR_CANDIDATE')
+          AND (:category IS NULL OR pc.name = :category OR cc.name = :category)
+          AND (:keyword IS NULL OR (
+               LOWER(ps.sku_code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.code) LIKE CONCAT('%', LOWER(:keyword), '%')
+            OR LOWER(pm.name) LIKE CONCAT('%', LOWER(:keyword), '%')
+          ))
+          AND ps.size IS NOT NULL
+        ORDER BY ps.size ASC
+        """, nativeQuery = true)
+    List<String> findStoreSkuSizes(
             @Param("locationId") Long locationId,
             @Param("category") String category,
             @Param("keyword") String keyword

--- a/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryController.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryController.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.store.inventory.model.StoreInventoryDto;
 import org.example.stockitbe.user.model.AuthUserDetails;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,15 +24,53 @@ public class StoreInventoryController {
 
     private final StoreInventoryService service;
 
-    // 매장 재고 품목 목록 조회 API
+    // 매장 재고 품목 페이지 조회 API
+    // category 단일 파라미터: 부모 또는 자식 한글 이름 (FE 한 줄 dropdown 호환).
     @GetMapping
-    public BaseResponse<List<StoreInventoryDto.ItemRes>> getStoreInventories(
-            @AuthenticationPrincipal AuthUserDetails me
+    public BaseResponse<StoreInventoryDto.ItemPageRes> getStoreInventories(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        return BaseResponse.success(service.getItems(me.getLocationCode()));
+        return BaseResponse.success(service.getItems(
+                me.getLocationCode(), category, status, keyword, pageable
+        ));
     }
 
-    // 매장 재고 SKU 목록 조회 API
+    // 매장 재고 SKU 단위 페이지 조회 API (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // status: 한국어 라벨("정상"/"부족"/"품절") — SQL HAVING 으로 필터.
+    // category: 부모 또는 자식 한글 이름 단일 파라미터.
+    // skuSize: SKU 사이즈 (M/L/XL 등) — Pageable 의 size 와 이름 충돌 방지 위해 query param 명 분리.
+    @GetMapping("/skus")
+    public BaseResponse<StoreInventoryDto.SkuPageRes> getSkus(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String color,
+            @RequestParam(value = "skuSize", required = false) String skuSize,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return BaseResponse.success(service.findSkus(
+                me.getLocationCode(), category, status, color, skuSize, keyword, pageable
+        ));
+    }
+
+    // 매장 재고 SKU 칩 필터용 facets API — 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 distinct.
+    @GetMapping("/skus/facets")
+    public BaseResponse<StoreInventoryDto.SkuFacetsRes> getSkuFacets(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String keyword
+    ) {
+        return BaseResponse.success(service.findSkuFacets(
+                me.getLocationCode(), category, keyword
+        ));
+    }
+
+    // 매장 재고 SKU 목록 조회 API (옛 라우트 — FE 라우트 폐기 후 cleanup 예정)
     // 지정 품목(itemCode) 내 SKU 단위 재고를 반환한다.
     @GetMapping("/{itemCode}/skus")
     public BaseResponse<List<StoreInventoryDto.SkuRes>> getStoreInventorySkus(

--- a/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryService.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/StoreInventoryService.java
@@ -1,6 +1,5 @@
 package org.example.stockitbe.store.inventory;
 
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
@@ -17,6 +16,11 @@ import org.example.stockitbe.hq.product.ProductSkuRepository;
 import org.example.stockitbe.hq.product.model.ProductMaster;
 import org.example.stockitbe.hq.product.model.ProductSku;
 import org.example.stockitbe.store.inventory.model.StoreInventoryDto;
+import org.example.stockitbe.store.inventory.model.StoreItemRow;
+import org.example.stockitbe.store.inventory.model.StoreSkuRow;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +30,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class StoreInventoryService {
-    private static final List<String> MAIN_CATEGORY_ORDER = List.of("상의", "바지", "치마", "아우터");
 
     private final InfrastructureRepository infrastructureRepository;
     private final InventoryRepository inventoryRepository;
@@ -34,76 +37,100 @@ public class StoreInventoryService {
     private final ProductMasterRepository productMasterRepository;
     private final CategoryRepository categoryRepository;
 
-    // 매장 재고 품목 목록 조회
-    // 품목 단위로 실재고/가용재고/안전재고를 집계해 반환한다.
+    // 매장 재고 품목 페이지 목록 조회
+    // 품목 단위로 실재고/가용재고/안전재고를 native @Query GROUP BY 로 집계 + LIMIT/OFFSET.
     @Transactional(readOnly = true)
-    public List<StoreInventoryDto.ItemRes> getItems(String locationCode) {
+    public StoreInventoryDto.ItemPageRes getItems(String locationCode,
+                                                   String category,
+                                                   String status,
+                                                   String keyword,
+                                                   Pageable pageable) {
         Infrastructure store = resolveStore(locationCode);
-        List<Inventory> inventories = inventoryRepository.findAllByLocationId(store.getId());
-        if (inventories.isEmpty()) {
-            return List.of();
-        }
+        String safeCategory = blankToNull(category);
+        String safeStatus = blankToNull(status);
+        String safeKeyword = blankToNull(keyword);
 
-        Context context = buildContext(inventories);
-        Map<String, ItemAccumulator> grouped = new HashMap<>();
+        // sort 무시(native @Query 안에 ORDER BY 박혀 있음) — page/size 만 사용
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
 
-        for (Inventory inventory : inventories) {
-            if (!InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.contains(inventory.getInventoryStatus())) continue;
-            ProductSku sku = context.skuById.get(inventory.getSkuId());
-            if (sku == null) continue;
+        Page<StoreItemRow> rows = inventoryRepository.findStoreAggregated(
+                store.getId(), safeCategory, safeStatus, safeKeyword, safePageable
+        );
 
-            ProductMaster master = context.masterByCode.get(sku.getProductCode());
-            if (master == null) continue;
+        Page<StoreInventoryDto.ItemRes> mapped = rows.map(row -> StoreInventoryDto.ItemRes.from(
+                row.getItemCode(),
+                row.getParentCategory(),
+                row.getChildCategory(),
+                row.getItemName(),
+                n(row.getActualStock()),
+                n(row.getAvailableStock()),
+                n(row.getSafetyStock()),
+                row.getStatus()
+        ));
 
-            Category child = context.categoryByCode.get(master.getCategoryCode());
-            if (child == null) continue;
-
-            Category parent = child.getParentId() == null ? child : context.categoryById.get(child.getParentId());
-            String parentCategory = parent == null ? child.getName() : parent.getName();
-            String childCategory = child.getName();
-            String itemCode = master.getCode();
-
-            ItemAccumulator acc = grouped.computeIfAbsent(itemCode, key -> ItemAccumulator.builder()
-                    .itemCode(itemCode)
-                    .parentCategory(parentCategory)
-                    .childCategory(childCategory)
-                    .itemName(master.getName())
-                    .actualStock(0)
-                    .availableStock(0)
-                    .safetyStock(0)
-                    .updatedAt(inventory.getUpdatedAt())
-                    .build());
-
-            acc.actualStock += n(inventory.getQuantity());
-            acc.availableStock += n(inventory.getAvailableQuantity());
-            acc.skuIds.add(sku.getId());
-            if (acc.updatedAt == null || (inventory.getUpdatedAt() != null && inventory.getUpdatedAt().after(acc.updatedAt))) {
-                acc.updatedAt = inventory.getUpdatedAt();
-            }
-        }
-
-        grouped.values().forEach(acc -> acc.safetyStock = acc.skuIds.size() * n(context.masterByCode.get(acc.itemCode).getStoreSafetyStock()));
-
-        return grouped.values().stream()
-                .map(acc -> StoreInventoryDto.ItemRes.from(
-                        acc.itemCode,
-                        acc.parentCategory,
-                        acc.childCategory,
-                        acc.itemName,
-                        acc.actualStock,
-                        acc.availableStock,
-                        acc.safetyStock,
-                        resolveStatus(acc.actualStock, acc.safetyStock),
-                        acc.updatedAt
-                ))
-                .sorted(Comparator
-                        .comparing(StoreInventoryDto.ItemRes::getParentCategory, this::compareMainCategory)
-                        .thenComparing(StoreInventoryDto.ItemRes::getChildCategory, Comparator.nullsLast(String::compareTo))
-                        .thenComparing(StoreInventoryDto.ItemRes::getItemName, Comparator.nullsLast(String::compareTo)))
-                .toList();
+        return StoreInventoryDto.ItemPageRes.from(mapped);
     }
 
-    // 매장 재고 SKU 목록 조회
+    // 매장 재고 SKU 단위 페이지 조회 (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // GROUP BY ps.id 로 SKU 단위 합산, status HAVING 으로 필터.
+    @Transactional(readOnly = true)
+    public StoreInventoryDto.SkuPageRes findSkus(String locationCode,
+                                                  String category,
+                                                  String status,
+                                                  String color,
+                                                  String skuSize,
+                                                  String keyword,
+                                                  Pageable pageable) {
+        Infrastructure store = resolveStore(locationCode);
+        Pageable safePageable = PageRequest.of(
+                Math.max(pageable.getPageNumber(), 0),
+                Math.max(pageable.getPageSize(), 1)
+        );
+
+        Page<StoreSkuRow> rows = inventoryRepository.findStoreSkus(
+                store.getId(),
+                blankToNull(category),
+                blankToNull(status),
+                blankToNull(color),
+                blankToNull(skuSize),
+                blankToNull(keyword),
+                safePageable
+        );
+
+        Page<StoreInventoryDto.SkuRowRes> mapped = rows.map(row -> StoreInventoryDto.SkuRowRes.from(
+                row.getSkuCode(),
+                row.getItemCode(),
+                row.getItemName(),
+                row.getParentCategory(),
+                row.getChildCategory(),
+                row.getColor(),
+                row.getSize(),
+                n(row.getActualStock()),
+                n(row.getAvailableStock()),
+                n(row.getSafetyStock()),
+                row.getStatus()
+        ));
+
+        return StoreInventoryDto.SkuPageRes.from(mapped);
+    }
+
+    // 매장 재고 SKU 칩 필터 facets — 같은 거점/카테고리/검색 조건 안의 가능한 색상/사이즈 distinct.
+    @Transactional(readOnly = true)
+    public StoreInventoryDto.SkuFacetsRes findSkuFacets(String locationCode,
+                                                         String category,
+                                                         String keyword) {
+        Infrastructure store = resolveStore(locationCode);
+        String safeCategory = blankToNull(category);
+        String safeKeyword = blankToNull(keyword);
+        List<String> colors = inventoryRepository.findStoreSkuColors(store.getId(), safeCategory, safeKeyword);
+        List<String> sizes = inventoryRepository.findStoreSkuSizes(store.getId(), safeCategory, safeKeyword);
+        return new StoreInventoryDto.SkuFacetsRes(colors, sizes);
+    }
+
+    // 매장 재고 SKU 목록 조회 (옛 /{itemCode}/skus 라우트 호환용 — FE 라우트 폐기 PR 머지 후 cleanup 예정)
     // 선택 품목(itemCode) 내 SKU 단위 재고를 조회한다.
     @Transactional(readOnly = true)
     public List<StoreInventoryDto.SkuRes> getItemSkus(String locationCode, String itemCode) {
@@ -154,12 +181,7 @@ public class StoreInventoryService {
         ProductMaster master = context.masterByCode.get(sku.getProductCode());
         if (master == null) return null;
 
-        Category child = context.categoryByCode.get(master.getCategoryCode());
-        if (child == null) return null;
-
-        String resolvedItemCode = master.getCode();
-
-        if (!Objects.equals(resolvedItemCode, itemCode)) {
+        if (!Objects.equals(master.getCode(), itemCode)) {
             return null;
         }
 
@@ -209,18 +231,12 @@ public class StoreInventoryService {
         return "정상";
     }
 
-    // 메인 카테고리 우선순위 기준으로 정렬 순서를 계산한다.
-    private int compareMainCategory(String a, String b) {
-        int ai = MAIN_CATEGORY_ORDER.indexOf(a);
-        int bi = MAIN_CATEGORY_ORDER.indexOf(b);
-        ai = ai < 0 ? MAIN_CATEGORY_ORDER.size() : ai;
-        bi = bi < 0 ? MAIN_CATEGORY_ORDER.size() : bi;
-        if (ai != bi) return Integer.compare(ai, bi);
-        return String.valueOf(a).compareTo(String.valueOf(b));
-    }
-
     private int n(Integer value) {
         return value == null ? 0 : value;
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value.trim();
     }
 
     private record Context(
@@ -229,20 +245,6 @@ public class StoreInventoryService {
             Map<Long, Category> categoryById,
             Map<String, Category> categoryByCode
     ) {
-    }
-
-    @Builder
-    private static class ItemAccumulator {
-        private String itemCode;
-        private String parentCategory;
-        private String childCategory;
-        private String itemName;
-        private int actualStock;
-        private int availableStock;
-        private int safetyStock;
-        private Date updatedAt;
-        @Builder.Default
-        private Set<Long> skuIds = new HashSet<>();
     }
 
     private static class SkuAccumulator {
@@ -254,7 +256,7 @@ public class StoreInventoryService {
         private int availableStock = 0;
         private Date updatedAt;
 
-        private SkuAccumulator(String skuCode, String color, String size, int safetyStock, Date updatedAt) {
+        SkuAccumulator(String skuCode, String color, String size, int safetyStock, Date updatedAt) {
             this.skuCode = skuCode;
             this.color = color;
             this.size = size;

--- a/src/main/java/org/example/stockitbe/store/inventory/model/StoreInventoryDto.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/model/StoreInventoryDto.java
@@ -1,14 +1,44 @@
 package org.example.stockitbe.store.inventory.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.util.Date;
+import java.util.List;
 
 public class StoreInventoryDto {
 
+    // 매장 재고 품목 페이지 응답 DTO
+    // 품목(상품코드) 단위 집계 결과 + 페이지 메타.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ItemPageRes {
+        private List<ItemRes> items;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        public static ItemPageRes from(Page<ItemRes> page) {
+            return ItemPageRes.builder()
+                    .items(page.getContent())
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
+    }
+
     // 매장 재고 품목 목록 응답 DTO
-    // 품목(상품코드) 단위 집계 결과를 반환한다.
+    // 품목(상품코드) 단위 집계 결과를 반환한다. updatedAt 은 응답에서 제외 (운영 추적용 DB 컬럼은 유지).
     @Getter
     @Builder
     public static class ItemRes {
@@ -20,7 +50,6 @@ public class StoreInventoryDto {
         private Integer availableStock;
         private Integer safetyStock;
         private String status;
-        private Date updatedAt;
 
         // 품목 집계 필드를 응답 DTO로 변환한다.
         public static ItemRes from(String itemCode,
@@ -30,8 +59,7 @@ public class StoreInventoryDto {
                                    int actualStock,
                                    int availableStock,
                                    int safetyStock,
-                                   String status,
-                                   Date updatedAt) {
+                                   String status) {
             return ItemRes.builder()
                     .itemCode(itemCode)
                     .parentCategory(parentCategory)
@@ -41,12 +69,11 @@ public class StoreInventoryDto {
                     .availableStock(availableStock)
                     .safetyStock(safetyStock)
                     .status(status)
-                    .updatedAt(updatedAt)
                     .build();
         }
     }
 
-    // 매장 재고 SKU 목록 응답 DTO
+    // 매장 재고 SKU 목록 응답 DTO (옛 /{itemCode}/skus 라우트 호환용 — FE 라우트 폐기 후 cleanup 예정)
     // 선택 품목 내 SKU 단위 집계 결과를 반환한다.
     @Getter
     @Builder
@@ -80,5 +107,84 @@ public class StoreInventoryDto {
                     .updatedAt(updatedAt)
                     .build();
         }
+    }
+
+    // 매장 재고 SKU 단위 페이지 응답 DTO (모드 토글 SKU 모드 — 마스터 무관 모든 SKU 한 표).
+    // updatedAt 응답 X (전사/창고재고 SKU 와 동일 정책).
+    @Getter
+    @Builder
+    public static class SkuRowRes {
+        private String skuCode;
+        private String itemCode;
+        private String itemName;
+        private String parentCategory;
+        private String childCategory;
+        private String color;
+        private String size;
+        private Integer actualStock;
+        private Integer availableStock;
+        private Integer safetyStock;
+        private String status;
+
+        public static SkuRowRes from(String skuCode,
+                                     String itemCode,
+                                     String itemName,
+                                     String parentCategory,
+                                     String childCategory,
+                                     String color,
+                                     String size,
+                                     int actualStock,
+                                     int availableStock,
+                                     int safetyStock,
+                                     String status) {
+            return SkuRowRes.builder()
+                    .skuCode(skuCode)
+                    .itemCode(itemCode)
+                    .itemName(itemName)
+                    .parentCategory(parentCategory)
+                    .childCategory(childCategory)
+                    .color(color)
+                    .size(size)
+                    .actualStock(actualStock)
+                    .availableStock(availableStock)
+                    .safetyStock(safetyStock)
+                    .status(status)
+                    .build();
+        }
+    }
+
+    // SKU 페이지 응답 DTO + 페이지 메타.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class SkuPageRes {
+        private List<SkuRowRes> items;
+        private Integer page;
+        private Integer size;
+        private Long totalElements;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        public static SkuPageRes from(Page<SkuRowRes> page) {
+            return SkuPageRes.builder()
+                    .items(page.getContent())
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
+    }
+
+    // SKU 칩 필터용 facets 응답 DTO — 같은 거점/카테고리/검색 필터 조건 안에서 가능한 색상/사이즈 distinct.
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class SkuFacetsRes {
+        private List<String> colors;
+        private List<String> sizes;
     }
 }

--- a/src/main/java/org/example/stockitbe/store/inventory/model/StoreItemRow.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/model/StoreItemRow.java
@@ -1,0 +1,13 @@
+package org.example.stockitbe.store.inventory.model;
+
+// 매장 재고(품목 단위) 집계 페이지네이션 native @Query 결과 매핑용 interface projection
+public interface StoreItemRow {
+    String getItemCode();
+    String getItemName();
+    String getParentCategory();
+    String getChildCategory();
+    Integer getActualStock();
+    Integer getAvailableStock();
+    Integer getSafetyStock();
+    String getStatus();
+}

--- a/src/main/java/org/example/stockitbe/store/inventory/model/StoreSkuRow.java
+++ b/src/main/java/org/example/stockitbe/store/inventory/model/StoreSkuRow.java
@@ -1,0 +1,16 @@
+package org.example.stockitbe.store.inventory.model;
+
+// 매장 재고 SKU 단위 페이지네이션 native @Query 결과 매핑용 interface projection
+public interface StoreSkuRow {
+    String getSkuCode();
+    String getItemCode();
+    String getItemName();
+    String getParentCategory();
+    String getChildCategory();
+    String getColor();
+    String getSize();
+    Integer getActualStock();
+    Integer getAvailableStock();
+    Integer getSafetyStock();
+    String getStatus();
+}


### PR DESCRIPTION
﻿## 📌 요약

> 📌 변경의 핵심 내용을 1~2줄로 적어주세요.<br><br>

매장 재고 마스터 endpoint 페이징 + 모드 토글 SKU 모드용 신규 `/skus` + `/skus/facets` 신설 — 전사/창고와 동일 패턴 통일.

## 🎯 작업 내용

> 🎯 어떤 변경이 있었는지 항목별로 정리해주세요.<br><br>

- `GET /api/store/inventories` 페이지 응답(`ItemPageRes`) + `category`/`status`/`keyword` 필터 + `Pageable` 도입
- 신규 `GET /api/store/inventories/skus` (마스터 무관 모든 SKU 한 표) + `?color`/`?skuSize` 필터 (Pageable size 충돌 방지 위해 `skuSize` 키)
- 신규 `GET /api/store/inventories/skus/facets` — 같은 거점/카테고리/검색 조건 안의 색상·사이즈 distinct
- `InventoryRepository` 에 `findStoreAggregated`/`findStoreSkus`/`findStoreSkuColors`/`findStoreSkuSizes` 4개 native @Query (status 라벨 SQL HAVING)
- `ItemRes` 응답에서 `updatedAt` 제거 (DB 컬럼은 유지). 옛 `/{itemCode}/skus` 는 FE 라우트 폐기 후 cleanup 까지 보존

## ✔️ 참고 사항

> 사이드 이펙트, 테스트 범위, 추가 확인 사항 등이 있으면 작성해주세요.<br><br>

-

## ✔️ 관련 이슈

> 관련 이슈 번호를 적어주세요. (예: Close #1)<br><br>

- Close #291
