### PR TITLE
feat: 본사관리자 순환재고 거래처 기능 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerController.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerDto;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,6 +23,22 @@ public class CircularBuyerController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String materialFit) {
         return BaseResponse.success(service.findAll(keyword, materialFit));
+    }
+
+    @GetMapping("/stats")
+    public BaseResponse<Map<String, Long>> stats() {
+        return BaseResponse.success(service.countByMaterialFit());
+    }
+
+    @GetMapping("/page")
+    public BaseResponse<CircularBuyerDto.PageRes> page(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String materialFit,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.min(Math.max(size, 1), 200);
+        return BaseResponse.success(service.findPage(keyword, materialFit, PageRequest.of(safePage, safeSize)));
     }
 
     @GetMapping("/{code}")

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerController.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerController.java
@@ -21,8 +21,9 @@ public class CircularBuyerController {
     @GetMapping
     public BaseResponse<List<CircularBuyerDto.ListRes>> list(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) String materialFit) {
-        return BaseResponse.success(service.findAll(keyword, materialFit));
+            @RequestParam(required = false) String materialFit,
+            @RequestParam(required = false) String partnerType) {
+        return BaseResponse.success(service.findAll(keyword, materialFit, partnerType));
     }
 
     @GetMapping("/stats")
@@ -34,11 +35,12 @@ public class CircularBuyerController {
     public BaseResponse<CircularBuyerDto.PageRes> page(
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String materialFit,
+            @RequestParam(required = false) String partnerType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         int safePage = Math.max(page, 0);
         int safeSize = Math.min(Math.max(size, 1), 200);
-        return BaseResponse.success(service.findPage(keyword, materialFit, PageRequest.of(safePage, safeSize)));
+        return BaseResponse.success(service.findPage(keyword, materialFit, partnerType, PageRequest.of(safePage, safeSize)));
     }
 
     @GetMapping("/{code}")

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerEmbeddingService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerEmbeddingService.java
@@ -28,16 +28,16 @@ public class CircularBuyerEmbeddingService {
      * 의미 필드를 합쳐 임베딩 입력 텍스트 빌드. null 안전 (null 필드는 빈 문자열).
      */
     public String buildEmbeddingText(CircularBuyer v) {
-        String productTypes = v.getProductTypes() != null
-                ? String.join(",", v.getProductTypes())
+        String factoryProduct = v.getFactoryProduct() != null
+                ? String.join(",", v.getFactoryProduct())
                 : "";
         return String.join(" ",
                 safe(v.getCompanyName()),
                 safe(v.getIndustryGroup()),
-                productTypes,
-                safe(v.getProductNote()),
+                factoryProduct,
                 safe(v.getDescription()),
-                safe(v.getPrimaryMaterialFit())
+                safe(v.getPrimaryMaterialFit()),
+                safe(v.getAddress())
         ).trim();
     }
 

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
@@ -241,7 +241,7 @@ public class CircularBuyerRecommendService {
         sb.append("  2) 요청 재고와 매칭되는 구체적 이유 (소재 일치·처리 방식 적합성·산업군 부합)\n");
         sb.append("  3) 처리 후 재활용 경로 (어떤 산업·제품으로 환생되는지 — 자동차 흡음재·건설 단열재·재생 원사·펄프·매트리스 충전 등)\n");
         sb.append("  4) 친환경·순환경제 가치 (ESG 효과·탄소 감축·자원 순환)\n");
-        sb.append("- 거래처 description·메모·취급 품목에 등장하는 구체 어휘를 적극 활용해 사실 기반으로 작성.\n");
+        sb.append("- 거래처 description·주소·취급 품목에 등장하는 구체 어휘를 적극 활용해 사실 기반으로 작성.\n");
         sb.append("- '적합한 거래처입니다' 같은 추상적 칭찬·불필요한 인사말·서론 금지 — 바로 본론.\n");
         sb.append("- 한국어 자연어 매끄러운 문장, 각 문장은 마침표로 종료.\n");
         sb.append("- JSON 안에 줄바꿈(\\n) 넣지 말고 한 문단으로 이어 써 (UI 가 자연스럽게 줄바꿈 처리).\n\n");
@@ -258,10 +258,10 @@ public class CircularBuyerRecommendService {
             sb.append(i + 1).append(". code=").append(b.getCode())
                     .append(" / 회사=").append(b.getCompanyName())
                     .append(" / 산업군=").append(safe(b.getIndustryGroup()));
-            if (b.getProductTypes() != null && !b.getProductTypes().isEmpty()) {
-                sb.append(" / 취급=").append(String.join(",", b.getProductTypes()));
+            if (b.getFactoryProduct() != null && !b.getFactoryProduct().isEmpty()) {
+                sb.append(" / 취급=").append(String.join(",", b.getFactoryProduct()));
             }
-            if (b.getProductNote() != null) sb.append(" / 메모=").append(b.getProductNote());
+            if (b.getAddress() != null) sb.append(" / 주소=").append(b.getAddress());
             if (b.getDescription() != null) sb.append(" / 설명=").append(b.getDescription());
             sb.append("\n");
         }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
@@ -46,11 +46,14 @@ public class CircularBuyerService {
     private static final int FIND_ALL_HARD_LIMIT = 500;
 
     @Transactional(readOnly = true)
-    public List<CircularBuyerDto.ListRes> findAll(String keyword, String materialFit) {
+    public List<CircularBuyerDto.ListRes> findAll(String keyword, String materialFit, String partnerType) {
         if (materialFit != null && !materialFit.isBlank()) {
             validateMaterialFit(materialFit);
         }
-        Specification<CircularBuyer> spec = buildSpec(keyword, materialFit, true);
+        if (partnerType != null && !partnerType.isBlank()) {
+            validatePartnerType(partnerType);
+        }
+        Specification<CircularBuyer> spec = buildSpec(keyword, materialFit, partnerType, true);
         Page<CircularBuyer> page = circularBuyerRepository.findAll(spec, PageRequest.of(0, FIND_ALL_HARD_LIMIT));
         return page.getContent().stream()
                 .map(CircularBuyerDto.ListRes::from)
@@ -58,16 +61,20 @@ public class CircularBuyerService {
     }
 
     @Transactional(readOnly = true)
-    public CircularBuyerDto.PageRes findPage(String keyword, String materialFit, Pageable pageable) {
+    public CircularBuyerDto.PageRes findPage(String keyword, String materialFit, String partnerType, Pageable pageable) {
         if (materialFit != null && !materialFit.isBlank()) {
             validateMaterialFit(materialFit);
+        }
+        if (partnerType != null && !partnerType.isBlank()) {
+            validatePartnerType(partnerType);
         }
         // embedding 컬럼 제외 JPQL 프로젝션 사용 — 행당 ~23KB JSON 역직렬화 방지.
         String kw = (keyword != null && !keyword.isBlank())
                 ? "%" + keyword.trim().toLowerCase() + "%"
                 : null;
         String mf = (materialFit != null && !materialFit.isBlank()) ? materialFit : null;
-        Page<CircularBuyerListView> page = circularBuyerRepository.findPageWithoutEmbedding(kw, mf, pageable);
+        String pt = (partnerType != null && !partnerType.isBlank()) ? partnerType : null;
+        Page<CircularBuyerListView> page = circularBuyerRepository.findPageWithoutEmbedding(kw, mf, pt, pageable);
         return CircularBuyerDto.PageRes.builder()
                 .content(page.getContent().stream().map(this::fromView).toList())
                 .page(page.getNumber())
@@ -234,10 +241,10 @@ public class CircularBuyerService {
     }
 
     /**
-     * 동적 필터 — keyword(companyName/code/managerName 부분일치 OR) + primaryMaterialFit equal.
+     * 동적 필터 — keyword(companyName/code/managerName 부분일치 OR) + primaryMaterialFit equal + partnerType equal.
      * 정렬: companyName ASC.
      */
-    private Specification<CircularBuyer> buildSpec(String keyword, String materialFit, boolean sortByCompanyName) {
+    private Specification<CircularBuyer> buildSpec(String keyword, String materialFit, String partnerType, boolean sortByCompanyName) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
@@ -250,6 +257,9 @@ public class CircularBuyerService {
             }
             if (materialFit != null && !materialFit.isBlank()) {
                 predicates.add(cb.equal(root.get("primaryMaterialFit"), materialFit));
+            }
+            if (partnerType != null && !partnerType.isBlank()) {
+                predicates.add(cb.equal(root.get("partnerType"), partnerType));
             }
             if (sortByCompanyName) {
                 query.orderBy(cb.asc(root.get("companyName")));

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
@@ -106,12 +106,12 @@ public class CircularBuyerService {
         v.updateProfile(
                 req.getCompanyName(),
                 req.getIndustryGroup(),
-                req.getProductTypes(),
-                req.getProductNote(),
+                req.getFactoryProduct(),
                 req.getDescription(),
                 req.getPrimaryMaterialFit(),
                 req.getManagerName(),
                 req.getPhone(),
+                req.getAddress(),
                 req.getPartnerType()
         );
         // ADR-021 — 의미 필드 중 하나라도 변경된 경우에만 임베딩 재생성. managerName/phone 만 바뀌면 OpenAI 콜 절약.
@@ -162,9 +162,9 @@ public class CircularBuyerService {
         return changed(v.getCompanyName(), req.getCompanyName())
                 || changed(v.getIndustryGroup(), req.getIndustryGroup())
                 || changed(v.getPrimaryMaterialFit(), req.getPrimaryMaterialFit())
-                || changed(v.getProductNote(), req.getProductNote())
+                || changed(v.getAddress(), req.getAddress())
                 || changed(v.getDescription(), req.getDescription())
-                || listChanged(v.getProductTypes(), req.getProductTypes());
+                || listChanged(v.getFactoryProduct(), req.getFactoryProduct());
     }
 
     private static boolean changed(String oldValue, String newValue) {

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
@@ -6,8 +6,11 @@ import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerDto;
+import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerListView;
 import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerRepository;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -15,8 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,21 +36,62 @@ public class CircularBuyerService {
     );
 
     private static final String CODE_PREFIX = "RCV-";
-    private static final int CODE_NUMBER_WIDTH = 3;
-    private static final int CODE_NUMBER_MAX = 999;
+    private static final int CODE_NUMBER_WIDTH = 5;
+    private static final int CODE_NUMBER_MAX = 99_999_999;
 
     private final CircularBuyerRepository circularBuyerRepository;
     private final CircularBuyerEmbeddingService embeddingService;
+
+    // 4만 건+ 환경에서 페이지 없는 전체 조회는 응답 불가 수준의 부하. 최대 500건으로 제한.
+    private static final int FIND_ALL_HARD_LIMIT = 500;
 
     @Transactional(readOnly = true)
     public List<CircularBuyerDto.ListRes> findAll(String keyword, String materialFit) {
         if (materialFit != null && !materialFit.isBlank()) {
             validateMaterialFit(materialFit);
         }
-        Specification<CircularBuyer> spec = buildSpec(keyword, materialFit);
-        return circularBuyerRepository.findAll(spec).stream()
+        Specification<CircularBuyer> spec = buildSpec(keyword, materialFit, true);
+        Page<CircularBuyer> page = circularBuyerRepository.findAll(spec, PageRequest.of(0, FIND_ALL_HARD_LIMIT));
+        return page.getContent().stream()
                 .map(CircularBuyerDto.ListRes::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CircularBuyerDto.PageRes findPage(String keyword, String materialFit, Pageable pageable) {
+        if (materialFit != null && !materialFit.isBlank()) {
+            validateMaterialFit(materialFit);
+        }
+        // embedding 컬럼 제외 JPQL 프로젝션 사용 — 행당 ~23KB JSON 역직렬화 방지.
+        String kw = (keyword != null && !keyword.isBlank())
+                ? "%" + keyword.trim().toLowerCase() + "%"
+                : null;
+        String mf = (materialFit != null && !materialFit.isBlank()) ? materialFit : null;
+        Page<CircularBuyerListView> page = circularBuyerRepository.findPageWithoutEmbedding(kw, mf, pageable);
+        return CircularBuyerDto.PageRes.builder()
+                .content(page.getContent().stream().map(this::fromView).toList())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+
+    private CircularBuyerDto.ListRes fromView(CircularBuyerListView v) {
+        return CircularBuyerDto.ListRes.builder()
+                .code(v.getCode())
+                .companyName(v.getCompanyName())
+                .industryGroup(v.getIndustryGroup())
+                .factoryProduct(v.getFactoryProduct())
+                .description(v.getDescription())
+                .primaryMaterialFit(v.getPrimaryMaterialFit())
+                .managerName(v.getManagerName())
+                .phone(v.getPhone())
+                .address(v.getAddress())
+                .partnerType(v.getPartnerType())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -72,7 +118,7 @@ public class CircularBuyerService {
     }
 
     /**
-     * 자동 코드 부여 — RCV-{NNN} 3자리 zero-padded.
+     * 자동 코드 부여 — RCV-{NNNNN} 5자리 zero-padded.
      * PESSIMISTIC_WRITE 로 마지막 row 락을 잡아 동시 등록 시 한 트랜잭션이 끝날 때까지 다른 트랜잭션 대기.
      */
     private String nextCircularBuyerCode() {
@@ -125,6 +171,16 @@ public class CircularBuyerService {
     public void delete(String code) {
         CircularBuyer v = lookup(code);
         circularBuyerRepository.delete(v);
+    }
+
+    /** primaryMaterialFit 별 전체 건수 — 통계 카드용. */
+    @Transactional(readOnly = true)
+    public Map<String, Long> countByMaterialFit() {
+        return circularBuyerRepository.countGroupByMaterialFit().stream()
+                .collect(Collectors.toMap(
+                        v -> v.getMaterialFit() != null ? v.getMaterialFit() : "unknown",
+                        v -> v.getCount() != null ? v.getCount() : 0L
+                ));
     }
 
     /**
@@ -181,7 +237,7 @@ public class CircularBuyerService {
      * 동적 필터 — keyword(companyName/code/managerName 부분일치 OR) + primaryMaterialFit equal.
      * 정렬: companyName ASC.
      */
-    private Specification<CircularBuyer> buildSpec(String keyword, String materialFit) {
+    private Specification<CircularBuyer> buildSpec(String keyword, String materialFit, boolean sortByCompanyName) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
@@ -195,7 +251,9 @@ public class CircularBuyerService {
             if (materialFit != null && !materialFit.isBlank()) {
                 predicates.add(cb.equal(root.get("primaryMaterialFit"), materialFit));
             }
-            query.orderBy(cb.asc(root.get("companyName")));
+            if (sortByCompanyName) {
+                query.orderBy(cb.asc(root.get("companyName")));
+            }
             return cb.and(predicates.toArray(new Predicate[0]));
         };
     }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyer.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyer.java
@@ -35,11 +35,8 @@ public class CircularBuyer extends BaseEntity {
 
     // 생산품 키워드 배열 — JSON 컬럼 (정규화 X, 검색 빈도 낮음)
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "product_types", columnDefinition = "json")
-    private List<String> productTypes;
-
-    @Column(name = "product_note", columnDefinition = "TEXT")
-    private String productNote;
+    @Column(name = "factory_product", columnDefinition = "json")
+    private List<String> factoryProduct;
 
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
@@ -54,6 +51,9 @@ public class CircularBuyer extends BaseEntity {
     @Column(name = "phone", nullable = false, length = 32)
     private String phone;
 
+    @Column(name = "address", nullable = false, length = 256)
+    private String address;
+
     // 파트너 유형 — local_small / social_enterprise / general. 점수 가산 룰은 사이클 3 (거래 이력 합류 후) 에서.
     @Column(name = "partner_type", nullable = false, length = 32)
     @ColumnDefault("'general'")
@@ -66,38 +66,38 @@ public class CircularBuyer extends BaseEntity {
 
     @Builder
     private CircularBuyer(String code, String companyName, String industryGroup,
-                           List<String> productTypes, String productNote, String description,
+                           List<String> factoryProduct, String description,
                            String primaryMaterialFit, String managerName, String phone,
-                           String partnerType, List<Double> embedding) {
+                           String address, String partnerType, List<Double> embedding) {
         this.code = code;
         this.companyName = companyName;
         this.industryGroup = industryGroup;
-        this.productTypes = productTypes;
-        this.productNote = productNote;
+        this.factoryProduct = factoryProduct;
         this.description = description;
         this.primaryMaterialFit = primaryMaterialFit;
         this.managerName = managerName;
         this.phone = phone;
+        this.address = address;
         this.partnerType = partnerType;
         this.embedding = embedding;
     }
 
     /**
      * 거래처 정보 수정. embedding 은 별도 메소드.
-     * 의미 필드(companyName/industryGroup/productTypes/productNote/description/primaryMaterialFit) 변경 시 임베딩 재생성 룰은 Service 책임.
+     * 의미 필드(companyName/industryGroup/factoryProduct/description/primaryMaterialFit/address) 변경 시 임베딩 재생성 룰은 Service 책임.
      * partnerType 은 의미 필드가 아님 — 임베딩 재생성 트리거 X.
      */
-    public void updateProfile(String companyName, String industryGroup, List<String> productTypes,
-                               String productNote, String description, String primaryMaterialFit,
-                               String managerName, String phone, String partnerType) {
+    public void updateProfile(String companyName, String industryGroup, List<String> factoryProduct,
+                              String description, String primaryMaterialFit,
+                              String managerName, String phone, String address, String partnerType) {
         if (companyName != null) this.companyName = companyName;
         if (industryGroup != null) this.industryGroup = industryGroup;
-        if (productTypes != null) this.productTypes = productTypes;
-        if (productNote != null) this.productNote = productNote;
+        if (factoryProduct != null) this.factoryProduct = factoryProduct;
         if (description != null) this.description = description;
         if (primaryMaterialFit != null) this.primaryMaterialFit = primaryMaterialFit;
         if (managerName != null) this.managerName = managerName;
         if (phone != null) this.phone = phone;
+        if (address != null) this.address = address;
         if (partnerType != null) this.partnerType = partnerType;
     }
 

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyer.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyer.java
@@ -54,6 +54,12 @@ public class CircularBuyer extends BaseEntity {
     @Column(name = "address", nullable = false, length = 256)
     private String address;
 
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
     // 파트너 유형 — local_small / social_enterprise / general. 점수 가산 룰은 사이클 3 (거래 이력 합류 후) 에서.
     @Column(name = "partner_type", nullable = false, length = 32)
     @ColumnDefault("'general'")
@@ -68,7 +74,8 @@ public class CircularBuyer extends BaseEntity {
     private CircularBuyer(String code, String companyName, String industryGroup,
                            List<String> factoryProduct, String description,
                            String primaryMaterialFit, String managerName, String phone,
-                           String address, String partnerType, List<Double> embedding) {
+                           String address, Double latitude, Double longitude,
+                           String partnerType, List<Double> embedding) {
         this.code = code;
         this.companyName = companyName;
         this.industryGroup = industryGroup;
@@ -78,6 +85,8 @@ public class CircularBuyer extends BaseEntity {
         this.managerName = managerName;
         this.phone = phone;
         this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.partnerType = partnerType;
         this.embedding = embedding;
     }
@@ -103,5 +112,10 @@ public class CircularBuyer extends BaseEntity {
 
     public void updateEmbedding(List<Double> embedding) {
         this.embedding = embedding;
+    }
+
+    public void updateCoordinates(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
@@ -108,6 +108,19 @@ public class CircularBuyerDto {
         }
     }
 
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class PageRes {
+        private List<ListRes> content;
+        private int page;
+        private int size;
+        private int totalPages;
+        private long totalElements;
+        private boolean hasNext;
+        private boolean hasPrevious;
+    }
+
     /**
      * ADR-021 추천 입력 — 옵션 B (사용자 결정 2026-04-30):
      *   materialFit (필수, 1층 SQL 룰 키) + productName + description + quantityHint.

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
@@ -1,5 +1,7 @@
 package org.example.stockitbe.hq.circularbuyer.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,8 +22,8 @@ public class CircularBuyerDto {
         private String companyName;
         @NotBlank
         private String industryGroup;
-        private List<String> productTypes;
-        private String productNote;
+        @JsonAlias("productTypes")
+        private List<String> factoryProduct;
         private String description;
         @NotBlank
         private String primaryMaterialFit;
@@ -30,6 +32,8 @@ public class CircularBuyerDto {
         @NotBlank
         private String phone;
         @NotBlank
+        private String address;
+        @NotBlank
         private String partnerType;
 
         public CircularBuyer toEntity(String code) {
@@ -37,12 +41,12 @@ public class CircularBuyerDto {
                     .code(code)
                     .companyName(this.companyName)
                     .industryGroup(this.industryGroup)
-                    .productTypes(this.productTypes)
-                    .productNote(this.productNote)
+                    .factoryProduct(this.factoryProduct)
                     .description(this.description)
                     .primaryMaterialFit(this.primaryMaterialFit)
                     .managerName(this.managerName)
                     .phone(this.phone)
+                    .address(this.address)
                     .partnerType(this.partnerType)
                     .build();
         }
@@ -55,12 +59,13 @@ public class CircularBuyerDto {
     public static class UpdateReq {
         private String companyName;
         private String industryGroup;
-        private List<String> productTypes;
-        private String productNote;
+        @JsonAlias("productTypes")
+        private List<String> factoryProduct;
         private String description;
         private String primaryMaterialFit;
         private String managerName;
         private String phone;
+        private String address;
         private String partnerType;
     }
 
@@ -71,27 +76,33 @@ public class CircularBuyerDto {
         private String code;
         private String companyName;
         private String industryGroup;
-        private List<String> productTypes;
-        // 거래처 카드/우측 디테일에서 표시 — ListRes 단일 호출로 description/productNote 노출
+        private List<String> factoryProduct;
+        // 거래처 카드/우측 디테일에서 표시 — ListRes 단일 호출로 description/address 노출
         // (목록은 30건 수준이라 TEXT 컬럼 포함해도 페이로드 영향 미미).
-        private String productNote;
         private String description;
         private String primaryMaterialFit;
         private String managerName;
         private String phone;
+        private String address;
         private String partnerType;
+
+        // FE 구버전 호환 alias (2단계 전환 중 임시 유지).
+        @JsonGetter("productTypes")
+        public List<String> legacyProductTypes() {
+            return factoryProduct;
+        }
 
         public static ListRes from(CircularBuyer v) {
             return ListRes.builder()
                     .code(v.getCode())
                     .companyName(v.getCompanyName())
                     .industryGroup(v.getIndustryGroup())
-                    .productTypes(v.getProductTypes())
-                    .productNote(v.getProductNote())
+                    .factoryProduct(v.getFactoryProduct())
                     .description(v.getDescription())
                     .primaryMaterialFit(v.getPrimaryMaterialFit())
                     .managerName(v.getManagerName())
                     .phone(v.getPhone())
+                    .address(v.getAddress())
                     .partnerType(v.getPartnerType())
                     .build();
         }
@@ -148,27 +159,33 @@ public class CircularBuyerDto {
         private String code;
         private String companyName;
         private String industryGroup;
-        private List<String> productTypes;
-        private String productNote;
+        private List<String> factoryProduct;
         private String description;
         private String primaryMaterialFit;
         private String managerName;
         private String phone;
+        private String address;
         private String partnerType;
         private Date createdAt;
         private Date updatedAt;
+
+        // FE 구버전 호환 alias (2단계 전환 중 임시 유지).
+        @JsonGetter("productTypes")
+        public List<String> legacyProductTypes() {
+            return factoryProduct;
+        }
 
         public static DetailRes from(CircularBuyer v) {
             return DetailRes.builder()
                     .code(v.getCode())
                     .companyName(v.getCompanyName())
                     .industryGroup(v.getIndustryGroup())
-                    .productTypes(v.getProductTypes())
-                    .productNote(v.getProductNote())
+                    .factoryProduct(v.getFactoryProduct())
                     .description(v.getDescription())
                     .primaryMaterialFit(v.getPrimaryMaterialFit())
                     .managerName(v.getManagerName())
                     .phone(v.getPhone())
+                    .address(v.getAddress())
                     .partnerType(v.getPartnerType())
                     .createdAt(v.getCreatedAt())
                     .updatedAt(v.getUpdatedAt())

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerListView.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerListView.java
@@ -1,0 +1,20 @@
+package org.example.stockitbe.hq.circularbuyer.repository;
+
+import java.util.List;
+
+/**
+ * 목록 조회 전용 JPQL 프로젝션 — embedding 컬럼(~23KB/행 JSON)을 SELECT에서 제외.
+ * 4만 건 환경에서 페이지당 ~460KB 불필요한 역직렬화를 방지.
+ */
+public interface CircularBuyerListView {
+    String getCode();
+    String getCompanyName();
+    String getIndustryGroup();
+    List<String> getFactoryProduct();
+    String getDescription();
+    String getPrimaryMaterialFit();
+    String getManagerName();
+    String getPhone();
+    String getAddress();
+    String getPartnerType();
+}

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerMaterialFitCount.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerMaterialFitCount.java
@@ -1,0 +1,6 @@
+package org.example.stockitbe.hq.circularbuyer.repository;
+
+public interface CircularBuyerMaterialFitCount {
+    String getMaterialFit();
+    Long getCount();
+}

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerRepository.java
@@ -20,7 +20,7 @@ public interface CircularBuyerRepository
 
     /**
      * 목록 페이지 조회 — embedding 컬럼을 SELECT에서 제외해 행당 ~23KB JSON 역직렬화 생략.
-     * kw: null 이면 keyword 조건 없음, mf: null 이면 materialFit 조건 없음.
+     * kw: null 이면 keyword 조건 없음, mf: null 이면 materialFit 조건 없음, pt: null 이면 partnerType 조건 없음.
      */
     @Query(value = "SELECT b.code as code, b.companyName as companyName, b.industryGroup as industryGroup, " +
                    "b.factoryProduct as factoryProduct, b.description as description, " +
@@ -29,14 +29,17 @@ public interface CircularBuyerRepository
                    "FROM CircularBuyer b " +
                    "WHERE (:kw IS NULL OR LOWER(b.companyName) LIKE :kw " +
                    "       OR LOWER(b.code) LIKE :kw OR LOWER(b.managerName) LIKE :kw) " +
-                   "AND (:mf IS NULL OR b.primaryMaterialFit = :mf)",
+                   "AND (:mf IS NULL OR b.primaryMaterialFit = :mf) " +
+                   "AND (:pt IS NULL OR b.partnerType = :pt)",
            countQuery = "SELECT COUNT(b) FROM CircularBuyer b " +
                         "WHERE (:kw IS NULL OR LOWER(b.companyName) LIKE :kw " +
                         "       OR LOWER(b.code) LIKE :kw OR LOWER(b.managerName) LIKE :kw) " +
-                        "AND (:mf IS NULL OR b.primaryMaterialFit = :mf)")
+                        "AND (:mf IS NULL OR b.primaryMaterialFit = :mf) " +
+                        "AND (:pt IS NULL OR b.partnerType = :pt)")
     Page<CircularBuyerListView> findPageWithoutEmbedding(
             @Param("kw") String kwLike,
             @Param("mf") String materialFit,
+            @Param("pt") String partnerType,
             Pageable pageable);
 
     /** primaryMaterialFit 별 건수 — 통계 카드용 단일 쿼리. */

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerRepository.java
@@ -2,11 +2,13 @@ package org.example.stockitbe.hq.circularbuyer.repository;
 
 import jakarta.persistence.LockModeType;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +17,31 @@ public interface CircularBuyerRepository
         extends JpaRepository<CircularBuyer, Long>, JpaSpecificationExecutor<CircularBuyer> {
 
     Optional<CircularBuyer> findByCode(String code);
+
+    /**
+     * 목록 페이지 조회 — embedding 컬럼을 SELECT에서 제외해 행당 ~23KB JSON 역직렬화 생략.
+     * kw: null 이면 keyword 조건 없음, mf: null 이면 materialFit 조건 없음.
+     */
+    @Query(value = "SELECT b.code as code, b.companyName as companyName, b.industryGroup as industryGroup, " +
+                   "b.factoryProduct as factoryProduct, b.description as description, " +
+                   "b.primaryMaterialFit as primaryMaterialFit, b.managerName as managerName, " +
+                   "b.phone as phone, b.address as address, b.partnerType as partnerType " +
+                   "FROM CircularBuyer b " +
+                   "WHERE (:kw IS NULL OR LOWER(b.companyName) LIKE :kw " +
+                   "       OR LOWER(b.code) LIKE :kw OR LOWER(b.managerName) LIKE :kw) " +
+                   "AND (:mf IS NULL OR b.primaryMaterialFit = :mf)",
+           countQuery = "SELECT COUNT(b) FROM CircularBuyer b " +
+                        "WHERE (:kw IS NULL OR LOWER(b.companyName) LIKE :kw " +
+                        "       OR LOWER(b.code) LIKE :kw OR LOWER(b.managerName) LIKE :kw) " +
+                        "AND (:mf IS NULL OR b.primaryMaterialFit = :mf)")
+    Page<CircularBuyerListView> findPageWithoutEmbedding(
+            @Param("kw") String kwLike,
+            @Param("mf") String materialFit,
+            Pageable pageable);
+
+    /** primaryMaterialFit 별 건수 — 통계 카드용 단일 쿼리. */
+    @Query("SELECT b.primaryMaterialFit as materialFit, COUNT(b) as count FROM CircularBuyer b GROUP BY b.primaryMaterialFit")
+    List<CircularBuyerMaterialFitCount> countGroupByMaterialFit();
 
     /**
      * 자동 코드 부여 시 동시성 제어 — 마지막(max code) row 에 PESSIMISTIC_WRITE 락.

--- a/src/main/java/org/example/stockitbe/hq/infrastructure/model/Infrastructure.java
+++ b/src/main/java/org/example/stockitbe/hq/infrastructure/model/Infrastructure.java
@@ -41,13 +41,19 @@ public class Infrastructure extends BaseEntity {
     @Column(name = "address", nullable = false, length = 256)
     private String address;
 
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 16)
     private InfraStatus status;
 
     @Builder
     private Infrastructure(String code, LocationType locationType, String name, String region, String managerName,
-                           String contact, String address, InfraStatus status) {
+                           String contact, String address, Double latitude, Double longitude, InfraStatus status) {
         this.code = code;
         this.locationType = locationType;
         this.name = name;
@@ -55,6 +61,8 @@ public class Infrastructure extends BaseEntity {
         this.managerName = managerName;
         this.contact = contact;
         this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.status = status == null ? InfraStatus.ACTIVE : status;
     }
 
@@ -66,5 +74,10 @@ public class Infrastructure extends BaseEntity {
         this.contact = contact;
         this.address = address;
         this.status = status;
+    }
+
+    public void updateCoordinates(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/src/main/resources/sql/08-circular_buyer_seed.sql
+++ b/src/main/resources/sql/08-circular_buyer_seed.sql
@@ -5,7 +5,7 @@
 -- embedding 컬럼 NULL — 시드 후 POST /api/hq/circular-buyers/embeddings/backfill 한 번 호출하여 일괄 임베딩 (300콜 ~$0.03 / 30~60초)
 
 INSERT INTO circular_buyer
-(code, company_name, industry_group, product_types, product_note, description,
+(code, company_name, industry_group, factory_product, address, description,
  primary_material_fit, manager_name, phone, partner_type, embedding,
  create_date, update_date)
 VALUES
@@ -312,8 +312,8 @@ VALUES
 ON DUPLICATE KEY UPDATE
   company_name = VALUES(company_name),
   industry_group = VALUES(industry_group),
-  product_types = VALUES(product_types),
-  product_note = VALUES(product_note),
+  factory_product = VALUES(factory_product),
+  address = VALUES(address),
   description = VALUES(description),
   primary_material_fit = VALUES(primary_material_fit),
   manager_name = VALUES(manager_name),

--- a/src/main/resources/sql/circular_buyer_csv_batch.sql
+++ b/src/main/resources/sql/circular_buyer_csv_batch.sql
@@ -1,0 +1,75 @@
+-- circular_buyer CSV 대량 적재 배치 SQL
+-- 전제:
+--   1) tools/load_circular_buyer_from_csv.py 가 아래 staging 테이블에 데이터 적재
+--   2) run_id 단위로 valid/reject 데이터가 분리됨
+--
+-- 실행 변수:
+--   SET @run_id = '20260515_223000';
+
+CREATE TABLE IF NOT EXISTS staging_circular_buyer_valid (
+    id                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    run_id                VARCHAR(64)  NOT NULL,
+    source_row_no         INT          NOT NULL,
+    code                  VARCHAR(32)  NOT NULL,
+    company_name          VARCHAR(128) NOT NULL,
+    phone                 VARCHAR(32)  NOT NULL,
+    address               VARCHAR(256) NOT NULL,
+    description           TEXT         NULL,
+    primary_material_fit  VARCHAR(32)  NOT NULL,
+    manager_name          VARCHAR(64)  NOT NULL,
+    industry_group        VARCHAR(64)  NOT NULL,
+    partner_type          VARCHAR(32)  NOT NULL,
+    factory_product       JSON         NULL,
+    created_at            DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_stg_cb_valid_run_row (run_id, source_row_no),
+    KEY idx_stg_cb_valid_run (run_id)
+);
+
+CREATE TABLE IF NOT EXISTS staging_circular_buyer_reject (
+    id                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    run_id                VARCHAR(64)   NOT NULL,
+    source_row_no         INT           NOT NULL,
+    company_name          VARCHAR(256)  NULL,
+    phone                 VARCHAR(128)  NULL,
+    factory_product_raw   TEXT          NULL,
+    address               VARCHAR(512)  NULL,
+    description           TEXT          NULL,
+    material_fit_raw      VARCHAR(128)  NULL,
+    manager_name          VARCHAR(256)  NULL,
+    industry_group        VARCHAR(256)  NULL,
+    partner_type_raw      VARCHAR(128)  NULL,
+    reject_reason         TEXT          NOT NULL,
+    created_at            DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_stg_cb_reject_run_row (run_id, source_row_no),
+    KEY idx_stg_cb_reject_run (run_id)
+);
+
+-- run_id 단위 본 테이블 전체 교체
+START TRANSACTION;
+
+DELETE FROM circular_buyer;
+
+INSERT INTO circular_buyer (
+    code, company_name, industry_group, factory_product, description,
+    primary_material_fit, manager_name, phone, address, partner_type,
+    embedding, create_date, update_date
+)
+SELECT
+    v.code,
+    v.company_name,
+    v.industry_group,
+    v.factory_product,
+    v.description,
+    v.primary_material_fit,
+    v.manager_name,
+    v.phone,
+    v.address,
+    v.partner_type,
+    NULL,
+    NOW(),
+    NOW()
+FROM staging_circular_buyer_valid v
+WHERE v.run_id = @run_id
+ORDER BY v.source_row_no;
+
+COMMIT;

--- a/src/main/resources/sql/migration-circular-buyer-index-2026-05-16.sql
+++ b/src/main/resources/sql/migration-circular-buyer-index-2026-05-16.sql
@@ -1,0 +1,8 @@
+-- 순환 거래처 목록 조회 성능 보강 인덱스
+-- page API 에서 material_fit 필터 + 페이지 조회 빈도가 높아 인덱스 추가
+-- keyword 는 '%...%' 부분일치라 일반 B-Tree 활용이 제한적이지만,
+-- manager/company 정렬/접두 검색 여지를 위해 보조 인덱스로 둔다.
+
+CREATE INDEX idx_circular_buyer_material_fit ON circular_buyer (primary_material_fit);
+CREATE INDEX idx_circular_buyer_company_name ON circular_buyer (company_name);
+CREATE INDEX idx_circular_buyer_manager_name ON circular_buyer (manager_name);

--- a/src/main/resources/sql/migration-circular-buyer-schema-2026-05-15.sql
+++ b/src/main/resources/sql/migration-circular-buyer-schema-2026-05-15.sql
@@ -1,0 +1,20 @@
+-- 순환재고 거래처 스키마 전환
+-- 1) product_types -> factory_product
+-- 2) product_note 제거
+-- 3) address 추가 (NOT NULL), 기존 데이터는 임시값 백필
+
+ALTER TABLE circular_buyer
+  CHANGE COLUMN product_types factory_product JSON NULL;
+
+ALTER TABLE circular_buyer
+  ADD COLUMN address VARCHAR(256) NULL AFTER phone;
+
+UPDATE circular_buyer
+SET address = '미등록'
+WHERE address IS NULL OR TRIM(address) = '';
+
+ALTER TABLE circular_buyer
+  MODIFY COLUMN address VARCHAR(256) NOT NULL;
+
+ALTER TABLE circular_buyer
+  DROP COLUMN product_note;

--- a/tools/export_geocode_miss_csv.py
+++ b/tools/export_geocode_miss_csv.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+geocode miss 테이블 CSV export 도구.
+
+기본 대상:
+- circular_buyer_geocode_miss
+
+환경변수:
+- DB_URL / DB_USER / DB_PASS
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from datetime import datetime
+from urllib.parse import urlparse
+
+import pymysql
+
+
+def parse_db_url(db_url: str) -> tuple[str, int, str]:
+    if db_url.startswith("jdbc:"):
+        db_url = db_url[5:]
+    parsed = urlparse(db_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 3306
+    database = parsed.path.lstrip("/")
+    if not database:
+        raise ValueError("DB_URL 에 database 이름이 없습니다.")
+    return host, port, database
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export geocode miss rows to CSV")
+    parser.add_argument("--db-url", default=os.getenv("DB_URL", ""), help="override DB_URL")
+    parser.add_argument("--db-user", default=os.getenv("DB_USER", ""), help="override DB_USER")
+    parser.add_argument("--db-pass", default=os.getenv("DB_PASS", ""), help="override DB_PASS")
+    parser.add_argument("--table", default="circular_buyer_geocode_miss", help="miss table name")
+    parser.add_argument("--limit", type=int, default=0, help="row limit (0 means all)")
+    parser.add_argument(
+        "--out",
+        default="",
+        help="output csv path (default: tools/out/<table>_YYYYmmdd_HHMMSS.csv)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.db_url or not args.db_user:
+        raise SystemExit("DB_URL/DB_USER 가 필요합니다.")
+
+    host, port, database = parse_db_url(args.db_url)
+    out_path = args.out
+    if not out_path:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = os.path.join(os.path.dirname(__file__), "out")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, f"{args.table}_{ts}.csv")
+
+    conn = pymysql.connect(
+        host=host,
+        port=port,
+        user=args.db_user,
+        password=args.db_pass,
+        database=database,
+        charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+    try:
+        limit_sql = f" LIMIT {args.limit}" if args.limit > 0 else ""
+        query = f"""
+            SELECT id, original_address, last_query, candidate_count, miss_reason, update_date
+            FROM {args.table}
+            ORDER BY id ASC
+            {limit_sql}
+        """
+        with conn.cursor() as cur:
+            cur.execute(query)
+            rows = cur.fetchall()
+
+        with open(out_path, "w", newline="", encoding="utf-8-sig") as fp:
+            writer = csv.writer(fp)
+            writer.writerow(
+                ["id", "original_address", "last_query", "candidate_count", "miss_reason", "update_date"]
+            )
+            for row in rows:
+                writer.writerow(
+                    [
+                        row.get("id"),
+                        row.get("original_address"),
+                        row.get("last_query"),
+                        row.get("candidate_count"),
+                        row.get("miss_reason"),
+                        row.get("update_date"),
+                    ]
+                )
+        print(f"exported rows={len(rows)} -> {out_path}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/geocode_kakao_batch.py
+++ b/tools/geocode_kakao_batch.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""
+카카오 주소 지오코딩 배치.
+
+대상:
+- circular_buyer(address -> latitude, longitude)
+- infrastructure(address -> latitude, longitude)
+
+환경변수:
+- KAKAO_REST_API_KEY (필수)
+- DB_URL / DB_USER / DB_PASS (Spring dev 설정과 동일하게 사용)
+  예) DB_URL=jdbc:mariadb://127.0.0.1:3306/stockit
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import pymysql
+import requests
+
+KAKAO_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+
+
+@dataclass
+class DbConfig:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+
+def clean_basic(address: str) -> str:
+    if not address:
+        return ""
+    out = address.strip()
+    out = out.replace("（", "(").replace("）", ")")
+    out = re.sub(r"\([^)]*\)", "", out)
+    out = out.split(",")[0]
+    out = re.sub(r"[)\]}>]+$", "", out)  # 꼬리 특수문자 제거
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def trim_detail_tokens(address: str) -> str:
+    out = address
+    # 외 N필지 제거
+    out = re.sub(r"\s*외\s*\d+\s*필지.*$", "", out)
+    # 건물 동/층/호 상세 제거 (A동, B동, 101동, 3층, 1409호 등)
+    # 주의: 지번 행정동(예: 가산동)은 제거하면 안 되므로 "숫자/영문 + 동"만 제거
+    out = re.sub(r"\s+[A-Za-z]\s*동\b.*$", "", out)
+    out = re.sub(r"\s+\d+(?:-\d+)?동\b.*$", "", out)
+    out = re.sub(r"\s+\d+\s*층.*$", "", out)
+    out = re.sub(r"\s+\d+\s*호.*$", "", out)
+    # 번지 표기는 카카오에서 없어도 잘 찾는 경우가 많아 후보를 넓히기 위해 제거본 생성
+    out = re.sub(r"번지", "", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def normalize_spacing_road(address: str) -> str:
+    out = address
+    # 붙어있는 도로명 숫자/길 토큰 보정: 장한로27가길 -> 장한로 27가길
+    out = re.sub(r"([로길])(\d)", r"\1 \2", out)
+    # 번길 앞 숫자 붙음 보정: 247번길 -> 247번길 (공백 제거 방향으로 통일)
+    out = re.sub(r"(\d)\s+번길", r"\1번길", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def normalize_collapse_bunggil(address: str) -> str:
+    """'42 번길' → '42번길': 카카오 API 는 번길 앞 공백 없는 형식을 선호."""
+    out = re.sub(r"(\d)\s+번길", r"\1번길", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def strip_trailing_building_number(address: str) -> str:
+    """도로명 뒤 건물번호(예: '1-18', '39') 제거 — 도로명만 남겨 후보 확장."""
+    out = re.sub(r"\s+\d+(?:-\d+)?\s*$", "", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def normalize_dong_number(address: str) -> str:
+    """청천2동 → 청천동: 숫자 행정동은 카카오가 모르는 경우가 있어 번호 제거 시도."""
+    out = re.sub(r"([가-힣]+)\d+(동)\b", r"\1\2", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def truncate_to_eupmon(address: str) -> str:
+    """읍/면 레벨까지만 남김 — 리(里) 단위 지번이 카카오에 없을 때 fallback.
+    세종특별자치시처럼 시/도 바로 아래 읍/면이 오는 구조도 지원."""
+    # 일반: 시/도 > 시/군/구 > 읍/면
+    m = re.match(r"^(.+?(?:시|도)\s+.+?(?:시|군|구)\s+\S+?(?:읍|면))\b", address)
+    if m:
+        return m.group(1).strip()
+    # 세종 등 군/구 없이 시/도 > 읍/면 구조
+    m2 = re.match(r"^(.+?(?:시|도)\s+\S+?(?:읍|면))\b", address)
+    if m2:
+        return m2.group(1).strip()
+    return ""
+
+
+def build_query_candidates(address: str) -> list[str]:
+    base = clean_basic(address)
+    if not base:
+        return []
+
+    candidates: list[str] = []
+    base_col = normalize_collapse_bunggil(base)
+    trimmed = trim_detail_tokens(base)
+    trimmed_col = normalize_collapse_bunggil(trimmed)
+
+    variants = [
+        # 번길 공백 제거 버전을 앞에 배치 — MISS 주원인이므로 우선 시도
+        base_col,
+        base,
+        trimmed_col,
+        trimmed,
+        normalize_spacing_road(base_col),
+        normalize_spacing_road(base),
+        normalize_spacing_road(trimmed_col),
+        normalize_spacing_road(trimmed),
+        # 건물번호 제거 버전 (도로명 레벨)
+        strip_trailing_building_number(base_col),
+        strip_trailing_building_number(base),
+    ]
+
+    # 숫자 행정동 정규화 (청천2동 → 청천동)
+    dong_norm = normalize_dong_number(base)
+    if dong_norm != base:
+        variants.append(dong_norm)
+        variants.append(strip_trailing_building_number(dong_norm))
+
+    # 읍/면 레벨 fallback — 리 단위 지번이 카카오 DB에 없는 농촌 필지 대응
+    eupmon = truncate_to_eupmon(base)
+    if eupmon:
+        variants.append(eupmon)
+
+    # 지번형 축약: 시/군/구 + 읍/면/동 + 번지(산 포함)까지만
+    m = re.match(
+        r"^(.+?(?:시|도)\s+.+?(?:시|군|구)\s+.+?(?:읍|면|동)\s+(?:산\s*)?\d+(?:-\d+)?)",
+        base,
+    )
+    if m:
+        variants.append(m.group(1))
+        variants.append(normalize_spacing_road(m.group(1)))
+
+    seen: set[str] = set()
+    for v in variants:
+        v = re.sub(r"\s+", " ", (v or "").strip())
+        if not v or v in seen:
+            continue
+        seen.add(v)
+        candidates.append(v)
+    return candidates
+
+
+def extract_region_tokens(address: str) -> list[str]:
+    source = clean_basic(address)
+    tokens = source.split()
+    regions: list[str] = []
+    for token in tokens:
+        if token.endswith(("시", "도", "군", "구")):
+            regions.append(token)
+        if len(regions) >= 3:
+            break
+    return regions
+
+
+# 카카오 API 가 공식 도명 대신 약칭을 반환하는 경우 매핑
+# 예: 충청북도 -> 충북, 경상남도 -> 경남
+_DO_ABBR: dict[str, str] = {
+    "충청북도": "충북",
+    "충청남도": "충남",
+    "경상북도": "경북",
+    "경상남도": "경남",
+    "전라북도": "전북",
+    "전라남도": "전남",
+    "전북특별자치도": "전북",
+    "강원특별자치도": "강원",
+    "강원도": "강원",
+}
+_DO_ABBR_REV: dict[str, str] = {v: k for k, v in _DO_ABBR.items()}
+
+
+def normalize_region_token(token: str) -> str:
+    out = token.strip()
+    # 광역/특별/자치 표기 차이 흡수
+    out = out.replace("특별자치시", "시")
+    out = out.replace("특별자치도", "도")
+    out = out.replace("특별시", "시")
+    out = out.replace("광역시", "시")
+    return out
+
+
+def region_aliases(token: str) -> set[str]:
+    norm = normalize_region_token(token)
+    aliases = {norm}
+    # 끝 접미 제거한 축약도 허용 (경기도 -> 경기, 대구시 -> 대구)
+    for suffix in ("시", "도", "군", "구"):
+        if norm.endswith(suffix) and len(norm) > 1:
+            aliases.add(norm[: -len(suffix)])
+    # 도 약칭 추가 (충청북도 -> 충북)
+    if norm in _DO_ABBR:
+        aliases.add(_DO_ABBR[norm])
+    # 역방향: 약칭이 입력된 경우 원형도 alias 에 포함 (충북 -> 충청북도, 충청북)
+    if norm in _DO_ABBR_REV:
+        full = _DO_ABBR_REV[norm]
+        aliases.add(full)
+        for suffix in ("시", "도", "군", "구"):
+            if full.endswith(suffix) and len(full) > 1:
+                aliases.add(full[: -len(suffix)])
+    return aliases
+
+
+def is_region_match(raw_address: str, result_address: str) -> bool:
+    expected = extract_region_tokens(raw_address)
+    if not expected:
+        return True
+    normalized_result = normalize_region_token(result_address)
+    # 표기 정규화 + 축약(경기도/경기) 별칭 중 하나라도 포함되면 매칭
+    for token in expected:
+        aliases = region_aliases(token)
+        if not any(alias in normalized_result for alias in aliases):
+            return False
+    return True
+
+
+def parse_db_url(db_url: str) -> tuple[str, int, str]:
+    # jdbc:mariadb://127.0.0.1:3306/stockit
+    if db_url.startswith("jdbc:"):
+        db_url = db_url[5:]
+    parsed = urlparse(db_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 3306
+    database = parsed.path.lstrip("/")
+    if not database:
+        raise ValueError("DB_URL 에 database 이름이 없습니다.")
+    return host, port, database
+
+
+def load_db_config(args: argparse.Namespace) -> DbConfig:
+    db_url = args.db_url or os.getenv("DB_URL", "")
+    db_user = args.db_user or os.getenv("DB_USER", "")
+    db_pass = args.db_pass or os.getenv("DB_PASS", "")
+    if not db_url or not db_user:
+        raise ValueError("DB_URL/DB_USER 가 필요합니다. (DB_PASS 는 비어도 됨)")
+    host, port, database = parse_db_url(db_url)
+    return DbConfig(host=host, port=port, user=db_user, password=db_pass, database=database)
+
+
+def geocode_kakao(rest_api_key: str, query: str) -> tuple[float | None, float | None, str]:
+    headers = {"Authorization": f"KakaoAK {rest_api_key}"}
+    response = requests.get(KAKAO_URL, headers=headers, params={"query": query}, timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    docs = payload.get("documents", [])
+    if not docs:
+        return None, None, ""
+    # 카카오 응답: x=경도(lng), y=위도(lat)
+    doc = docs[0]
+    lng = float(doc["x"])
+    lat = float(doc["y"])
+    addr_name = ""
+    road = doc.get("road_address") or {}
+    if road.get("address_name"):
+        addr_name = str(road.get("address_name"))
+    elif doc.get("address", {}).get("address_name"):
+        addr_name = str(doc.get("address", {}).get("address_name"))
+    return lat, lng, addr_name
+
+
+def escape_sql(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def process_table(
+    conn: pymysql.Connection,
+    rest_api_key: str,
+    table: str,
+    pk_col: str,
+    addr_col: str,
+    sleep_sec: float,
+    limit: int,
+    only_miss: bool,
+    max_consecutive_api_errors: int,
+) -> tuple[int, int, int, int]:
+    miss_table = f"{table}_geocode_miss"
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {miss_table} (
+              id BIGINT PRIMARY KEY,
+              original_address VARCHAR(256) NOT NULL,
+              last_query VARCHAR(256) NULL,
+              candidate_count INT NOT NULL DEFAULT 0,
+              miss_reason VARCHAR(32) NOT NULL,
+              update_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+    where = [f"{addr_col} IS NOT NULL", f"TRIM({addr_col}) <> ''", "(latitude IS NULL OR longitude IS NULL)"]
+    if only_miss:
+        where.append(f"{pk_col} IN (SELECT id FROM {miss_table})")
+    where_sql = " AND ".join(where)
+    limit_sql = f" LIMIT {limit}" if limit > 0 else ""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT {pk_col} AS id, {addr_col} AS address
+            FROM {table}
+            WHERE {where_sql}
+            ORDER BY {pk_col} ASC
+            {limit_sql}
+            """
+        )
+        rows = cur.fetchall()
+
+    success = 0
+    miss = 0
+    fail = 0
+    mismatch = 0
+    consecutive_api_errors = 0
+
+    for row in rows:
+        row_id = row["id"]
+        raw_address = str(row["address"])
+        candidates = build_query_candidates(raw_address)
+        if not candidates:
+            miss += 1
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
+                    VALUES(%s, %s, %s, %s, %s)
+                    """,
+                    (row_id, raw_address, "", 0, "EMPTY_CANDIDATE"),
+                )
+            conn.commit()
+            continue
+
+        resolved = False
+        last_query = candidates[-1]
+        saw_mismatch = False
+        mismatch_result_address = ""
+
+        try:
+            for query in candidates:
+                last_query = query
+                lat, lng, result_address = geocode_kakao(rest_api_key, query)
+                if lat is None or lng is None:
+                    continue
+                if not is_region_match(raw_address, result_address):
+                    saw_mismatch = True
+                    mismatch_result_address = result_address
+                    continue
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"UPDATE {table} SET latitude=%s, longitude=%s WHERE {pk_col}=%s",
+                        (lat, lng, row_id),
+                    )
+                    cur.execute(f"DELETE FROM {miss_table} WHERE id=%s", (row_id,))
+                conn.commit()
+                success += 1
+                resolved = True
+                break
+            consecutive_api_errors = 0
+            time.sleep(sleep_sec)
+        except Exception as exc:  # noqa: BLE001
+            fail += 1
+            consecutive_api_errors += 1
+            print(f"[FAIL] {table}:{row_id} -> {last_query} ({exc})")
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
+                    VALUES(%s, %s, %s, %s, %s)
+                    """,
+                    (row_id, raw_address, last_query, len(candidates), "API_FAIL"),
+                )
+            conn.commit()
+            if max_consecutive_api_errors > 0 and consecutive_api_errors >= max_consecutive_api_errors:
+                print(
+                    f"[ABORT] 연속 API 오류 {consecutive_api_errors}회 발생으로 중단합니다. "
+                    f"(threshold={max_consecutive_api_errors})"
+                )
+                break
+            continue
+
+        if resolved:
+            continue
+
+        if saw_mismatch:
+            mismatch += 1
+            print(
+                f"[SKIP_MISMATCH] {table}:{row_id} -> region mismatch, "
+                f"candidate_count={len(candidates)}, last_query='{last_query}', "
+                f"result='{mismatch_result_address}'"
+            )
+            reason = "REGION_MISMATCH"
+        else:
+            miss += 1
+            print(
+                f"[MISS] {table}:{row_id} -> candidate_count={len(candidates)}, "
+                f"last_query='{last_query}'"
+            )
+            reason = "MISS"
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
+                VALUES(%s, %s, %s, %s, %s)
+                """,
+                (row_id, raw_address, last_query, len(candidates), reason),
+            )
+        conn.commit()
+    return success, miss, fail, mismatch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Kakao geocoding batch updater")
+    parser.add_argument("--db-url", default="", help="override DB_URL")
+    parser.add_argument("--db-user", default="", help="override DB_USER")
+    parser.add_argument("--db-pass", default="", help="override DB_PASS")
+    parser.add_argument("--sleep", type=float, default=0.12, help="seconds between API calls")
+    parser.add_argument(
+        "--table",
+        choices=["all", "circular_buyer", "infrastructure"],
+        default="all",
+        help="target table",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="max rows per table. 0 means no limit")
+    parser.add_argument(
+        "--only-miss",
+        action="store_true",
+        help="process only rows that are recorded in <table>_geocode_miss",
+    )
+    parser.add_argument(
+        "--max-consecutive-api-errors",
+        type=int,
+        default=5,
+        help="abort when this many API exceptions happen consecutively (0 disables)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    rest_api_key = os.getenv("KAKAO_REST_API_KEY", "").strip()
+    if not rest_api_key:
+        print("KAKAO_REST_API_KEY 가 필요합니다.")
+        return 1
+
+    try:
+        db = load_db_config(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"DB 설정 오류: {exc}")
+        return 1
+
+    conn = pymysql.connect(
+        host=db.host,
+        port=db.port,
+        user=db.user,
+        password=db.password,
+        database=db.database,
+        charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=False,
+    )
+
+    total = {
+        "circular_buyer": {"success": 0, "miss": 0, "fail": 0, "mismatch": 0},
+        "infrastructure": {"success": 0, "miss": 0, "fail": 0, "mismatch": 0},
+    }
+    targets = (
+        ["circular_buyer", "infrastructure"]
+        if args.table == "all"
+        else [args.table]
+    )
+
+    try:
+        for target in targets:
+            ok, miss, fail, mismatch = process_table(
+                conn=conn,
+                rest_api_key=rest_api_key,
+                table=target,
+                pk_col="id",
+                addr_col="address",
+                sleep_sec=args.sleep,
+                limit=args.limit,
+                only_miss=args.only_miss,
+                max_consecutive_api_errors=args.max_consecutive_api_errors,
+            )
+            total[target]["success"] = ok
+            total[target]["miss"] = miss
+            total[target]["fail"] = fail
+            total[target]["mismatch"] = mismatch
+    except KeyboardInterrupt:
+        print("\n[INTERRUPTED] 수동 중단됨. 현재까지 집계:")
+    finally:
+        conn.close()
+
+    for target in ["circular_buyer", "infrastructure"]:
+        if args.table != "all" and target != args.table:
+            continue
+        print(
+            f"[{target}] success={total[target]['success']}, "
+            f"miss={total[target]['miss']}, fail={total[target]['fail']}, "
+            f"mismatch={total[target]['mismatch']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/load_circular_buyer_from_csv.py
+++ b/tools/load_circular_buyer_from_csv.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""
+circular_buyer CSV 대량 적재 도구.
+
+기능:
+1) CSV 검증/정규화
+2) valid/reject 분리 + 리포트 생성
+3) (옵션) MySQL staging/reject 테이블 적재 + 본 테이블 전체 교체
+
+예시:
+  python3 tools/load_circular_buyer_from_csv.py \
+    --csv /path/to/circular_buyer.csv \
+    --out-dir /tmp/circular-buyer-load \
+    --run-id 20260515_230000
+
+  python3 tools/load_circular_buyer_from_csv.py \
+    --csv /path/to/circular_buyer.csv \
+    --out-dir /tmp/circular-buyer-load \
+    --run-id 20260515_230000 \
+    --apply \
+    --db-host 127.0.0.1 \
+    --db-port 3306 \
+    --db-name stockit \
+    --db-user root \
+    --db-password secret
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+EXPECTED_HEADERS = [
+    "회사명",
+    "전화번호",
+    "생산품",
+    "주소",
+    "설명",
+    "소재분류",
+    "담당자",
+    "산업군",
+    "기업 분류",
+]
+
+REQUIRED_HEADERS = set(EXPECTED_HEADERS)
+REQUIRED_FIELDS = [
+    ("회사명", "company_name"),
+    ("전화번호", "phone"),
+    ("주소", "address"),
+    ("소재분류", "primary_material_fit"),
+    ("담당자", "manager_name"),
+    ("산업군", "industry_group"),
+    ("기업 분류", "partner_type"),
+]
+
+MATERIAL_FIT_MAP = {
+    "natural-single": "natural-single",
+    "synthetic": "synthetic",
+    "blended": "blended",
+    "천연 단일 섬유": "natural-single",
+    "합성 섬유": "synthetic",
+    "혼방": "blended",
+}
+
+PARTNER_TYPE_MAP = {
+    "GENERAL": "general",
+    "SMALL_BUSINESS": "local_small",
+    "SOCIAL_ENTERPRISE": "social_enterprise",
+    "general": "general",
+    "local_small": "local_small",
+    "social_enterprise": "social_enterprise",
+}
+
+CODE_NUMBER_MAX = 99_999_999
+
+
+@dataclass
+class ValidRow:
+    source_row_no: int
+    code: str
+    company_name: str
+    phone: str
+    address: str
+    description: str
+    primary_material_fit: str
+    manager_name: str
+    industry_group: str
+    partner_type: str
+    factory_product_json: str
+
+
+@dataclass
+class RejectRow:
+    source_row_no: int
+    company_name: str
+    phone: str
+    factory_product_raw: str
+    address: str
+    description: str
+    material_fit_raw: str
+    manager_name: str
+    industry_group: str
+    partner_type_raw: str
+    reject_reason: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate/normalize circular_buyer CSV and optionally load into MySQL."
+    )
+    parser.add_argument("--csv", required=True, help="입력 CSV 경로")
+    parser.add_argument("--out-dir", required=True, help="결과 파일 출력 디렉터리")
+    parser.add_argument("--run-id", default="", help="실행 식별자(미입력 시 현재시각)")
+    parser.add_argument(
+        "--encoding",
+        default="utf-8-sig",
+        help="CSV 인코딩(기본값: utf-8-sig)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="검증 후 MySQL 적재/교체까지 수행",
+    )
+    parser.add_argument("--db-host", default="127.0.0.1", help="MySQL host")
+    parser.add_argument("--db-port", type=int, default=3306, help="MySQL port")
+    parser.add_argument("--db-name", default="", help="MySQL database name")
+    parser.add_argument("--db-user", default="", help="MySQL user")
+    parser.add_argument("--db-password", default="", help="MySQL password")
+    parser.add_argument(
+        "--sql-path",
+        default="src/main/resources/sql/circular_buyer_csv_batch.sql",
+        help="staging/swap SQL 파일 경로",
+    )
+    return parser.parse_args()
+
+
+def non_empty(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_factory_product(raw: str) -> list[str]:
+    if not raw:
+        return []
+    candidates = []
+    for chunk in str(raw).split(","):
+        item = chunk.strip()
+        if item:
+            candidates.append(item)
+    deduped = list(dict.fromkeys(candidates))
+    return deduped
+
+
+def normalize_material_fit(raw: str) -> str:
+    value = non_empty(raw)
+    return MATERIAL_FIT_MAP.get(value, "")
+
+
+def normalize_partner_type(raw: str) -> str:
+    value = non_empty(raw)
+    return PARTNER_TYPE_MAP.get(value, "")
+
+
+def build_code(index_from_1: int) -> str:
+    return f"RCV-{index_from_1:05d}"
+
+
+def validate_header(fieldnames: list[str] | None) -> None:
+    if not fieldnames:
+        raise ValueError("CSV header 가 없습니다.")
+    missing = sorted(REQUIRED_HEADERS - set(fieldnames))
+    if missing:
+        raise ValueError(f"CSV header 누락: {', '.join(missing)}")
+
+
+def validate_row(raw: dict[str, str], source_row_no: int, code_index: int) -> tuple[ValidRow | None, RejectRow | None]:
+    reasons: list[str] = []
+
+    company_name = non_empty(raw.get("회사명"))
+    phone = non_empty(raw.get("전화번호"))
+    factory_product_raw = non_empty(raw.get("생산품"))
+    address = non_empty(raw.get("주소"))
+    description = non_empty(raw.get("설명"))
+    material_fit_raw = non_empty(raw.get("소재분류"))
+    manager_name = non_empty(raw.get("담당자"))
+    industry_group = non_empty(raw.get("산업군"))
+    partner_type_raw = non_empty(raw.get("기업 분류"))
+
+    for key, label in REQUIRED_FIELDS:
+        if not non_empty(raw.get(key)):
+            reasons.append(f"필수값 누락: {label}")
+
+    primary_material_fit = normalize_material_fit(material_fit_raw)
+    if material_fit_raw and not primary_material_fit:
+        reasons.append(f"소재분류 매핑 실패: {material_fit_raw}")
+
+    partner_type = normalize_partner_type(partner_type_raw)
+    if partner_type_raw and not partner_type:
+        reasons.append(f"기업 분류 매핑 실패: {partner_type_raw}")
+
+    factory_product = normalize_factory_product(factory_product_raw)
+    try:
+        factory_product_json = json.dumps(factory_product, ensure_ascii=False)
+        json.loads(factory_product_json)
+    except json.JSONDecodeError:
+        reasons.append("factory_product JSON 변환 실패")
+        factory_product_json = "[]"
+
+    if reasons:
+        reject = RejectRow(
+            source_row_no=source_row_no,
+            company_name=company_name,
+            phone=phone,
+            factory_product_raw=factory_product_raw,
+            address=address,
+            description=description,
+            material_fit_raw=material_fit_raw,
+            manager_name=manager_name,
+            industry_group=industry_group,
+            partner_type_raw=partner_type_raw,
+            reject_reason=" | ".join(reasons),
+        )
+        return None, reject
+
+    valid = ValidRow(
+        source_row_no=source_row_no,
+        code=build_code(code_index),
+        company_name=company_name,
+        phone=phone,
+        address=address,
+        description=description,
+        primary_material_fit=primary_material_fit,
+        manager_name=manager_name,
+        industry_group=industry_group,
+        partner_type=partner_type,
+        factory_product_json=factory_product_json,
+    )
+    return valid, None
+
+
+def write_valid_csv(path: str, rows: list[ValidRow]) -> None:
+    with open(path, "w", encoding="utf-8", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(
+            [
+                "source_row_no",
+                "code",
+                "company_name",
+                "phone",
+                "address",
+                "description",
+                "primary_material_fit",
+                "manager_name",
+                "industry_group",
+                "partner_type",
+                "factory_product_json",
+            ]
+        )
+        for row in rows:
+            writer.writerow(
+                [
+                    row.source_row_no,
+                    row.code,
+                    row.company_name,
+                    row.phone,
+                    row.address,
+                    row.description,
+                    row.primary_material_fit,
+                    row.manager_name,
+                    row.industry_group,
+                    row.partner_type,
+                    row.factory_product_json,
+                ]
+            )
+
+
+def write_reject_csv(path: str, rows: list[RejectRow]) -> None:
+    with open(path, "w", encoding="utf-8", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(
+            [
+                "source_row_no",
+                "company_name",
+                "phone",
+                "factory_product_raw",
+                "address",
+                "description",
+                "material_fit_raw",
+                "manager_name",
+                "industry_group",
+                "partner_type_raw",
+                "reject_reason",
+            ]
+        )
+        for row in rows:
+            writer.writerow(
+                [
+                    row.source_row_no,
+                    row.company_name,
+                    row.phone,
+                    row.factory_product_raw,
+                    row.address,
+                    row.description,
+                    row.material_fit_raw,
+                    row.manager_name,
+                    row.industry_group,
+                    row.partner_type_raw,
+                    row.reject_reason,
+                ]
+            )
+
+
+def write_summary(path: str, run_id: str, total_rows: int, valid_rows: list[ValidRow], reject_rows: list[RejectRow]) -> None:
+    counter = Counter()
+    for row in reject_rows:
+        for reason in row.reject_reason.split(" | "):
+            counter[reason] += 1
+
+    payload = {
+        "run_id": run_id,
+        "total_rows": total_rows,
+        "success_rows": len(valid_rows),
+        "reject_rows": len(reject_rows),
+        "reject_reason_counts": dict(counter),
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+
+def load_with_pymysql(
+    args: argparse.Namespace,
+    run_id: str,
+    valid_rows: list[ValidRow],
+    reject_rows: list[RejectRow],
+) -> None:
+    try:
+        import pymysql  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "pymysql 이 설치되어 있지 않습니다. `pip install pymysql` 후 재실행하세요."
+        ) from exc
+
+    if not args.db_name or not args.db_user:
+        raise RuntimeError("--apply 사용 시 --db-name, --db-user 는 필수입니다.")
+
+    conn = pymysql.connect(
+        host=args.db_host,
+        port=args.db_port,
+        user=args.db_user,
+        password=args.db_password,
+        database=args.db_name,
+        charset="utf8mb4",
+        autocommit=False,
+    )
+
+    try:
+        with conn.cursor() as cur:
+            with open(args.sql_path, "r", encoding="utf-8") as fp:
+                sql = fp.read()
+            for statement in split_sql_statements(sql):
+                if statement.strip():
+                    cur.execute(statement)
+
+            cur.execute("DELETE FROM staging_circular_buyer_valid WHERE run_id = %s", (run_id,))
+            cur.execute("DELETE FROM staging_circular_buyer_reject WHERE run_id = %s", (run_id,))
+
+            if valid_rows:
+                cur.executemany(
+                    """
+                    INSERT INTO staging_circular_buyer_valid (
+                        run_id, source_row_no, code, company_name, phone, address, description,
+                        primary_material_fit, manager_name, industry_group, partner_type, factory_product
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, CAST(%s AS JSON))
+                    """,
+                    [
+                        (
+                            run_id,
+                            r.source_row_no,
+                            r.code,
+                            r.company_name,
+                            r.phone,
+                            r.address,
+                            r.description,
+                            r.primary_material_fit,
+                            r.manager_name,
+                            r.industry_group,
+                            r.partner_type,
+                            r.factory_product_json,
+                        )
+                        for r in valid_rows
+                    ],
+                )
+
+            if reject_rows:
+                cur.executemany(
+                    """
+                    INSERT INTO staging_circular_buyer_reject (
+                        run_id, source_row_no, company_name, phone, factory_product_raw, address, description,
+                        material_fit_raw, manager_name, industry_group, partner_type_raw, reject_reason
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    [
+                        (
+                            run_id,
+                            r.source_row_no,
+                            r.company_name,
+                            r.phone,
+                            r.factory_product_raw,
+                            r.address,
+                            r.description,
+                            r.material_fit_raw,
+                            r.manager_name,
+                            r.industry_group,
+                            r.partner_type_raw,
+                            r.reject_reason,
+                        )
+                        for r in reject_rows
+                    ],
+                )
+
+            cur.execute("SET @run_id = %s", (run_id,))
+            cur.execute("START TRANSACTION")
+            cur.execute("DELETE FROM circular_buyer")
+            cur.execute(
+                """
+                INSERT INTO circular_buyer (
+                    code, company_name, industry_group, factory_product, description,
+                    primary_material_fit, manager_name, phone, address, partner_type,
+                    embedding, create_date, update_date
+                )
+                SELECT
+                    v.code, v.company_name, v.industry_group, v.factory_product, v.description,
+                    v.primary_material_fit, v.manager_name, v.phone, v.address, v.partner_type,
+                    NULL, NOW(), NOW()
+                FROM staging_circular_buyer_valid v
+                WHERE v.run_id = %s
+                ORDER BY v.source_row_no
+                """,
+                (run_id,),
+            )
+            cur.execute("COMMIT")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def split_sql_statements(sql: str) -> list[str]:
+    statements = []
+    current = []
+    in_string = False
+    quote_char = ""
+    for ch in sql:
+        if ch in ("'", '"'):
+            if not in_string:
+                in_string = True
+                quote_char = ch
+            elif quote_char == ch:
+                in_string = False
+                quote_char = ""
+        if ch == ";" and not in_string:
+            statement = "".join(current).strip()
+            if statement:
+                statements.append(statement)
+            current = []
+        else:
+            current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def main() -> int:
+    args = parse_args()
+
+    run_id = args.run_id.strip() or datetime.now().strftime("%Y%m%d_%H%M%S")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    valid_rows: list[ValidRow] = []
+    reject_rows: list[RejectRow] = []
+    total_rows = 0
+    valid_index = 0
+
+    try:
+        with open(args.csv, "r", encoding=args.encoding, newline="") as fp:
+            reader = csv.DictReader(fp)
+            validate_header(reader.fieldnames)
+            for i, raw in enumerate(reader, start=2):
+                total_rows += 1
+                valid, reject = validate_row(raw, i, valid_index + 1)
+                if valid:
+                    valid_rows.append(valid)
+                    valid_index += 1
+                else:
+                    assert reject is not None
+                    reject_rows.append(reject)
+    except Exception as exc:
+        print(f"[ERROR] CSV 처리 실패: {exc}", file=sys.stderr)
+        return 1
+
+    valid_csv = os.path.join(args.out_dir, f"{run_id}.valid.csv")
+    reject_csv = os.path.join(args.out_dir, f"{run_id}.reject.csv")
+    summary_json = os.path.join(args.out_dir, f"{run_id}.summary.json")
+
+    write_valid_csv(valid_csv, valid_rows)
+    write_reject_csv(reject_csv, reject_rows)
+    write_summary(summary_json, run_id, total_rows, valid_rows, reject_rows)
+
+    print(f"run_id={run_id}")
+    print(f"total_rows={total_rows}")
+    print(f"success_rows={len(valid_rows)}")
+    print(f"reject_rows={len(reject_rows)}")
+    print(f"valid_csv={valid_csv}")
+    print(f"reject_csv={reject_csv}")
+    print(f"summary_json={summary_json}")
+
+    if args.apply:
+        try:
+            load_with_pymysql(args, run_id, valid_rows, reject_rows)
+            print("apply_status=SUCCESS")
+        except Exception as exc:
+            print(f"[ERROR] DB 적재 실패: {exc}", file=sys.stderr)
+            return 2
+    else:
+        print("apply_status=SKIPPED (--apply 미지정)")
+
+    # 참고: 서비스 코드 신규 생성 상한과 동기화.
+    if len(valid_rows) > CODE_NUMBER_MAX:
+        print(
+            f"[WARN] valid row 가 {CODE_NUMBER_MAX:,}를 초과합니다. "
+            f"API 신규 등록 코드 상한(CODE_NUMBER_MAX={CODE_NUMBER_MAX:,}) "
+            "확장 작업을 별도로 진행하세요."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 📌 요약
- 거래처 조회 성능/페이징 개선과 거래처 분류 기반 필터링, 등록/상세 UI 개선을 포함합니다.
- 거래처 도메인 스키마 전환 및 CSV 기반 시드 적재를 통해 운영 데이터 기반을 구성했습니다.

<br><br>

## 🎯 작업 내용
- 순환재고 거래처 도메인 전환
  - `circular_buyer` 테이블 컬럼 정비 및 도메인 구조 반영
  - 위도/경도 컬럼 추가, 스키마 마이그레이션 반영
- 데이터 적재 및 조회 API 강화
  - 거래처 CSV 데이터를 MariaDB에 적재
  - 거래처 목록 조회 페이징 처리 및 인덱스 추가
- 본사 관리자 UI/UX 개선
  - 거래처 리스트 조회/상세/등록 기능 구현
  - 거래처 분류(`partner_type`) 필터 추가
  - 등록 폼 입력 레이아웃 정돈(업체명-산업군 / 대표소재-파트너유형)
  - 초기/상태별 화면 동작 개선(목록 중심 표시, 액션 기반 패널 전환)
  - 등록 상태일 때 상단 `새 거래처 등록` 버튼 비활성화

<br><br>

## ✔️ 참고 사항
- 산업군 드롭다운 옵션을 운영 요구사항 기준 8개로 재정의했습니다.
- 기존 데이터의 산업군 값은 표시에는 영향 없고, 수정 시 새 옵션 체계로 정규화될 수 있습니다.

<br><br>

## ✔️ 관련 이슈

- Close #280

<br><br>