### PR TITLE
chore(prod): 부하테스트 대응 로그·풀 튜닝

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,8 +8,7 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
-      maximum-pool-size: 20
-      minimum-idle: 2
+      maximum-pool-size: 50
       connection-timeout: 10000
 
   jpa:
@@ -19,7 +18,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
 
   # ADR-021 AI 거래처 추천 — 임베딩(text-embedding-3-small) + 추천 사유(gpt-4o-mini)
   ai:
@@ -34,8 +33,8 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.SQL: warn
+    org.hibernate.orm.jdbc.bind: warn
 
 # SYS-001 본사 발주 자동 전환 배치
 purchase-order:


### PR DESCRIPTION
## 📌 요약

부하테스트(전사재고조회 k6) 사전 작업 — prod 환경의 SQL 로깅 끄기 + HikariCP 풀 확대.

<br>

## 🎯 작업 내용

- `application-prod.yml` Hibernate 로깅 `debug/trace → warn` (prod 만 dev 보다 더 켜져 있던 상태 정정)
- `format_sql: true → false` — 포맷팅 비용 제거
- HikariCP `maximum-pool-size: 20 → 50` — k6 100~200 VU 시 connection wait 방지
- HikariCP `minimum-idle: 2` 제거 — 공식 권장(`maximum-pool-size` 만 두면 idle=max, steady-state 안정성)
- dev yml 은 시연 편의(SQL 보임) 유지

<br>

## ✔️ 참고 사항

- 

<br>

## ✔️ 관련 이슈

- 
