### PR TITLE
feat: 순환 재고 거래처 추천시 위치 반영하도록 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
@@ -10,6 +10,8 @@ import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerDto;
 import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerRepository;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.product.ProductMasterRepository;
 import org.example.stockitbe.hq.product.model.Material;
 import org.example.stockitbe.hq.product.model.ProductMaterialComposition;
@@ -23,9 +25,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * ADR-021 AI 거래처 추천 — 3층 RAG 파이프라인.
@@ -45,6 +50,10 @@ public class CircularBuyerRecommendService {
             "natural-single", "synthetic", "blended"
     );
     private static final int TOP_K = 5;
+    private static final double SIM_WEIGHT = 0.7;
+    private static final double DIST_WEIGHT = 0.3;
+    private static final double DIST_NORM_KM = 30.0;
+    private static final double EARTH_RADIUS_KM = 6371.0;
     private static final Pattern JSON_ARRAY = Pattern.compile("\\[.*]", Pattern.DOTALL);
 
     /**
@@ -62,6 +71,7 @@ public class CircularBuyerRecommendService {
     );
 
     private final CircularBuyerRepository circularBuyerRepository;
+    private final InfrastructureRepository infrastructureRepository;
     private final ProductMasterRepository productMasterRepository;
     private final EmbeddingModel embeddingModel;
     private final ChatModel chatModel;
@@ -81,20 +91,34 @@ public class CircularBuyerRecommendService {
         }
 
         // 2층 — 쿼리 임베딩 + 코사인 top 5
-        List<CircularBuyer> top = rankByCosine(candidates, buildQueryText(req));
+        WarehousePoint warehousePoint = resolveWarehousePoint(req.getWarehouseCode());
+        List<RankedBuyer> rankedTop = rankByScore(candidates, buildQueryText(req), warehousePoint);
+        List<CircularBuyer> top = rankedTop.stream().map(RankedBuyer::buyer).toList();
 
         // 3층 — LLM 사유 생성 (실패 시 fallback)
         Map<String, String> rationales = generateRationales(top, req);
+        Map<String, RankedBuyer> rankedByCode = rankedTop.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        r -> r.buyer().getCode(),
+                        r -> r,
+                        (left, right) -> left
+                ));
 
         List<CircularBuyerDto.RecommendItem> items = top.stream()
-                .map(b -> CircularBuyerDto.RecommendItem.builder()
+                .map(b -> {
+                    RankedBuyer rankedBuyer = rankedByCode.get(b.getCode());
+                    Double distanceKm = rankedBuyer == null ? null : rankedBuyer.distanceKm();
+                    return CircularBuyerDto.RecommendItem.builder()
                         .code(b.getCode())
                         .companyName(b.getCompanyName())
                         .primaryMaterialFit(b.getPrimaryMaterialFit())
                         .industryGroup(b.getIndustryGroup())
                         .partnerType(b.getPartnerType())
+                        .distanceKm(distanceKm)
                         .rationale(rationales.getOrDefault(b.getCode(), fallbackRationale()))
-                        .build())
+                        .build();
+                })
                 .toList();
 
         return CircularBuyerDto.RecommendRes.builder()
@@ -161,21 +185,43 @@ public class CircularBuyerRecommendService {
         });
     }
 
-    private List<CircularBuyer> rankByCosine(List<CircularBuyer> candidates, String queryText) {
+    private List<RankedBuyer> rankByScore(
+            List<CircularBuyer> candidates,
+            String queryText,
+            WarehousePoint warehousePoint
+    ) {
         float[] q;
         try {
             q = embeddingModel.embed(queryText);
         } catch (Exception e) {
             log.warn("쿼리 임베딩 생성 실패 — 코사인 정렬 없이 fallback 정렬(앞 N건). reason={}", e.getMessage());
-            return candidates.stream().limit(TOP_K).toList();
+            return candidates.stream()
+                    .limit(TOP_K)
+                    .map(b -> new RankedBuyer(b, null, 0.0))
+                    .toList();
         }
         List<Double> qVec = toDoubleList(q);
         return candidates.stream()
-                .map(b -> Map.entry(b, cosine(qVec, b.getEmbedding())))
-                .sorted((a, b) -> Double.compare(b.getValue(), a.getValue()))
+                .map(buyer -> toRankedBuyer(buyer, qVec, warehousePoint))
+                .sorted((a, b) -> Double.compare(b.score(), a.score()))
                 .limit(TOP_K)
-                .map(Map.Entry::getKey)
                 .toList();
+    }
+
+    private RankedBuyer toRankedBuyer(CircularBuyer buyer, List<Double> qVec, WarehousePoint warehousePoint) {
+        double simScore = cosine(qVec, buyer.getEmbedding());
+        boolean canUseDistance = warehousePoint != null
+                && isValidLatLng(buyer.getLatitude(), buyer.getLongitude());
+        if (!canUseDistance) {
+            return new RankedBuyer(buyer, null, simScore);
+        }
+        double distanceKm = haversineKm(
+                warehousePoint.latitude(), warehousePoint.longitude(),
+                buyer.getLatitude(), buyer.getLongitude()
+        );
+        double distScore = 1.0 / (1.0 + (distanceKm / DIST_NORM_KM));
+        double finalScore = (SIM_WEIGHT * simScore) + (DIST_WEIGHT * distScore);
+        return new RankedBuyer(buyer, round2(distanceKm), finalScore);
     }
 
     private static double cosine(List<Double> a, List<Double> b) {
@@ -230,6 +276,7 @@ public class CircularBuyerRecommendService {
 
     private String buildPrompt(List<CircularBuyer> top, CircularBuyerDto.RecommendReq req) {
         StringBuilder sb = new StringBuilder();
+        WarehousePoint wp = resolveWarehousePoint(req.getWarehouseCode());
         sb.append("너는 SPA 브랜드 본사 관리자에게 순환재고 처리 거래처를 추천하는 한국어 어시스턴트야.\n");
         sb.append("아래 재고 정보와 후보 거래처 ").append(top.size()).append("곳을 보고, ");
         sb.append("각 거래처가 왜 이 재고에 적합한지 충분히 자세하고 신뢰감 있는 사유를 작성해.\n\n");
@@ -262,6 +309,12 @@ public class CircularBuyerRecommendService {
                 sb.append(" / 취급=").append(String.join(",", b.getFactoryProduct()));
             }
             if (b.getAddress() != null) sb.append(" / 주소=").append(b.getAddress());
+            if (isValidLatLng(b.getLatitude(), b.getLongitude()) && wp != null) {
+                double d = haversineKm(wp.latitude(), wp.longitude(), b.getLatitude(), b.getLongitude());
+                sb.append(" / 거리=").append(round2(d)).append("km");
+            } else {
+                sb.append(" / 거리=거리 정보 없음");
+            }
             if (b.getDescription() != null) sb.append(" / 설명=").append(b.getDescription());
             sb.append("\n");
         }
@@ -311,4 +364,35 @@ public class CircularBuyerRecommendService {
         }
         return out;
     }
+
+    private WarehousePoint resolveWarehousePoint(String warehouseCode) {
+        if (warehouseCode == null || warehouseCode.isBlank()) return null;
+        Optional<Infrastructure> infraOpt = infrastructureRepository.findByCode(warehouseCode.trim());
+        if (infraOpt.isEmpty()) return null;
+        Infrastructure infra = infraOpt.get();
+        if (!isValidLatLng(infra.getLatitude(), infra.getLongitude())) return null;
+        return new WarehousePoint(infra.getLatitude(), infra.getLongitude());
+    }
+
+    private static boolean isValidLatLng(Double lat, Double lng) {
+        if (lat == null || lng == null) return false;
+        return lat >= -90.0 && lat <= 90.0 && lng >= -180.0 && lng <= 180.0;
+    }
+
+    private static double haversineKm(double lat1, double lng1, double lat2, double lng2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
+    }
+
+    private static double round2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private record WarehousePoint(double latitude, double longitude) {}
+    private record RankedBuyer(CircularBuyer buyer, Double distanceKm, double score) {}
 }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerRecommendService.java
@@ -115,6 +115,10 @@ public class CircularBuyerRecommendService {
                         .primaryMaterialFit(b.getPrimaryMaterialFit())
                         .industryGroup(b.getIndustryGroup())
                         .partnerType(b.getPartnerType())
+                        .factoryProduct(b.getFactoryProduct())
+                        .managerName(b.getManagerName())
+                        .phone(b.getPhone())
+                        .address(b.getAddress())
                         .distanceKm(distanceKm)
                         .rationale(rationales.getOrDefault(b.getCode(), fallbackRationale()))
                         .build();

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
@@ -156,6 +156,10 @@ public class CircularBuyerDto {
         private String primaryMaterialFit;
         private String industryGroup;
         private String partnerType;
+        private List<String> factoryProduct;
+        private String managerName;
+        private String phone;
+        private String address;
         private Double distanceKm;
         private String rationale;
     }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerDto.java
@@ -140,6 +140,7 @@ public class CircularBuyerDto {
         private String description;
         private String quantityHint;
         private String productCode;
+        private String warehouseCode;
     }
 
     /**
@@ -155,6 +156,7 @@ public class CircularBuyerDto {
         private String primaryMaterialFit;
         private String industryGroup;
         private String partnerType;
+        private Double distanceKm;
         private String rationale;
     }
 

--- a/tools/geocode_kakao_batch.py
+++ b/tools/geocode_kakao_batch.py
@@ -26,6 +26,12 @@ import pymysql
 import requests
 
 KAKAO_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+LOCK_WAIT_ERROR_CODES = {1205, 1213}
+
+_REGION_BARE_TOKENS = {
+    "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
+    "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주",
+}
 
 
 @dataclass
@@ -92,6 +98,19 @@ def strip_trailing_business_name(address: str) -> str:
     return out
 
 
+def strip_industrial_suffix(address: str) -> str:
+    """
+    산업단지 코드/층 범위 등 꼬리 제거.
+    예) 104블록6로트, 14B-1L, 1~2층
+    """
+    out = address
+    out = re.sub(r"\s+\d+\s*블록\s*\d+\s*로트.*$", "", out)
+    out = re.sub(r"\s+[A-Za-z가-힣]+\d+[A-Za-z0-9-]*\s*$", "", out)
+    out = re.sub(r"\s+\d+\s*~\s*\d+\s*층.*$", "", out)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
 def trim_detail_tokens(address: str) -> str:
     out = address
     # 외 N필지 제거
@@ -118,6 +137,13 @@ def normalize_spacing_road(address: str) -> str:
     return out
 
 
+def collapse_spacing_road(address: str) -> str:
+    """'흥안대로 439번길' -> '흥안대로439번길'."""
+    out = re.sub(r"([로길])\s+(\d)", r"\1\2", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
 def normalize_collapse_bunggil(address: str) -> str:
     """'42 번길' → '42번길': 카카오 API 는 번길 앞 공백 없는 형식을 선호."""
     out = re.sub(r"(\d)\s+번길", r"\1번길", address)
@@ -128,6 +154,20 @@ def normalize_collapse_bunggil(address: str) -> str:
 def strip_trailing_building_number(address: str) -> str:
     """도로명 뒤 건물번호(예: '1-18', '39') 제거 — 도로명만 남겨 후보 확장."""
     out = re.sub(r"\s+\d+(?:-\d+)?\s*$", "", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def strip_trailing_lot_number(address: str) -> str:
+    """지번 뒤 숫자 제거(동/읍/면까지만)."""
+    out = re.sub(r"\s+(?:산\s*)?\d+(?:-\d+)?\s*$", "", address)
+    out = re.sub(r"\s+", " ", out).strip()
+    return out
+
+
+def strip_invalid_zero_lot(address: str) -> str:
+    """비정상 지번(0, 00-0) 제거."""
+    out = re.sub(r"\s+(?:산\s*)?0+(?:-0+)?\s*$", "", address)
     out = re.sub(r"\s+", " ", out).strip()
     return out
 
@@ -175,14 +215,26 @@ def build_query_candidates(address: str) -> list[str]:
         normalize_spacing_road(base),
         normalize_spacing_road(trimmed_col),
         normalize_spacing_road(trimmed),
+        collapse_spacing_road(base_col),
+        collapse_spacing_road(base),
+        collapse_spacing_road(trimmed_col),
+        collapse_spacing_road(trimmed),
         # 건물번호 제거 버전 (도로명 레벨)
         strip_trailing_building_number(base_col),
         strip_trailing_building_number(base),
+        strip_trailing_lot_number(base_col),
+        strip_trailing_lot_number(base),
+        strip_invalid_zero_lot(base_col),
+        strip_invalid_zero_lot(base),
         # 상호 꼬리 제거 버전
         strip_trailing_business_name(base_col),
         strip_trailing_business_name(base),
         strip_trailing_business_name(trimmed_col),
         strip_trailing_business_name(trimmed),
+        strip_industrial_suffix(base_col),
+        strip_industrial_suffix(base),
+        strip_industrial_suffix(trimmed_col),
+        strip_industrial_suffix(trimmed),
     ]
 
     # 숫자 행정동 정규화 (청천2동 → 청천동)
@@ -222,8 +274,12 @@ def extract_region_tokens(address: str) -> list[str]:
     tokens = source.split()
     regions: list[str] = []
     for token in tokens:
-        if token.endswith(("시", "도", "군", "구")):
+        is_region_like = token.endswith(("시", "도", "군", "구")) or token in _REGION_BARE_TOKENS
+        if is_region_like:
             regions.append(token)
+        elif regions:
+            # 주소 선두의 행정구역 블록만 사용하고 이후 상호/설명 토큰은 무시
+            break
         if len(regions) >= 3:
             break
     return regions
@@ -288,12 +344,36 @@ def is_region_match(raw_address: str, result_address: str) -> bool:
     if "연기군" in raw_address:
         normalized_result = normalized_result.replace("세종", "충남")
 
+    result_tokens = extract_region_tokens(normalized_result)
     # 표기 정규화 + 축약(경기도/경기) 별칭 중 하나라도 포함되면 매칭
     for token in expected:
         aliases = region_aliases(token)
-        if not any(alias in normalized_result for alias in aliases):
-            return False
+        if any(alias in normalized_result for alias in aliases):
+            continue
+        if any(rt in aliases for rt in result_tokens):
+            continue
+        return False
     return True
+
+
+def execute_with_retry(
+    conn: pymysql.Connection,
+    sql: str,
+    params: tuple | None = None,
+    retry: int = 3,
+    retry_sleep: float = 0.2,
+) -> None:
+    for attempt in range(1, retry + 1):
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params or ())
+            conn.commit()
+            return
+        except pymysql.err.OperationalError as exc:
+            code = exc.args[0] if exc.args else None
+            if code not in LOCK_WAIT_ERROR_CODES or attempt == retry:
+                raise
+            time.sleep(retry_sleep * attempt)
 
 
 def parse_db_url(db_url: str) -> tuple[str, int, str]:
@@ -427,13 +507,12 @@ def process_table(
                     saw_mismatch = True
                     mismatch_result_address = result_address
                     continue
-                with conn.cursor() as cur:
-                    cur.execute(
-                        f"UPDATE {table} SET latitude=%s, longitude=%s WHERE {pk_col}=%s",
-                        (lat, lng, row_id),
-                    )
-                    cur.execute(f"DELETE FROM {miss_table} WHERE id=%s", (row_id,))
-                conn.commit()
+                execute_with_retry(
+                    conn,
+                    f"UPDATE {table} SET latitude=%s, longitude=%s WHERE {pk_col}=%s",
+                    (lat, lng, row_id),
+                )
+                execute_with_retry(conn, f"DELETE FROM {miss_table} WHERE id=%s", (row_id,))
                 success += 1
                 resolved = True
                 break
@@ -443,15 +522,14 @@ def process_table(
             fail += 1
             consecutive_api_errors += 1
             print(f"[FAIL] {table}:{row_id} -> {last_query} ({exc})")
-            with conn.cursor() as cur:
-                cur.execute(
-                    f"""
-                    REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
-                    VALUES(%s, %s, %s, %s, %s)
-                    """,
-                    (row_id, raw_address, last_query, len(candidates), "API_FAIL"),
-                )
-            conn.commit()
+            execute_with_retry(
+                conn,
+                f"""
+                REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
+                VALUES(%s, %s, %s, %s, %s)
+                """,
+                (row_id, raw_address, last_query, len(candidates), "API_FAIL"),
+            )
             if max_consecutive_api_errors > 0 and consecutive_api_errors >= max_consecutive_api_errors:
                 print(
                     f"[ABORT] 연속 API 오류 {consecutive_api_errors}회 발생으로 중단합니다. "
@@ -478,15 +556,14 @@ def process_table(
                 f"last_query='{last_query}'"
             )
             reason = "MISS"
-        with conn.cursor() as cur:
-            cur.execute(
-                f"""
-                REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
-                VALUES(%s, %s, %s, %s, %s)
-                """,
-                (row_id, raw_address, last_query, len(candidates), reason),
-            )
-        conn.commit()
+        execute_with_retry(
+            conn,
+            f"""
+            REPLACE INTO {miss_table}(id, original_address, last_query, candidate_count, miss_reason)
+            VALUES(%s, %s, %s, %s, %s)
+            """,
+            (row_id, raw_address, last_query, len(candidates), reason),
+        )
     return success, miss, fail, mismatch
 
 


### PR DESCRIPTION
## 📌 요약
- 순환 재고 거래처 추천 시 위치 정보를 반영하도록 백엔드 추천 로직을 개선했습니다.

<br><br>

## 🎯 작업 내용
- 거래처 추천 요청/처리 과정에서 위치 정보를 활용하도록 API 및 서비스 로직 수정
- 위치 기반으로 추천 거래처를 필터링하거나 정렬할 수 있도록 추천 기준 보완
- 위치 정보가 없는 경우에도 기존 추천 흐름이 유지되도록 예외 처리 추가

<br><br>

## ✔️ 참고 사항
- 프론트에서 전달하는 위치 정보와 백엔드 추천 API 요청/응답 형식이 맞는지 확인이 필요합니다.
- 위치 기반 추천 결과 검증을 위해 관련 테스트 또는 실제 데이터 확인이 권장됩니다.

<br><br>

## ✔️ 관련 이슈

- Close #307 

<br><br>