### PR TITLE
refactor(purchase-order): 카탈로그 SQL JOIN/필터 인덱스 추가

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/ProductSku.java
@@ -8,10 +8,16 @@ import lombok.NoArgsConstructor;
 import org.example.stockitbe.common.model.BaseEntity;
 
 @Entity
-@Table(name = "product_sku", uniqueConstraints = {
+@Table(name = "product_sku",
+    uniqueConstraints = {
         @UniqueConstraint(name = "uk_product_sku_code", columnNames = "sku_code"),
         @UniqueConstraint(name = "uk_product_sku_product_color_size", columnNames = {"product_code", "color", "size"})
-})
+    },
+    // status 단독 인덱스 — 카탈로그 진입점 ACTIVE 필터 가속 (ADR-027).
+    indexes = {
+        @Index(name = "idx_product_sku_status", columnList = "status")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductSku extends BaseEntity {

--- a/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
+++ b/src/main/java/org/example/stockitbe/hq/vendor/model/VendorProduct.java
@@ -10,9 +10,16 @@ import org.example.stockitbe.common.model.BaseEntity;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "vendor_product", uniqueConstraints = {
+@Table(name = "vendor_product",
+    uniqueConstraints = {
         @UniqueConstraint(name = "uk_vendor_product_code", columnNames = "code")
-})
+    },
+    // (product_code, status) 복합 인덱스 — 새 발주 카탈로그 4-way JOIN 의
+    // ProductSku ↔ VendorProduct nested loop 풀스캔 회피 (ADR-027).
+    indexes = {
+        @Index(name = "idx_vendor_product_product_code_status", columnList = "product_code, status")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VendorProduct extends BaseEntity {


### PR DESCRIPTION
## 📌 요약
- 새 발주 카탈로그 SQL 의 JOIN/필터 핵심 컬럼에 인덱스를 추가해 응답 지연을 개선.

<br><br>

## 🎯 작업 내용
- `VendorProduct` 에 `(product_code, status)` 복합 인덱스 추가 — 카탈로그 4-way JOIN nested loop 풀스캔 회피.
- `ProductSku` 에 `(status)` 인덱스 추가 — 카탈로그 진입점 ACTIVE 필터 가속.
- `ddl-auto: update` 가 다음 BE 기동 시 두 인덱스를 자동 반영.

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #313

<br><br>
