### PR TITLE
refactor: 순환 재고 거래처 조회 es 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 .env.prod
 .bkit
 .claude
+
+# Keep ES folder local-only
+ES/**

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerEsSearchService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerEsSearchService.java
@@ -1,0 +1,146 @@
+package org.example.stockitbe.hq.circularbuyer;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CircularBuyerEsSearchService {
+
+    private final ElasticsearchClient esClient;
+
+    @Value("${stockit.elasticsearch.circular-buyer-index:circular-buyer-v1}")
+    private String indexName;
+
+    public CircularBuyerDto.PageRes findPage(String keyword,
+                                             String materialFit,
+                                             String partnerType,
+                                             Pageable pageable) throws IOException {
+        String safeKeyword = blankToNull(keyword);
+        String safeMaterialFit = blankToNull(materialFit);
+        String safePartnerType = blankToNull(partnerType);
+        int page = Math.max(pageable.getPageNumber(), 0);
+        int size = Math.max(pageable.getPageSize(), 1);
+
+        List<Query> filters = new ArrayList<>();
+        if (safeMaterialFit != null) {
+            filters.add(termQuery("primary_material_fit", safeMaterialFit));
+        }
+        if (safePartnerType != null) {
+            filters.add(termQuery("partner_type", safePartnerType));
+        }
+
+        List<Query> musts = new ArrayList<>();
+        if (safeKeyword != null) {
+            musts.add(Query.of(q -> q.multiMatch(m -> m
+                    .query(safeKeyword)
+                    .fields(
+                            "code^4",
+                            "company_name^3",
+                            "company_name.ngram^2",
+                            "manager_name^2",
+                            "manager_name.ngram",
+                            "factory_product",
+                            "industry_group.text"
+                    ))));
+        }
+
+        SearchResponse<Map> response = esClient.search(s -> {
+            s.index(indexName)
+                    .from(page * size)
+                    .size(size)
+                    .trackTotalHits(t -> t.enabled(true))
+                    .source(src -> src.filter(f -> f.includes(
+                            "code",
+                            "company_name",
+                            "industry_group",
+                            "factory_product",
+                            "description",
+                            "primary_material_fit",
+                            "manager_name",
+                            "phone",
+                            "address",
+                            "partner_type"
+                    )))
+                    .query(q -> q.bool(b -> b.filter(filters).must(musts)));
+
+            if (safeKeyword == null) {
+                s.sort(so -> so.field(f -> f.field("company_name.keyword").order(SortOrder.Asc)));
+                s.sort(so -> so.field(f -> f.field("code").order(SortOrder.Asc)));
+            }
+            return s;
+        }, Map.class);
+
+        long total = response.hits().total() == null ? 0L : response.hits().total().value();
+        int totalPages = size <= 0 ? 0 : (int) Math.ceil((double) total / size);
+        List<CircularBuyerDto.ListRes> content = response.hits().hits().stream()
+                .map(Hit::source)
+                .map(this::toListRes)
+                .toList();
+
+        return CircularBuyerDto.PageRes.builder()
+                .content(content)
+                .page(page)
+                .size(size)
+                .totalPages(totalPages)
+                .totalElements(total)
+                .hasNext(page + 1 < totalPages)
+                .hasPrevious(page > 0)
+                .build();
+    }
+
+    private CircularBuyerDto.ListRes toListRes(Map<String, Object> source) {
+        return CircularBuyerDto.ListRes.builder()
+                .code(str(source.get("code")))
+                .companyName(str(source.get("company_name")))
+                .industryGroup(str(source.get("industry_group")))
+                .factoryProduct(strList(source.get("factory_product")))
+                .description(str(source.get("description")))
+                .primaryMaterialFit(str(source.get("primary_material_fit")))
+                .managerName(str(source.get("manager_name")))
+                .phone(str(source.get("phone")))
+                .address(str(source.get("address")))
+                .partnerType(str(source.get("partner_type")))
+                .build();
+    }
+
+    private Query termQuery(String field, String value) {
+        return Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(value))));
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static List<String> strList(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream()
+                    .map(v -> v == null ? "" : String.valueOf(v))
+                    .filter(s -> !s.isBlank())
+                    .toList();
+        }
+        if (value == null) {
+            return List.of();
+        }
+        String single = String.valueOf(value);
+        return single.isBlank() ? List.of() : List.of(single);
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/CircularBuyerService.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.hq.circularbuyer;
 
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CircularBuyerService {
 
     private static final Set<String> ALLOWED_MATERIAL_FITS = Set.of(
@@ -41,23 +43,15 @@ public class CircularBuyerService {
 
     private final CircularBuyerRepository circularBuyerRepository;
     private final CircularBuyerEmbeddingService embeddingService;
+    private final CircularBuyerEsSearchService esSearchService;
 
     // 4만 건+ 환경에서 페이지 없는 전체 조회는 응답 불가 수준의 부하. 최대 500건으로 제한.
     private static final int FIND_ALL_HARD_LIMIT = 500;
 
     @Transactional(readOnly = true)
     public List<CircularBuyerDto.ListRes> findAll(String keyword, String materialFit, String partnerType) {
-        if (materialFit != null && !materialFit.isBlank()) {
-            validateMaterialFit(materialFit);
-        }
-        if (partnerType != null && !partnerType.isBlank()) {
-            validatePartnerType(partnerType);
-        }
-        Specification<CircularBuyer> spec = buildSpec(keyword, materialFit, partnerType, true);
-        Page<CircularBuyer> page = circularBuyerRepository.findAll(spec, PageRequest.of(0, FIND_ALL_HARD_LIMIT));
-        return page.getContent().stream()
-                .map(CircularBuyerDto.ListRes::from)
-                .toList();
+        return findPage(keyword, materialFit, partnerType, PageRequest.of(0, FIND_ALL_HARD_LIMIT))
+                .getContent();
     }
 
     @Transactional(readOnly = true)
@@ -68,6 +62,15 @@ public class CircularBuyerService {
         if (partnerType != null && !partnerType.isBlank()) {
             validatePartnerType(partnerType);
         }
+        try {
+            return esSearchService.findPage(keyword, materialFit, partnerType, pageable);
+        } catch (Exception e) {
+            log.warn("순환재고 거래처 ES 조회 실패 — RDB fallback 수행. reason={}", e.getMessage());
+        }
+        return findPageFromRdb(keyword, materialFit, partnerType, pageable);
+    }
+
+    private CircularBuyerDto.PageRes findPageFromRdb(String keyword, String materialFit, String partnerType, Pageable pageable) {
         // embedding 컬럼 제외 JPQL 프로젝션 사용 — 행당 ~23KB JSON 역직렬화 방지.
         String kw = (keyword != null && !keyword.isBlank())
                 ? "%" + keyword.trim().toLowerCase() + "%"

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -712,6 +712,7 @@ public class InventoryService {
                 .collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
         List<Inventory> warehouseCirculars = circularInventories.stream()
                 .filter(inv -> warehouseById.containsKey(inv.getLocationId()))
+                .filter(inv -> Math.max(0, n(inv.getAvailableQuantity())) > 0)
                 .toList();
         if (warehouseCirculars.isEmpty()) {
             return buildCircularInventoryPage(List.of(), safePage, safeSize, 0);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,9 +8,10 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
-      maximum-pool-size: 20
-      minimum-idle: 2
-      connection-timeout: 10000
+      maximum-pool-size: ${DB_POOL_MAX:10}
+      minimum-idle: ${DB_POOL_MIN_IDLE:1}
+      connection-timeout: ${DB_CONNECTION_TIMEOUT_MS:15000}
+      leak-detection-threshold: ${DB_LEAK_DETECTION_THRESHOLD_MS:20000}
 
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
@@ -85,3 +86,4 @@ stockit:
     port: ${ES_PORT}
     user: ${ES_USER}
     password: ${ES_PASSWORD}
+    circular-buyer-index: ${ES_CIRCULAR_BUYER_INDEX:circular-buyer-v1}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,9 +8,10 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 3
-      connection-timeout: 10000
+      maximum-pool-size: ${DB_POOL_MAX:10}
+      minimum-idle: ${DB_POOL_MIN_IDLE:1}
+      connection-timeout: ${DB_CONNECTION_TIMEOUT_MS:15000}
+      leak-detection-threshold: ${DB_LEAK_DETECTION_THRESHOLD_MS:20000}
 
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
@@ -80,3 +81,4 @@ stockit:
     port: ${ES_PORT:9200}
     user: ${ES_USER:elastic}
     password: ${ES_PASSWORD:}
+    circular-buyer-index: ${ES_CIRCULAR_BUYER_INDEX:circular-buyer-v1}


### PR DESCRIPTION
## 📌 요약
- 순환재고 거래처 목록/페이지 조회를 Elasticsearch 기반으로 전환하고, ES 장애 시 기존 RDB 조회로 자동 fallback 되도록 적용했습니다.

<br><br>

## 🎯 작업 내용
- `CircularBuyerEsSearchService` 신규 추가: `circular-buyer-v1` 인덱스 대상 검색/필터/페이징 조회 구현
- `CircularBuyerService` 수정: `findPage`, `findAll`을 ES 우선 조회로 변경하고 예외 시 기존 JPA 조회(`findPageWithoutEmbedding`)로 fallback 처리
- 설정 추가: `stockit.elasticsearch.circular-buyer-index` / `ES_CIRCULAR_BUYER_INDEX` 환경변수로 인덱스명 외부화

<br><br>

## ✔️ 참고 사항
- ES 매핑 필드명(`company_name`, `primary_material_fit`, `partner_type` 등)에 맞춰 조회 쿼리를 구성했습니다.
- ES 응답 실패/타임아웃 상황에서도 API 가용성을 유지하도록 RDB fallback 경로를 보존했습니다.

<br><br>

## ✔️ 관련 이슈

- Close #321

<br><br>