### PR TITLE
refactor(hq-inventory): 화면별 인덱스 분리 + match/from-size + 매장·창고 분리 색인

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
@@ -21,7 +21,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -44,7 +43,6 @@ public class InventoryQueryService {
     private final InfrastructureRepository infrastructureRepository;
 
     // 전사 재고(품목 단위) 페이지 조회 — inventory-master 인덱스 + match + from/size + nested filter.
-    @Transactional(readOnly = true)
     public InventoryDto.CompanyWidePageRes findCompanyWide(LocationType locationType,
                                                             List<Long> locationIds,
                                                             String parentCategory,
@@ -111,7 +109,6 @@ public class InventoryQueryService {
     }
 
     // 전사 재고(SKU 단위) 페이지 조회 — inventory-sku 인덱스 + match + from/size + nested filter.
-    @Transactional(readOnly = true)
     public InventoryDto.CompanyWideSkuPageRes findCompanyWideSkus(LocationType locationType,
                                                                     List<Long> locationIds,
                                                                     String parentCategory,
@@ -185,7 +182,6 @@ public class InventoryQueryService {
     }
 
     // 전사 재고 SKU 상세 조회 (특정 product 의 SKU 들) — inventory-sku 인덱스 + term: product_code.
-    @Transactional(readOnly = true)
     public List<InventoryDto.CompanyWideSkuDetailRes> findCompanyWideSkuDetails(String itemCode,
                                                                                  LocationType locationType,
                                                                                  List<Long> locationIds,
@@ -237,7 +233,6 @@ public class InventoryQueryService {
     }
 
     // SKU facets (color/size distinct) — inventory-sku 인덱스 + 단순 terms agg.
-    @Transactional(readOnly = true)
     public InventoryDto.CompanyWideSkuFacetsRes findCompanyWideSkuFacets(LocationType locationType,
                                                                           List<Long> locationIds,
                                                                           String parentCategory,

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
@@ -3,25 +3,19 @@ package org.example.stockitbe.hq.inventory;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
-import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
-import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQueryField;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
-import co.elastic.clients.json.JsonData;
-import co.elastic.clients.util.NamedValue;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.infrastructure.model.LocationType;
-import org.example.stockitbe.hq.inventory.model.InventoryDoc;
 import org.example.stockitbe.hq.inventory.model.InventoryDto;
 import org.example.stockitbe.hq.inventory.model.InventoryStatus;
-import org.example.stockitbe.hq.inventory.model.InventoryStatusPolicy;
+import org.example.stockitbe.hq.inventory.model.ProductInventoryDoc;
+import org.example.stockitbe.hq.inventory.model.SkuInventoryDoc;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -31,32 +25,25 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 // ADR-028 전사 재고 조회 Read-side — Elasticsearch CQRS.
-// Command(MariaDB)/Query(ES) 책임 분리. Logstash JDBC pipeline 으로 동기화된 `inventory` 인덱스를 조회.
-// QUERY_ALLOWED_STATUSES (NORMAL/CIRCULAR_CANDIDATE) 필터는 ES query 측에서 처리.
-// terms agg + bucket_sort (ES 측 페이지 자르기) + cardinality (totalElements) 패턴 — 메모리 subList 회귀 제거.
+// Command(MariaDB)/Query(ES) 책임 분리. Logstash JDBC pipeline 으로 동기화.
+// - 마스터 화면 (findCompanyWide): `inventory-master` 인덱스 (product 단위 doc, GROUP BY product_code 미리 합산).
+// - SKU 화면 (findCompanyWideSkus / Details / Facets): `inventory-sku` 인덱스 (sku 단위 doc, GROUP BY sku_id 미리 합산).
+// terms agg + sub-aggs 제거 → match + from/size + nested by_location filter 로 ms 단위 latency.
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class InventoryQueryService {
 
-    private static final String INDEX = "inventory";
-    private static final int MAX_PRODUCT_BUCKETS = 5000;
-    private static final int MAX_SKU_BUCKETS = 5000;
+    private static final String MASTER_INDEX = "inventory-master";
+    private static final String SKU_INDEX = "inventory-sku";
 
     private final ElasticsearchClient esClient;
     private final InfrastructureRepository infrastructureRepository;
 
-    // 전사 재고(품목 단위) 페이지 조회 — terms agg + bucket_sort (ES 측 페이지 자르기) + cardinality (totalElements).
-    // 모놀리식 시기 응답 포맷(page/totalElements/totalPages) 그대로 유지 (FE 호환).
-    // ES 단순 이전(PR #320) 의 회귀(1000 buckets fetch + 메모리 subList) 제거 — buckets 자르기를 ES coordinator 가 수행.
+    // 전사 재고(품목 단위) 페이지 조회 — inventory-master 인덱스 + match + from/size + nested filter.
     @Transactional(readOnly = true)
     public InventoryDto.CompanyWidePageRes findCompanyWide(LocationType locationType,
                                                             List<Long> locationIds,
@@ -78,51 +65,44 @@ public class InventoryQueryService {
         int from = safePageable.getPageNumber() * safePageable.getPageSize();
         int pageSize = safePageable.getPageSize();
 
-        List<Query> filters = buildCommonFilters(
-                locationType, locationIds, safeParent, safeChild, safeCategory, status, safeKeyword
-        );
+        List<Query> filters = new ArrayList<>();
+        if (safeParent != null) filters.add(termQuery("parent_category", safeParent));
+        if (safeChild != null) filters.add(termQuery("child_category", safeChild));
+        if (safeCategory != null) {
+            filters.add(Query.of(q -> q.bool(b -> b
+                    .should(termQuery("parent_category", safeCategory))
+                    .should(termQuery("child_category", safeCategory))
+                    .minimumShouldMatch("1"))));
+        }
+        if (locationType != null || (locationIds != null && !locationIds.isEmpty())) {
+            filters.add(buildNestedLocationFilter(locationType, locationIds));
+        }
+
+        List<Query> musts = new ArrayList<>();
+        if (safeKeyword != null) {
+            musts.add(Query.of(q -> q.multiMatch(m -> m
+                    .query(safeKeyword)
+                    .fields("product_code", "product_name"))));
+        }
 
         try {
-            SearchResponse<InventoryDoc> response = esClient.search(s -> s
-                    .index(INDEX)
-                    .size(0)
-                    .query(q -> q.bool(b -> b.filter(filters)))
-                    .aggregations("by_product", a -> a
-                            .terms(t -> t.field("product_code.keyword")
-                                    .size(MAX_PRODUCT_BUCKETS)
-                                    .order(NamedValue.of("_key", SortOrder.Asc)))
-                            .aggregations("total_quantity", sub -> sub.sum(sm -> sm.field("quantity")))
-                            .aggregations("total_available", sub -> sub.sum(sm -> sm.field("available_quantity")))
-                            .aggregations("last_update", sub -> sub.max(mx -> mx.field("update_date")))
-                            .aggregations("safety_warehouse", sub -> sub
-                                    .filter(qf -> qf.term(t -> t.field("location_type.keyword").value("WAREHOUSE")))
-                                    .aggregations("sum_w", inner -> inner.sum(sm -> sm.field("warehouse_safety_stock"))))
-                            .aggregations("safety_store", sub -> sub
-                                    .filter(qf -> qf.term(t -> t.field("location_type.keyword").value("STORE")))
-                                    .aggregations("sum_s", inner -> inner.sum(sm -> sm.field("store_safety_stock"))))
-                            .aggregations("product_meta", sub -> sub
-                                    .topHits(th -> th.size(1)
-                                            .source(src -> src.filter(f -> f.includes(
-                                                    "product_name", "parent_category", "child_category"
-                                            )))))
-                            // bucket_sort: terms buckets 를 coordinator 가 from/size 로 자른다 → BE 로 전송되는 buckets 는 pageSize 만.
-                            .aggregations("page_window", sub -> sub
-                                    .bucketSort(bs -> bs.from(from).size(pageSize)))
-                    )
-                    .aggregations("total_products", a -> a
-                            .cardinality(c -> c.field("product_code.keyword"))),
-                    InventoryDoc.class);
+            SearchResponse<ProductInventoryDoc> response = esClient.search(s -> s
+                    .index(MASTER_INDEX)
+                    .from(from)
+                    .size(pageSize)
+                    .trackTotalHits(t -> t.enabled(true))
+                    .query(q -> q.bool(b -> b.filter(filters).must(musts)))
+                    .sort(so -> so.field(f -> f.field("product_code").order(SortOrder.Asc))),
+                    ProductInventoryDoc.class);
 
-            Aggregate byProduct = response.aggregations().get("by_product");
-            List<StringTermsBucket> buckets = byProduct.sterms().buckets().array();
-
-            List<InventoryDto.CompanyWideRes> pageContent = buckets.stream()
-                    .map(this::toCompanyWideRes)
+            long total = response.hits().total() == null ? 0L : response.hits().total().value();
+            List<InventoryDto.CompanyWideRes> items = response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(d -> d != null)
+                    .map(d -> toCompanyWideResFromDoc(d, locationType))
                     .toList();
 
-            long total = (long) response.aggregations().get("total_products").cardinality().value();
-            Page<InventoryDto.CompanyWideRes> page = new PageImpl<>(pageContent, safePageable, total);
-
+            Page<InventoryDto.CompanyWideRes> page = new PageImpl<>(items, safePageable, total);
             return InventoryDto.CompanyWidePageRes.from(page, buildLocationOptions(locationType));
         } catch (Exception e) {
             log.error("findCompanyWide ES query failed", e);
@@ -130,82 +110,7 @@ public class InventoryQueryService {
         }
     }
 
-    @Transactional(readOnly = true)
-    public List<InventoryDto.CompanyWideSkuDetailRes> findCompanyWideSkuDetails(String itemCode,
-                                                                                 LocationType locationType,
-                                                                                 List<Long> locationIds,
-                                                                                 String parentCategory,
-                                                                                 String childCategory,
-                                                                                 InventoryStatus status,
-                                                                                 String keyword) {
-        if (itemCode == null || itemCode.isBlank()) return List.of();
-        String safeItemCode = itemCode.trim();
-        String safeKeyword = blankToNull(keyword);
-
-        List<Query> filters = new ArrayList<>();
-        filters.add(termQuery("product_code.keyword", safeItemCode));
-        filters.add(allowedStatusFilter());
-        if (locationType != null) filters.add(termQuery("location_type", locationType.name()));
-        if (locationIds != null && !locationIds.isEmpty()) filters.add(termsLongQuery("location_id", locationIds));
-        if (status != null) filters.add(termQuery("inventory_status", status.name()));
-        if (parentCategory != null && !parentCategory.isBlank()) filters.add(termQuery("parent_category", parentCategory.trim()));
-        if (childCategory != null && !childCategory.isBlank()) filters.add(termQuery("child_category", childCategory.trim()));
-
-        List<Query> musts = new ArrayList<>();
-        if (safeKeyword != null) {
-            musts.add(Query.of(q -> q.multiMatch(m -> m
-                    .query(safeKeyword)
-                    .fields("sku_code", "color", "size", "location_name"))));
-        }
-
-        try {
-            SearchResponse<InventoryDoc> response = esClient.search(s -> s
-                    .index(INDEX)
-                    .size(MAX_SKU_BUCKETS)
-                    .query(q -> q.bool(b -> b
-                            .filter(filters)
-                            .must(musts)
-                    )), InventoryDoc.class);
-
-            Map<Long, SkuDetailAggregate> bySku = new LinkedHashMap<>();
-            for (Hit<InventoryDoc> hit : response.hits().hits()) {
-                InventoryDoc doc = hit.source();
-                if (doc == null || doc.getSkuId() == null) continue;
-                SkuDetailAggregate agg = bySku.computeIfAbsent(doc.getSkuId(), k -> new SkuDetailAggregate(doc));
-                agg.actualStock += nz(doc.getQuantity());
-                agg.availableStock += nz(doc.getAvailableQuantity());
-                String safetyKey = doc.getSkuId() + ":" + doc.getLocationId();
-                if (agg.safetyKeys.add(safetyKey)) {
-                    boolean isWarehouse = "WAREHOUSE".equals(doc.getLocationType());
-                    agg.safetyStock += nz(isWarehouse ? doc.getWarehouseSafetyStock() : doc.getStoreSafetyStock());
-                }
-                Date docUpdated = doc.getUpdateDate();
-                if (docUpdated != null && (agg.updatedAt == null || docUpdated.after(agg.updatedAt))) {
-                    agg.updatedAt = docUpdated;
-                }
-            }
-
-            return bySku.values().stream()
-                    .filter(agg -> agg.actualStock > 0 || agg.availableStock > 0)
-                    .map(agg -> InventoryDto.CompanyWideSkuDetailRes.builder()
-                            .skuCode(agg.skuCode)
-                            .color(agg.color)
-                            .size(agg.size)
-                            .unitPrice(agg.unitPrice)
-                            .actualStock(agg.actualStock)
-                            .availableStock(agg.availableStock)
-                            .safetyStock(agg.safetyStock)
-                            .status(toUiStatus(agg.availableStock, agg.safetyStock))
-                            .updatedAt(agg.updatedAt)
-                            .build())
-                    .sorted(Comparator.comparing(InventoryDto.CompanyWideSkuDetailRes::getSkuCode))
-                    .toList();
-        } catch (Exception e) {
-            log.error("findCompanyWideSkuDetails ES query failed", e);
-            throw new RuntimeException(e);
-        }
-    }
-
+    // 전사 재고(SKU 단위) 페이지 조회 — inventory-sku 인덱스 + match + from/size + nested filter.
     @Transactional(readOnly = true)
     public InventoryDto.CompanyWideSkuPageRes findCompanyWideSkus(LocationType locationType,
                                                                     List<Long> locationIds,
@@ -231,13 +136,13 @@ public class InventoryQueryService {
         int pageSize = safePageable.getPageSize();
 
         List<Query> filters = new ArrayList<>();
-        filters.add(allowedStatusFilter());
-        if (locationType != null) filters.add(termQuery("location_type", locationType.name()));
-        if (locationIds != null && !locationIds.isEmpty()) filters.add(termsLongQuery("location_id", locationIds));
         if (safeParent != null) filters.add(termQuery("parent_category", safeParent));
         if (safeChild != null) filters.add(termQuery("child_category", safeChild));
         if (safeColor != null) filters.add(termQuery("color", safeColor));
         if (safeSkuSize != null) filters.add(termQuery("size", safeSkuSize));
+        if (locationType != null || (locationIds != null && !locationIds.isEmpty())) {
+            filters.add(buildNestedLocationFilter(locationType, locationIds));
+        }
 
         List<Query> musts = new ArrayList<>();
         if (safeKeyword != null) {
@@ -247,46 +152,23 @@ public class InventoryQueryService {
         }
 
         try {
-            SearchResponse<InventoryDoc> response = esClient.search(s -> s
-                    .index(INDEX)
-                    .size(0)
+            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> s
+                    .index(SKU_INDEX)
+                    .from(from)
+                    .size(pageSize)
+                    .trackTotalHits(t -> t.enabled(true))
                     .query(q -> q.bool(b -> b.filter(filters).must(musts)))
-                    .aggregations("by_sku", a -> a
-                            .terms(t -> t.field("sku_id")
-                                    .size(MAX_SKU_BUCKETS)
-                                    .order(NamedValue.of("_key", SortOrder.Asc)))
-                            .aggregations("total_quantity", sub -> sub.sum(sm -> sm.field("quantity")))
-                            .aggregations("total_available", sub -> sub.sum(sm -> sm.field("available_quantity")))
-                            .aggregations("safety_warehouse", sub -> sub
-                                    .filter(qf -> qf.term(t -> t.field("location_type.keyword").value("WAREHOUSE")))
-                                    .aggregations("sum_w", inner -> inner.sum(sm -> sm.field("warehouse_safety_stock"))))
-                            .aggregations("safety_store", sub -> sub
-                                    .filter(qf -> qf.term(t -> t.field("location_type.keyword").value("STORE")))
-                                    .aggregations("sum_s", inner -> inner.sum(sm -> sm.field("store_safety_stock"))))
-                            .aggregations("sku_meta", sub -> sub
-                                    .topHits(th -> th.size(1)
-                                            .source(src -> src.filter(f -> f.includes(
-                                                    "sku_code", "color", "size",
-                                                    "product_code", "product_name",
-                                                    "parent_category", "child_category"
-                                            )))))
-                            // bucket_sort: terms buckets 를 coordinator 가 from/size 로 자른다 → BE 로 전송되는 buckets 는 pageSize 만.
-                            .aggregations("page_window", sub -> sub
-                                    .bucketSort(bs -> bs.from(from).size(pageSize)))
-                    )
-                    .aggregations("total_skus", a -> a
-                            .cardinality(c -> c.field("sku_id"))),
-                    InventoryDoc.class);
+                    .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc))),
+                    SkuInventoryDoc.class);
 
-            Aggregate bySku = response.aggregations().get("by_sku");
-            List<LongTermsBucket> buckets = bySku.lterms().buckets().array();
-
-            List<InventoryDto.CompanyWideSkuRowRes> pageContent = buckets.stream()
-                    .map(this::toSkuRowRes)
+            long total = response.hits().total() == null ? 0L : response.hits().total().value();
+            List<InventoryDto.CompanyWideSkuRowRes> items = response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(d -> d != null)
+                    .map(d -> toSkuRowResFromDoc(d, locationType))
                     .toList();
 
-            long total = (long) response.aggregations().get("total_skus").cardinality().value();
-            Page<InventoryDto.CompanyWideSkuRowRes> page = new PageImpl<>(pageContent, safePageable, total);
+            Page<InventoryDto.CompanyWideSkuRowRes> page = new PageImpl<>(items, safePageable, total);
 
             if (safeStatus != null) {
                 List<InventoryDto.CompanyWideSkuRowRes> filtered = page.getContent().stream()
@@ -302,6 +184,59 @@ public class InventoryQueryService {
         }
     }
 
+    // 전사 재고 SKU 상세 조회 (특정 product 의 SKU 들) — inventory-sku 인덱스 + term: product_code.
+    @Transactional(readOnly = true)
+    public List<InventoryDto.CompanyWideSkuDetailRes> findCompanyWideSkuDetails(String itemCode,
+                                                                                 LocationType locationType,
+                                                                                 List<Long> locationIds,
+                                                                                 String parentCategory,
+                                                                                 String childCategory,
+                                                                                 InventoryStatus status,
+                                                                                 String keyword) {
+        if (itemCode == null || itemCode.isBlank()) return List.of();
+        String safeItemCode = itemCode.trim();
+        String safeKeyword = blankToNull(keyword);
+        String safeParent = blankToNull(parentCategory);
+        String safeChild = blankToNull(childCategory);
+
+        List<Query> filters = new ArrayList<>();
+        filters.add(termQuery("product_code", safeItemCode));
+        if (safeParent != null) filters.add(termQuery("parent_category", safeParent));
+        if (safeChild != null) filters.add(termQuery("child_category", safeChild));
+        if (locationType != null || (locationIds != null && !locationIds.isEmpty())) {
+            filters.add(buildNestedLocationFilter(locationType, locationIds));
+        }
+
+        List<Query> musts = new ArrayList<>();
+        if (safeKeyword != null) {
+            musts.add(Query.of(q -> q.multiMatch(m -> m
+                    .query(safeKeyword)
+                    .fields("sku_code", "color", "size"))));
+        }
+
+        try {
+            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> s
+                    .index(SKU_INDEX)
+                    .size(1000)
+                    .trackTotalHits(t -> t.enabled(true))
+                    .query(q -> q.bool(b -> b.filter(filters).must(musts)))
+                    .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc))),
+                    SkuInventoryDoc.class);
+
+            final LocationType lt = locationType;
+            return response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(d -> d != null)
+                    .filter(d -> nz(d.getTotalQuantity()) > 0 || nz(d.getTotalAvailable()) > 0)
+                    .map(d -> toSkuDetailResFromDoc(d, lt))
+                    .toList();
+        } catch (Exception e) {
+            log.error("findCompanyWideSkuDetails ES query failed", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    // SKU facets (color/size distinct) — inventory-sku 인덱스 + 단순 terms agg.
     @Transactional(readOnly = true)
     public InventoryDto.CompanyWideSkuFacetsRes findCompanyWideSkuFacets(LocationType locationType,
                                                                           List<Long> locationIds,
@@ -313,11 +248,11 @@ public class InventoryQueryService {
         String safeKeyword = blankToNull(keyword);
 
         List<Query> filters = new ArrayList<>();
-        filters.add(allowedStatusFilter());
-        if (locationType != null) filters.add(termQuery("location_type", locationType.name()));
-        if (locationIds != null && !locationIds.isEmpty()) filters.add(termsLongQuery("location_id", locationIds));
         if (safeParent != null) filters.add(termQuery("parent_category", safeParent));
         if (safeChild != null) filters.add(termQuery("child_category", safeChild));
+        if (locationType != null || (locationIds != null && !locationIds.isEmpty())) {
+            filters.add(buildNestedLocationFilter(locationType, locationIds));
+        }
 
         List<Query> musts = new ArrayList<>();
         if (safeKeyword != null) {
@@ -328,11 +263,11 @@ public class InventoryQueryService {
 
         try {
             SearchResponse<Void> response = esClient.search(s -> s
-                    .index(INDEX)
+                    .index(SKU_INDEX)
                     .size(0)
                     .query(q -> q.bool(b -> b.filter(filters).must(musts)))
-                    .aggregations("colors", a -> a.terms(t -> t.field("color.keyword").size(100)))
-                    .aggregations("sizes", a -> a.terms(t -> t.field("size.keyword").size(100))),
+                    .aggregations("colors", a -> a.terms(t -> t.field("color").size(100)))
+                    .aggregations("sizes", a -> a.terms(t -> t.field("size").size(100))),
                     Void.class);
 
             List<String> colors = response.aggregations().get("colors").sterms().buckets().array().stream()
@@ -356,117 +291,99 @@ public class InventoryQueryService {
         }
     }
 
-    private List<Query> buildCommonFilters(LocationType locationType,
-                                            List<Long> locationIds,
-                                            String parentCategory,
-                                            String childCategory,
-                                            String category,
-                                            InventoryStatus status,
-                                            String keyword) {
-        List<Query> filters = new ArrayList<>();
-        filters.add(allowedStatusFilter());
-        if (locationType != null) filters.add(termQuery("location_type", locationType.name()));
-        if (locationIds != null && !locationIds.isEmpty()) filters.add(termsLongQuery("location_id", locationIds));
-        if (status != null) filters.add(termQuery("inventory_status", status.name()));
-        if (parentCategory != null) filters.add(termQuery("parent_category", parentCategory));
-        if (childCategory != null) filters.add(termQuery("child_category", childCategory));
-        if (category != null) {
-            filters.add(Query.of(q -> q.bool(b -> b
-                    .should(termQuery("parent_category", category))
-                    .should(termQuery("child_category", category))
-                    .minimumShouldMatch("1"))));
+    // ---------- Helpers ----------
+
+    private Query buildNestedLocationFilter(LocationType locationType, List<Long> locationIds) {
+        List<Query> inner = new ArrayList<>();
+        if (locationType != null) {
+            inner.add(Query.of(q -> q.term(t -> t
+                    .field("by_location.location_type")
+                    .value(locationType.name()))));
         }
-        if (keyword != null) {
-            filters.add(Query.of(q -> q.multiMatch(m -> m
-                    .query(keyword)
-                    .fields("product_code", "product_name", "sku_code"))));
+        if (locationIds != null && !locationIds.isEmpty()) {
+            List<FieldValue> ids = locationIds.stream().map(FieldValue::of).toList();
+            inner.add(Query.of(q -> q.terms(t -> t
+                    .field("by_location.location_id")
+                    .terms(TermsQueryField.of(tf -> tf.value(ids))))));
         }
-        return filters;
+        return Query.of(q -> q.nested(n -> n
+                .path("by_location")
+                .query(qi -> qi.bool(b -> b.filter(inner)))));
     }
 
-    private Query allowedStatusFilter() {
-        List<FieldValue> values = InventoryStatusPolicy.QUERY_ALLOWED_STATUSES.stream()
-                .map(s -> FieldValue.of(s.name()))
-                .toList();
-        return Query.of(q -> q.terms(t -> t
-                .field("inventory_status.keyword")
-                .terms(TermsQueryField.of(tf -> tf.value(values)))));
-    }
-
-    // text 필드는 keyword 서브필드 사용 (Logstash dynamic mapping 기준 ES 기본값).
-    // 호출처에서 이미 ".keyword" 명시한 경우 그대로 사용.
     private Query termQuery(String field, String value) {
-        String f = field.endsWith(".keyword") ? field : field + ".keyword";
-        return Query.of(q -> q.term(t -> t.field(f).value(value)));
+        return Query.of(q -> q.term(t -> t.field(field).value(value)));
     }
 
-    private Query termsLongQuery(String field, List<Long> ids) {
-        List<FieldValue> values = ids.stream().map(FieldValue::of).toList();
-        return Query.of(q -> q.terms(t -> t.field(field).terms(TermsQueryField.of(tf -> tf.value(values)))));
+    // locationType 별로 store_*, warehouse_*, total_* field 선택.
+    private static class StockTriple {
+        final int actual, available, safety;
+        StockTriple(int a, int av, int s) { this.actual = a; this.available = av; this.safety = s; }
     }
 
-    private InventoryDto.CompanyWideRes toCompanyWideRes(StringTermsBucket bucket) {
-        String itemCode = bucket.key().stringValue();
-        int actual = (int) Math.round(bucket.aggregations().get("total_quantity").sum().value());
-        int available = (int) Math.round(bucket.aggregations().get("total_available").sum().value());
-        int safety = readSafetySum(bucket.aggregations());
+    private StockTriple pickProductStocks(ProductInventoryDoc d, LocationType lt) {
+        if (lt == LocationType.STORE) {
+            return new StockTriple(nz(d.getStoreQuantity()), nz(d.getStoreAvailable()), nz(d.getStoreSafety()));
+        } else if (lt == LocationType.WAREHOUSE) {
+            return new StockTriple(nz(d.getWarehouseQuantity()), nz(d.getWarehouseAvailable()), nz(d.getWarehouseSafety()));
+        }
+        return new StockTriple(nz(d.getTotalQuantity()), nz(d.getTotalAvailable()), nz(d.getTotalSafety()));
+    }
 
-        InventoryDoc metaDoc = readTopHit(bucket.aggregations().get("product_meta").topHits());
-        String itemName = metaDoc == null ? "" : nullToEmpty(metaDoc.getProductName());
-        String parent = metaDoc == null ? "" : nullToEmpty(metaDoc.getParentCategory());
-        String child = metaDoc == null ? "" : nullToEmpty(metaDoc.getChildCategory());
+    private StockTriple pickSkuStocks(SkuInventoryDoc d, LocationType lt) {
+        if (lt == LocationType.STORE) {
+            return new StockTriple(nz(d.getStoreQuantity()), nz(d.getStoreAvailable()), nz(d.getStoreSafety()));
+        } else if (lt == LocationType.WAREHOUSE) {
+            return new StockTriple(nz(d.getWarehouseQuantity()), nz(d.getWarehouseAvailable()), nz(d.getWarehouseSafety()));
+        }
+        return new StockTriple(nz(d.getTotalQuantity()), nz(d.getTotalAvailable()), nz(d.getTotalSafety()));
+    }
 
-        Double lastUpdate = bucket.aggregations().get("last_update").max().value();
-        Date updatedAt = lastUpdate == null || lastUpdate == 0d || Double.isNaN(lastUpdate)
-                ? null : new Date(lastUpdate.longValue());
-
+    private InventoryDto.CompanyWideRes toCompanyWideResFromDoc(ProductInventoryDoc doc, LocationType locationType) {
+        StockTriple s = pickProductStocks(doc, locationType);
         return InventoryDto.CompanyWideRes.builder()
-                .itemCode(itemCode)
-                .parentCategory(parent)
-                .childCategory(child)
-                .itemName(itemName)
-                .actualStock(actual)
-                .availableStock(available)
-                .safetyStock(safety)
-                .status(toUiStatus(available, safety))
-                .updatedAt(updatedAt)
+                .itemCode(doc.getProductCode())
+                .parentCategory(nullToEmpty(doc.getParentCategory()))
+                .childCategory(nullToEmpty(doc.getChildCategory()))
+                .itemName(nullToEmpty(doc.getProductName()))
+                .actualStock(s.actual)
+                .availableStock(s.available)
+                .safetyStock(s.safety)
+                .status(toUiStatus(s.available, s.safety))
+                .updatedAt(doc.getLastUpdate())
                 .build();
     }
 
-    private InventoryDto.CompanyWideSkuRowRes toSkuRowRes(LongTermsBucket bucket) {
-        int actual = (int) Math.round(bucket.aggregations().get("total_quantity").sum().value());
-        int available = (int) Math.round(bucket.aggregations().get("total_available").sum().value());
-        int safety = readSafetySum(bucket.aggregations());
-
-        InventoryDoc m = readTopHit(bucket.aggregations().get("sku_meta").topHits());
-
+    private InventoryDto.CompanyWideSkuRowRes toSkuRowResFromDoc(SkuInventoryDoc doc, LocationType locationType) {
+        StockTriple s = pickSkuStocks(doc, locationType);
         return InventoryDto.CompanyWideSkuRowRes.builder()
-                .skuCode(m == null ? "" : nullToEmpty(m.getSkuCode()))
-                .itemCode(m == null ? "" : nullToEmpty(m.getProductCode()))
-                .itemName(m == null ? "" : nullToEmpty(m.getProductName()))
-                .parentCategory(m == null ? "" : nullToEmpty(m.getParentCategory()))
-                .childCategory(m == null ? "" : nullToEmpty(m.getChildCategory()))
-                .color(m == null ? "" : nullToEmpty(m.getColor()))
-                .size(m == null ? "" : nullToEmpty(m.getSize()))
-                .actualStock(actual)
-                .availableStock(available)
-                .safetyStock(safety)
-                .status(toUiStatus(available, safety))
+                .skuCode(nullToEmpty(doc.getSkuCode()))
+                .itemCode(nullToEmpty(doc.getProductCode()))
+                .itemName(nullToEmpty(doc.getProductName()))
+                .parentCategory(nullToEmpty(doc.getParentCategory()))
+                .childCategory(nullToEmpty(doc.getChildCategory()))
+                .color(nullToEmpty(doc.getColor()))
+                .size(nullToEmpty(doc.getSize()))
+                .actualStock(s.actual)
+                .availableStock(s.available)
+                .safetyStock(s.safety)
+                .status(toUiStatus(s.available, s.safety))
                 .build();
     }
 
-    private int readSafetySum(Map<String, Aggregate> aggs) {
-        double w = aggs.get("safety_warehouse").filter().aggregations().get("sum_w").sum().value();
-        double s = aggs.get("safety_store").filter().aggregations().get("sum_s").sum().value();
-        return (int) Math.round(w + s);
-    }
-
-    private InventoryDoc readTopHit(TopHitsAggregate topHits) {
-        if (topHits == null) return null;
-        List<Hit<JsonData>> hits = topHits.hits().hits();
-        if (hits.isEmpty()) return null;
-        JsonData src = hits.get(0).source();
-        return src == null ? null : src.to(InventoryDoc.class);
+    private InventoryDto.CompanyWideSkuDetailRes toSkuDetailResFromDoc(SkuInventoryDoc doc, LocationType locationType) {
+        StockTriple s = pickSkuStocks(doc, locationType);
+        return InventoryDto.CompanyWideSkuDetailRes.builder()
+                .skuCode(nullToEmpty(doc.getSkuCode()))
+                .color(nullToEmpty(doc.getColor()))
+                .size(nullToEmpty(doc.getSize()))
+                .unitPrice(null)
+                .actualStock(s.actual)
+                .availableStock(s.available)
+                .safetyStock(s.safety)
+                .status(toUiStatus(s.available, s.safety))
+                .updatedAt(doc.getLastUpdate())
+                .build();
     }
 
     private List<InventoryDto.LocationOptionRes> buildLocationOptions(LocationType locationType) {
@@ -490,24 +407,5 @@ public class InventoryQueryService {
         if (available <= 0) return "품절";
         if (available < safety) return "부족";
         return "정상";
-    }
-
-    private static class SkuDetailAggregate {
-        private final String skuCode;
-        private final String color;
-        private final String size;
-        private final Long unitPrice;
-        private int actualStock = 0;
-        private int availableStock = 0;
-        private int safetyStock = 0;
-        private Date updatedAt;
-        private final Set<String> safetyKeys = new HashSet<>();
-
-        private SkuDetailAggregate(InventoryDoc doc) {
-            this.skuCode = doc.getSkuCode();
-            this.color = doc.getColor();
-            this.size = doc.getSize();
-            this.unitPrice = doc.getUnitPrice();
-        }
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/ProductInventoryDoc.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/ProductInventoryDoc.java
@@ -1,0 +1,84 @@
+package org.example.stockitbe.hq.inventory.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+// inventory-master ES 인덱스 매핑 DTO (ADR-028 — product 단위 doc 재설계).
+// Logstash JDBC pipeline 이 GROUP BY product_code 로 미리 집계된 doc 색인.
+@Data
+@NoArgsConstructor
+public class ProductInventoryDoc {
+
+    @JsonProperty("product_code")
+    private String productCode;
+
+    @JsonProperty("product_name")
+    private String productName;
+
+    @JsonProperty("parent_category")
+    private String parentCategory;
+
+    @JsonProperty("child_category")
+    private String childCategory;
+
+    @JsonProperty("total_quantity")
+    private Integer totalQuantity;
+
+    @JsonProperty("total_available")
+    private Integer totalAvailable;
+
+    @JsonProperty("total_safety")
+    private Integer totalSafety;
+
+    @JsonProperty("store_quantity")
+    private Integer storeQuantity;
+
+    @JsonProperty("warehouse_quantity")
+    private Integer warehouseQuantity;
+
+    @JsonProperty("store_available")
+    private Integer storeAvailable;
+
+    @JsonProperty("warehouse_available")
+    private Integer warehouseAvailable;
+
+    @JsonProperty("store_safety")
+    private Integer storeSafety;
+
+    @JsonProperty("warehouse_safety")
+    private Integer warehouseSafety;
+
+    @JsonProperty("last_update")
+    private Date lastUpdate;
+
+    @JsonProperty("by_location")
+    private List<LocationStock> byLocation;
+
+    @Data
+    @NoArgsConstructor
+    public static class LocationStock {
+        @JsonProperty("location_id")
+        private Long locationId;
+
+        @JsonProperty("location_code")
+        private String locationCode;
+
+        @JsonProperty("location_type")
+        private String locationType;
+
+        @JsonProperty("location_region")
+        private String locationRegion;
+
+        private Integer quantity;
+
+        @JsonProperty("available_quantity")
+        private Integer availableQuantity;
+
+        @JsonProperty("safety_stock")
+        private Integer safetyStock;
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/inventory/model/SkuInventoryDoc.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/model/SkuInventoryDoc.java
@@ -1,0 +1,69 @@
+package org.example.stockitbe.hq.inventory.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+// inventory-sku ES 인덱스 매핑 DTO (ADR-028 — sku 단위 doc 재설계).
+// Logstash JDBC pipeline 이 GROUP BY sku_id 로 미리 집계된 doc 색인.
+@Data
+@NoArgsConstructor
+public class SkuInventoryDoc {
+
+    @JsonProperty("sku_id")
+    private Long skuId;
+
+    @JsonProperty("sku_code")
+    private String skuCode;
+
+    private String color;
+    private String size;
+
+    @JsonProperty("product_code")
+    private String productCode;
+
+    @JsonProperty("product_name")
+    private String productName;
+
+    @JsonProperty("parent_category")
+    private String parentCategory;
+
+    @JsonProperty("child_category")
+    private String childCategory;
+
+    @JsonProperty("total_quantity")
+    private Integer totalQuantity;
+
+    @JsonProperty("total_available")
+    private Integer totalAvailable;
+
+    @JsonProperty("total_safety")
+    private Integer totalSafety;
+
+    @JsonProperty("store_quantity")
+    private Integer storeQuantity;
+
+    @JsonProperty("warehouse_quantity")
+    private Integer warehouseQuantity;
+
+    @JsonProperty("store_available")
+    private Integer storeAvailable;
+
+    @JsonProperty("warehouse_available")
+    private Integer warehouseAvailable;
+
+    @JsonProperty("store_safety")
+    private Integer storeSafety;
+
+    @JsonProperty("warehouse_safety")
+    private Integer warehouseSafety;
+
+    @JsonProperty("last_update")
+    private Date lastUpdate;
+
+    @JsonProperty("by_location")
+    private List<ProductInventoryDoc.LocationStock> byLocation;
+}


### PR DESCRIPTION
## 📌 요약
- ADR-028 doc 재설계 — 화면 단위와 doc 단위 mismatch 해결 (`inventory-master` / `inventory-sku` 별 인덱스 + Logstash 미리 합산 색인). terms agg + 5 sub-aggs 제거 → `match + from/size + nested filter` 로 단순화.

<br><br>

## 🎯 작업 내용
- `ProductInventoryDoc` / `SkuInventoryDoc` DTO 신설 — 마스터/SKU 화면별 ES 인덱스 매핑.
- `InventoryQueryService.findCompanyWide` / `findCompanyWideSkus` / `findCompanyWideSkuDetails` / `findCompanyWideSkuFacets` 재작성 — terms agg + bucket_sort + cardinality + top_hits 제거, match + from/size + nested `by_location` filter 로 단순화.
- 매장/창고 별 quantity·available·safety 분리 색인 (`store_*`, `warehouse_*`). `locationType` 따라 적절한 field 선택 — 단계 3 의 row 단위 filter UX (재고량 변화) 를 product 단위 doc 에서도 유지.
- `inventory_status` 필터 위치 이동: BE query → Logstash WHERE 절. doc 단위 미리 합산이라 BE row-level filter 불가.
- 기존 helper (`toCompanyWideRes` / `toSkuRowRes` / `readSafetySum` / `readTopHit` / `SkuDetailAggregate` / `allowedStatusFilter` / `termsLongQuery` / `MAX_*_BUCKETS`) 제거.

<br><br>

## ✔️ 참고 사항
- 인프라 측: Logstash CR 의 `master` / `sku` pipeline 추가 + JDBC SQL GROUP BY + JSON_ARRAYAGG + store/warehouse SUM CASE. ES 인덱스는 nori analyzer + nested `by_location` 명시 매핑.
- dev 데이터 규모: product 29 / sku 500 unique. 실제 운영급 SPA (product 수천~) 에선 더 큰 효과 예상.
- portfolio 단계 4 narrative — k6 재측정 결과는 별도 보고.

<br><br>

## ✔️ 관련 이슈

- Close #332

<br><br>
