### PR TITLE
Feat/feedback work

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/AsyncConfig.java
@@ -1,0 +1,42 @@
+package org.example.stockitbe.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 비동기 처리 전용 스레드 풀 설정.
+ *
+ * 현재 등록 풀:
+ *   - notificationExecutor : SSE push fan-out 전용 (1500+ HQ admin 대응)
+ *
+ * 정책:
+ *   - CallerRunsPolicy — 큐 가득 차면 호출자(도메인 스레드)가 실행.
+ *     알림 누락 없이 약간의 지연만 발생 (Discard/Abort 보다 안전).
+ *   - 사용자별 emitter.send 가 별도 스레드에서 병렬 실행 → fan-out 시간 ↓.
+ */
+@Configuration
+public class AsyncConfig {
+
+    // SSE push 전용 풀.
+    // 1500명 fan-out 시 사용자별 send 를 N개 스레드로 병렬화 → 도메인 응답 즉시 반환.
+    @Bean(name = "notificationExecutor")
+    public ThreadPoolTaskExecutor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(8);            // 평시 유지 스레드 수
+        executor.setMaxPoolSize(32);            // 폭주 시 최대 스레드 수
+        executor.setQueueCapacity(2000);        // 1500명 + 여유 (버퍼링)
+        executor.setKeepAliveSeconds(60);       // core 초과 스레드는 60초 후 회수
+        executor.setThreadNamePrefix("notif-"); // 로그/스레드 덤프에서 식별 용이
+        // 큐 가득 시 호출자(도메인 스레드)가 직접 실행 — 알림 손실 방지 + 자연스러운 백프레셔
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        // 부팅 시 풀 미리 초기화
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.initialize();
+        return executor;
+    }
+
+}

--- a/src/main/java/org/example/stockitbe/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/SecurityConfig.java
@@ -25,31 +25,35 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-        // CSRF ??쑵??源딆넅 (REST API + JWT 疫꿸퀡而?
+        // CSRF 비활성화 (REST API + JWT 기반)
         http.csrf((csrf) -> csrf.disable());
 
-        // Form 嚥≪뮄?????쑵??源딆넅
+        // Form 로그인 비활성화
         http.formLogin((form) -> form.disable());
 
-        //Basic ?紐꾩쵄 ??쑵??源딆넅
+        // Basic 인증 비활성화
         http.httpBasic((basic) -> basic.disable());
 
-        // ?紐꾨?STATELESS (JWT ????
+        // 세션을 STATELESS (JWT 사용)
         http.sessionManagement((session) ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        // 亦낅슦釉녘퉪??臾롫젏 ??뽯선
+        // 인가 규칙 정의
         http.authorizeHttpRequests((auth) -> auth
-                // ERROR ?遺용뮞??ν뒄???뚢뫂?껅에?살쑎 ??됱뇚 筌ｌ꼶???⑥눘??癒?퐣 ??彛??뉖릭沃샕嚥??紐꾩쵄 筌ｋ똾寃?癒?퐣 ??뽰뇚??뺣뼄.
-                // (??됱뇚 ?癒?뵥??401嚥???肉???쇱젫 ??쑴已??됰뮞 ?癒?쑎揶쎛 揶쎛??????얜챷??獄쎻뫗?)
+                // ERROR 디스패치는 항상 통과 — 내부 에러 페이지로의 재진입 시 인증 검사 제외.
+                // (에러 핸들러가 401/403 응답을 직접 쓰도록 위에서 처리)
                 .dispatcherTypeMatchers(
                         jakarta.servlet.DispatcherType.ASYNC,
                         jakarta.servlet.DispatcherType.ERROR
                 ).permitAll()
-                .requestMatchers("/api/user/signup", "/api/user/login", "/api/user/logout", "/api/user/refresh", "/api/public/**").permitAll()        // ???뜚揶쎛??嚥≪뮄???                .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll() // k8s probe/筌롫??껆뵳???륁춿 ??됱뒠
-                // Spring 疫꿸퀡???癒?쑎 ?遺얜굡????紐껊뮉 ??? ??됱뇚 ???쐭筌?野껋럥以???嚥??紐꾩쵄 ??됱뇚????筌왖 ??꾩쓺 ??됱뒠??뺣뼄.
+                .requestMatchers("/api/user/signup", "/api/user/login", "/api/user/logout", "/api/user/refresh", "/api/public/**").permitAll()
+                .requestMatchers("/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll() // k8s probe / 모니터링용 엔드포인트
+                // Spring 기본 에러 디스패치 경로 — 인증 없이 도달 가능해야 핸들러가 정상 동작
                 .requestMatchers("/error").permitAll()
-                .requestMatchers("/api/hq/**").hasRole("HQ")                  // 癰귣챷沅?                .requestMatchers("/api/store/**").hasRole("STORE")            // 筌띲끉??                .requestMatchers("/api/warehouse/**").hasRole("WAREHOUSE")    // 筌≪럡??                .anyRequest().authenticated()
+                .requestMatchers("/api/hq/**").hasRole("HQ")                  // 본사
+                .requestMatchers("/api/store/**").hasRole("STORE")            // 매장
+                .requestMatchers("/api/warehouse/**").hasRole("WAREHOUSE")    // 물류창고
+                .anyRequest().authenticated()
         );
 
         http.exceptionHandling(ex -> ex
@@ -58,21 +62,21 @@ public class SecurityConfig {
                     res.setContentType("application/json;charset=UTF-8");
                     res.setCharacterEncoding("UTF-8");
                     res.getWriter().write(
-                            "{\"success\":false,\"code\":3002,\"message\":\"?紐꾩쵄???袁⑹뒄??몃빍??\"}"
+                            "{\"success\":false,\"code\":3002,\"message\":\"인증이 필요하거나 만료되었습니다.\"}"
                     );
                 })
-                // ?紐꾩쵄?? ??뤿?筌왖筌?亦낅슦釉?ROLE) ?봔鈺곌퉮??野껋럩??몴?403??곗쨮 ?브쑬????癒?뵥 ???툢??揶쎛?館釉?袁⑥쨯 ??뺣뼄.
+                // 인증은 되었으나 권한(ROLE) 불일치로 거부된 경우(403) — 메시지를 별도로 내려 구분
                 .accessDeniedHandler((req, res, accessDeniedException) -> {
                     res.setStatus(HttpServletResponse.SC_FORBIDDEN);
                     res.setContentType("application/json;charset=UTF-8");
                     res.setCharacterEncoding("UTF-8");
                     res.getWriter().write(
-                            "{\"success\":false,\"code\":3008,\"message\":\"亦낅슦釉????곷뮸??덈뼄.\"}"
+                            "{\"success\":false,\"code\":3008,\"message\":\"권한이 없는 요청입니다.\"}"
                     );
                 })
         );
 
-        // LoginFilter ?源낆쨯 (筌욊낯???紐꾨뮞??곷뮞??
+        // LoginFilter 등록 (커스텀 로그인 처리)
         AuthenticationManager authManager = configuration.getAuthenticationManager();
         LoginFilter loginFilter = new LoginFilter(authManager);
         loginFilter.setAuthenticationManager(authManager);

--- a/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
+++ b/src/main/java/org/example/stockitbe/common/model/BaseResponseStatus.java
@@ -138,6 +138,7 @@ public enum BaseResponseStatus {
     USER_ALREADY_WITHDRAWN(false, 4802, "이미 탈퇴 처리된 사용자입니다."),
     USER_PASSWORD_SAME(false, 4803, "새 비밀번호가 기존 비밀번호와 동일합니다."),
     EMPLOYEE_CODE_SEQUENCE_NOT_FOUND(false, 4804, "사원코드 시퀀스가 초기화되지 않았습니다. 관리자에게 문의해주세요."),
+    USER_CONCURRENT_MODIFICATION(false, 4805, "다른 관리자가 먼저 처리했습니다. 새로고침 후 다시 시도해주세요."),
     // 5000번대 실패
     FAIL(false, 5000, "요청 실패"),
 

--- a/src/main/java/org/example/stockitbe/hq/account/AccountService.java
+++ b/src/main/java/org/example/stockitbe/hq/account/AccountService.java
@@ -11,6 +11,7 @@ import org.example.stockitbe.user.UserRepository;
 import org.example.stockitbe.user.model.entity.User;
 import org.example.stockitbe.user.model.entity.UserRole;
 import org.example.stockitbe.user.model.entity.UserStatus;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -38,36 +39,49 @@ public class AccountService {
 
     @Transactional
     public AccountDto.ProcessRes approve(Long accountId) {
-        User user = findUserOrThrow(accountId);
-        validatePending(user);
+        try {
+            User user = findUserOrThrow(accountId);
+            validatePending(user);
 
-        String employeeCode = generateEmployeeCode(user.getRole());
-        user.approve(employeeCode);
+            String employeeCode = generateEmployeeCode(user.getRole());
+            user.approve(employeeCode);
 
-        return AccountDto.ProcessRes.from(user);
+            return AccountDto.ProcessRes.from(user);
+        } catch (OptimisticLockingFailureException ex) {
+            // 두 admin 동시 승인 충돌 — @Version 가드. 사번 시퀀스 중복 발급 방지됨.
+            throw BaseException.from(BaseResponseStatus.USER_CONCURRENT_MODIFICATION);
+        }
     }
 
     @Transactional
     public AccountDto.ProcessRes reject(Long accountId) {
-        User user = findUserOrThrow(accountId);
-        validatePending(user);
+        try {
+            User user = findUserOrThrow(accountId);
+            validatePending(user);
 
-        user.reject();
+            user.reject();
 
-        return AccountDto.ProcessRes.from(user);
+            return AccountDto.ProcessRes.from(user);
+        } catch (OptimisticLockingFailureException ex) {
+            throw BaseException.from(BaseResponseStatus.USER_CONCURRENT_MODIFICATION);
+        }
     }
 
     //  본사 관리자가 사용자 계정을 탈퇴 처리
     @Transactional
     public AccountDto.ProcessRes withdraw(Long accountId) {
-        User user = findUserOrThrow(accountId);
-        validateApproved(user);
+        try {
+            User user = findUserOrThrow(accountId);
+            validateApproved(user);
 
-        user.withdraw();
-        // 탈퇴 사용자의 모든 Refresh Token 삭제 → 즉시 강제 로그아웃 효과
-        jwtRefreshRepository.deleteAllByEmployeeCode(user.getEmployeeCode());
+            user.withdraw();
+            // 탈퇴 사용자의 모든 Refresh Token 삭제 → 즉시 강제 로그아웃 효과
+            jwtRefreshRepository.deleteAllByEmployeeCode(user.getEmployeeCode());
 
-        return AccountDto.ProcessRes.from(user);
+            return AccountDto.ProcessRes.from(user);
+        } catch (OptimisticLockingFailureException ex) {
+            throw BaseException.from(BaseResponseStatus.USER_CONCURRENT_MODIFICATION);
+        }
     }
 
 

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerTransaction.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/model/CircularBuyerTransaction.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -47,19 +48,32 @@ public class CircularBuyerTransaction {
     @Column(name = "transacted_at", nullable = false)
     private LocalDateTime transactedAt;
 
+    // Phase 2: 혼방 거래의 70% 주 소재 코드. 단일 거래는 NULL.
+    // ScoreEventsService 가 effective factor 계산 시 materialCode='BLEND' + mainMaterialCode 존재
+    // → (material.carbon_factor[mainMaterialCode]) × mainMaterialRatio 로 가중 적용.
+    @Column(name = "main_material_code", length = 32)
+    private String mainMaterialCode;
+
+    // 주 소재 비율 (예: 0.70). 단일 거래는 NULL.
+    @Column(name = "main_material_ratio", precision = 3, scale = 2)
+    private BigDecimal mainMaterialRatio;
+
     @Column(name = "create_date", nullable = false)
     private LocalDateTime createDate;
 
     @Builder
     private CircularBuyerTransaction(CircularBuyer buyer, String materialCode,
                                       Integer weightKg, Integer unitPrice,
-                                      Long totalAmount, LocalDateTime transactedAt) {
+                                      Long totalAmount, LocalDateTime transactedAt,
+                                      String mainMaterialCode, BigDecimal mainMaterialRatio) {
         this.buyer = buyer;
         this.materialCode = materialCode;
         this.weightKg = weightKg;
         this.unitPrice = unitPrice;
         this.totalAmount = totalAmount;
         this.transactedAt = transactedAt;
+        this.mainMaterialCode = mainMaterialCode;
+        this.mainMaterialRatio = mainMaterialRatio;
         this.createDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
@@ -106,22 +106,35 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
     /**
      * 지정 연도의 월별 수익/거래 건수 집계.
      * 결과 컬럼: month(1~12), revenue(SUM total_amount), cnt(COUNT)
+     *
+     * 성능 개선 (2026-05-23): WHERE 절에서 YEAR(transacted_at) 함수 제거 → 범위 조건으로 변경.
+     *   - Before: WHERE YEAR(transacted_at) = ?  → 컬럼에 함수 적용으로 인덱스 사용 불가 (풀 스캔)
+     *   - After : WHERE transacted_at >= :from AND transacted_at < :to → transacted_at 인덱스 활용
+     *   - GROUP BY MONTH(...) 는 결과 그룹핑용이라 인덱스 영향 없음 (유지)
      */
     @Query(value = """
         SELECT MONTH(t.transacted_at) AS m,
                COALESCE(SUM(t.total_amount), 0) AS revenue,
                COUNT(t.id) AS cnt
         FROM circular_buyer_transaction t
-        WHERE YEAR(t.transacted_at) = :year
+        WHERE t.transacted_at >= :from
+          AND t.transacted_at <  :to
         GROUP BY MONTH(t.transacted_at)
         ORDER BY MONTH(t.transacted_at)
         """, nativeQuery = true)
-    List<Object[]> aggregateMonthlyRevenue(@Param("year") int year);
+    List<Object[]> aggregateMonthlyRevenue(@Param("from") Date from, @Param("to") Date to);
 
 
     /**
-     * 점수 페이지용 — 지정 연도의 거래 이벤트 + 거래처 첫 거래일(neyBuyer 판정용).
-     * 결과 컬럼: id, transacted_at, company_name, material_code, weight_kg, first_tx_at
+     * 점수 페이지용 — 지정 기간의 거래 이벤트 + 거래처 첫 거래일(newBuyer 판정용) + partner_type + 혼방 주 소재.
+     * 결과 컬럼:
+     *   r[0] id, r[1] transacted_at, r[2] company_name, r[3] material_code,
+     *   r[4] weight_kg, r[5] first_tx_at,
+     *   r[6] partner_type            (Phase 2: isLocalPartner 매핑용)
+     *   r[7] main_material_code      (Phase 2: 혼방 70% 주 소재. 단일은 NULL)
+     *   r[8] main_material_ratio     (Phase 2: 0.70 또는 NULL)
+     *
+     * 성능 개선 (2026-05-23): WHERE YEAR(transacted_at) 함수 제거 → 범위 조건. 인덱스 활용.
      */
     @Query(value = """
         SELECT t.id,
@@ -131,13 +144,17 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
                t.weight_kg,
                (SELECT MIN(t2.transacted_at)
                   FROM circular_buyer_transaction t2
-                 WHERE t2.buyer_id = t.buyer_id) AS first_tx_at
+                 WHERE t2.buyer_id = t.buyer_id) AS first_tx_at,
+               b.partner_type,
+               t.main_material_code,
+               t.main_material_ratio
         FROM circular_buyer_transaction t
         JOIN circular_buyer b ON b.id = t.buyer_id
-        WHERE YEAR(t.transacted_at) = :year
-        ORDER BY t.transacted_at DESC
+        WHERE t.transacted_at >= :from
+          AND t.transacted_at <  :to
+        ORDER BY t.id DESC
         """, nativeQuery = true)
-    List<Object[]> findEventsForYear(@Param("year") int year);
+    List<Object[]> findEventsForYear(@Param("from") Date from, @Param("to") Date to);
 
 
 }

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -7,7 +7,9 @@ import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.category.CategoryRepository;
 import org.example.stockitbe.hq.category.model.Category;
 import org.example.stockitbe.hq.circularbuyer.model.CircularBuyer;
+import org.example.stockitbe.hq.circularbuyer.model.CircularBuyerTransaction;
 import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerRepository;
+import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerTransactionRepository;
 import org.example.stockitbe.hq.circularsale.model.CircularSaleStatus;
 import org.example.stockitbe.hq.circularsale.model.dto.CircularSaleDto;
 import org.example.stockitbe.hq.circularsale.model.entity.CircularSaleHeader;
@@ -78,6 +80,8 @@ public class CircularSaleService {
     private final CircularSaleItemMaterialRepository saleItemMaterialRepository;
     private final CircularSaleStatusHistoryRepository saleStatusHistoryRepository;
     private final CircularBuyerRepository circularBuyerRepository;
+    // Phase 3: 실제 판매 시 ESG 점수 가산용 거래 row 를 함께 INSERT 하기 위한 Repository
+    private final CircularBuyerTransactionRepository transactionRepository;
     private final ProductSkuRepository productSkuRepository;
     private final ProductMasterRepository productMasterRepository;
     private final CategoryRepository categoryRepository;
@@ -598,7 +602,11 @@ public class CircularSaleService {
                 .reason("CIRCULAR_SALE_CREATE")
                 .build());
 
-        // 6) 생성 결과 반환
+        // 6) Phase 3 — 실제 판매를 ESG 점수에 즉시 반영 (circular_buyer_transaction 자동 INSERT)
+        //    sale_item 별로 transaction 1건씩 생성 + 혼방 product 의 70% 주 소재 자동 분배
+        createTransactionsFromSale(header, buyer, savedItems, contexts);
+
+        // 7) 생성 결과 반환
         return new SalePersistResult(header, outbound, savedItems, materialRows);
     }
 
@@ -641,6 +649,92 @@ public class CircularSaleService {
         return items.get(0).getProductName() + " 외 " + (items.size() - 1) + "건";
     }
 
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Phase 3 — 운영 판매 → ESG 점수 가산 파이프라인
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 사용하는 메서드: persistSaleAndOutbound
+     * Phase 3: 실제 판매 완료 시 ESG 점수 가산을 위해 circular_buyer_transaction 에도 거래 row 를 INSERT.
+     *  - sale_item 별로 transaction 1건씩 생성 (product 별 정밀 ESG 점수)
+     *  - 혼방 product 의 경우 70% 주 소재 코드와 비율도 함께 기록 (ScoreEventsService 의 가중 산식 입력)
+     *  - 거래 시점 단가/금액은 sale_item 의 값을 그대로 스냅샷 (KAU 시세와 무관, 실제 거래가 기준)
+     */
+    private void createTransactionsFromSale(CircularSaleHeader header,
+                                             CircularBuyer buyer,
+                                             List<CircularSaleItem> savedItems,
+                                             List<LineContext> contexts) {
+        // sold_at(Date) → LocalDateTime(KST) 변환 — circular_buyer_transaction.transacted_at 컬럼 매칭
+        java.time.LocalDateTime soldAt = header.getSoldAt().toInstant()
+                .atZone(KST).toLocalDateTime();
+
+        List<CircularBuyerTransaction> rows = new ArrayList<>();
+        for (int i = 0; i < savedItems.size(); i++) {
+            CircularSaleItem item = savedItems.get(i);
+            ProductMaster master = contexts.get(i).master;
+
+            // composition 기반으로 material_code / main_material_code / main_material_ratio 산출
+            TxMaterial tx = deriveTransactionMaterial(master);
+
+            rows.add(CircularBuyerTransaction.builder()
+                    .buyer(buyer)
+                    .materialCode(tx.materialCode())
+                    .weightKg(item.getActualWeightKg() != null
+                            ? item.getActualWeightKg().intValue()
+                            : 0)
+                    // CircularSaleItem.unitPrice 는 Long, CircularBuyerTransaction.unitPrice 는 Integer
+                    // → 시드/운영 단가가 Integer 범위(약 21억) 내라 안전하게 intValue() 변환
+                    .unitPrice(item.getUnitPrice() != null ? item.getUnitPrice().intValue() : 0)
+                    .totalAmount(item.getLineAmount() != null ? item.getLineAmount() : 0L)
+                    .transactedAt(soldAt)
+                    .mainMaterialCode(tx.mainMaterialCode())
+                    .mainMaterialRatio(tx.mainMaterialRatio())
+                    .build());
+        }
+
+        if (!rows.isEmpty()) {
+            transactionRepository.saveAll(rows);
+        }
+    }
+
+    /**
+     * 사용하는 메서드: createTransactionsFromSale
+     * product 의 composition 분포로 transaction.material_code / main_material_code / main_material_ratio 산출.
+     *  - composition row 2개 이상 → 'BLEND' + composition[0] 의 material/ratio 를 main 으로
+     *  - composition 단일       → 그 material code, main 정보는 NULL
+     *  - composition 없음       → 'BLEND' 폴백 (예외 케이스)
+     *
+     * Phase 1 의 material_group 어휘와는 별개 — 여기서는 거래 단위의 material_code 만 결정.
+     */
+    private TxMaterial deriveTransactionMaterial(ProductMaster master) {
+        List<ProductMaterialComposition> comps = master.getMaterialCompositions();
+        if (comps == null || comps.isEmpty()) {
+            return new TxMaterial("BLEND", null, null);
+        }
+        // composition_order 오름차순 기준 가장 작은 (즉 주 소재) 1개 선별
+        ProductMaterialComposition primary = comps.stream()
+                .min((a, b) -> Integer.compare(
+                        a.getCompositionOrder() == null ? Integer.MAX_VALUE : a.getCompositionOrder(),
+                        b.getCompositionOrder() == null ? Integer.MAX_VALUE : b.getCompositionOrder()))
+                .orElse(comps.get(0));
+
+        String primaryCode = primary.getMaterial().getCode();
+
+        // 단일 composition → 자기 material 코드 그대로, main 은 NULL
+        if (comps.size() == 1) {
+            return new TxMaterial(primaryCode, null, null);
+        }
+
+        // 2개 이상 → BLEND, 주 소재는 primary, 비율은 ratio/100
+        BigDecimal ratio = primary.getRatio() != null
+                ? BigDecimal.valueOf(primary.getRatio()).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP)
+                : BigDecimal.valueOf(0.70);  // 안전 폴백 (시드 표준 70%)
+        return new TxMaterial("BLEND", primaryCode, ratio);
+    }
+
+    /** Phase 3 — transaction 의 material 결정 결과 보관용 record */
+    private record TxMaterial(String materialCode, String mainMaterialCode, BigDecimal mainMaterialRatio) {}
+
     // 사용하는 메서드: create
     // 소재 조합 기반으로 판매 소재 구분 라벨을 산출한다.
     private String deriveMaterialType(ProductMaster master) {
@@ -653,7 +747,9 @@ public class CircularSaleService {
         }
         ProductMaterialComposition single = comps.get(0);
         String group = single.getMaterial().getMaterialGroup();
-        if ("NATURAL".equalsIgnoreCase(group)) {
+        // Phase 1: material_group 어휘를 'NATURAL' → 'NATURAL_SINGLE' 로 통일하면서
+        //          기존 'NATURAL' 도 안전망으로 함께 수용 (시드 적용 전/후 호환).
+        if ("NATURAL_SINGLE".equalsIgnoreCase(group) || "NATURAL".equalsIgnoreCase(group)) {
             return "천연 단일 섬유";
         }
         if ("SYNTHETIC".equalsIgnoreCase(group)) {

--- a/src/main/java/org/example/stockitbe/hq/esg/circularrevenue/CircularRevenueService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/circularrevenue/CircularRevenueService.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -25,8 +27,15 @@ public class CircularRevenueService {
     public CircularRevenueDto.Response getMonthlyRevenue(Integer year) {
         int targetYear = (year != null) ? year : LocalDate.now().getYear();
 
+        // year → [yyyy-01-01 00:00, (yyyy+1)-01-01 00:00) 범위로 변환.
+        // Repository 가 WHERE transacted_at >= :from AND < :to 형태로 인덱스 활용.
+        Date from = Date.from(LocalDate.of(targetYear, 1, 1)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date to   = Date.from(LocalDate.of(targetYear + 1, 1, 1)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant());
+
         // [{ m, revenue, count }, ...] 형태로 BE 에서 받음 (거래 있는 월만)
-        List<Object[]> rows = txRepo.aggregateMonthlyRevenue(targetYear);
+        List<Object[]> rows = txRepo.aggregateMonthlyRevenue(from, to);
 
         // 12개월 버킷 초기화
         long[] revByMonth = new long[12];

--- a/src/main/java/org/example/stockitbe/hq/esg/emissionquota/EmissionQuotaService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/emissionquota/EmissionQuotaService.java
@@ -3,12 +3,6 @@ package org.example.stockitbe.hq.esg.emissionquota;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.hq.esg.emissionquota.model.EmissionQuota;
 import org.example.stockitbe.hq.esg.emissionquota.model.EmissionQuotaDto;
-// Phase 2 알림 트리거 — 배출권 사용률 임계 (75%/100%) 전이 시 본사 알림
-import org.example.stockitbe.notification.event.NotificationEvent;
-import org.example.stockitbe.notification.model.entity.NotificationSeverity;
-import org.example.stockitbe.notification.model.entity.NotificationType;
-import org.example.stockitbe.user.model.entity.UserRole;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +16,6 @@ import java.time.LocalDate;
 public class EmissionQuotaService {
 
     private final EmissionQuotaRepository repository;
-    // Phase 2 — 도메인 이벤트 발행자. updateQuota 직후 임계 전이 감지 시 사용
-    private final ApplicationEventPublisher eventPublisher;
 
     /** GET — 없으면 기본값 새로 생성해서 반환 (영속화) */
     @Transactional
@@ -51,10 +43,8 @@ public class EmissionQuotaService {
                         .warnThresholdPct(75)
                         .build());
 
-        // Phase 2 — 임계 전이 감지를 위해 갱신 *이전* 사용률 스냅샷을 저장
-        //         이렇게 해야 75% 임박/100% 초과를 "처음 도달한 순간" 만 1회 알림 가능
-        BigDecimal beforePct = toResponse(quota).getUtilizationPct();
-
+        // 2026-05-22: 탄소 배출 한도 알림(ESG_QUOTA_WARNING/EXCEEDED) 발송 로직 제거 — 알림 종류 4종 정리.
+        //   EmissionQuota 도메인의 한도 조회/저장 기능은 유지하되, 임계 전이 알림은 더 이상 발송하지 않음.
         quota.update(
                 req.getYearlyAllocation(),
                 req.getMonthlyEmissions(),
@@ -62,40 +52,7 @@ public class EmissionQuotaService {
                 employeeCode
         );
         EmissionQuota saved = repository.save(quota);
-
-        EmissionQuotaDto.Response result = toResponse(saved);
-        BigDecimal afterPct = result.getUtilizationPct();
-        BigDecimal warnThreshold = BigDecimal.valueOf(saved.getWarnThresholdPct()); // 보통 75%
-        BigDecimal hundred = BigDecimal.valueOf(100);
-
-        // (a) 임박 전이 — 이전 < 임계 && 이후 >= 임계 (예: 70% → 80%)
-        //     동일 이상 유지 (예: 80% → 90%) 시 알림 안 나옴 — 스팸 방지
-        if (beforePct.compareTo(warnThreshold) < 0 && afterPct.compareTo(warnThreshold) >= 0) {
-            eventPublisher.publishEvent(NotificationEvent.builder()
-                    .type(NotificationType.ESG_QUOTA_WARNING)
-                    .severity(NotificationSeverity.WARNING)
-                    .title("배출권 사용률 임계 임박")
-                    .message(targetYear + "년 배출권 사용률 " + afterPct + "% — 경고 임계(" + warnThreshold + "%) 도달")
-                    .targetRole(UserRole.HQ)
-                    .refType("EMISSION_QUOTA")
-                    .refId(String.valueOf(targetYear))
-                    .build());
-        }
-        // (b) 초과 전이 — 이전 < 100 && 이후 >= 100
-        //     초과는 CRITICAL 로 발행 (운영자 즉각 대응 필요)
-        if (beforePct.compareTo(hundred) < 0 && afterPct.compareTo(hundred) >= 0) {
-            eventPublisher.publishEvent(NotificationEvent.builder()
-                    .type(NotificationType.ESG_QUOTA_EXCEEDED)
-                    .severity(NotificationSeverity.CRITICAL)
-                    .title("배출권 할당량 초과")
-                    .message(targetYear + "년 배출권 사용률 " + afterPct + "% — 할당량을 초과했습니다.")
-                    .targetRole(UserRole.HQ)
-                    .refType("EMISSION_QUOTA")
-                    .refId(String.valueOf(targetYear))
-                    .build());
-        }
-
-        return result;
+        return toResponse(saved);
     }
 
     /** Entity → Response (분기/YTD 자동 합계) */

--- a/src/main/java/org/example/stockitbe/hq/esg/materialfactor/MaterialFactorController.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/materialfactor/MaterialFactorController.java
@@ -1,0 +1,32 @@
+package org.example.stockitbe.hq.esg.materialfactor;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.hq.esg.materialfactor.model.MaterialFactorDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 소재 환산 계수 마스터 조회 API.
+ *  - FE ESG 페이지(대시보드 / 점수 페이지)가 진입 시 1회 호출
+ *  - 응답 형태: BaseResponse<MaterialFactorDto.Response>
+ */
+@RestController
+@RequestMapping("/api/hq/esg")
+@RequiredArgsConstructor
+public class MaterialFactorController {
+
+    private final MaterialFactorService service;
+
+    /**
+     * active 소재 환산 계수 전체 조회.
+     *  - 정렬: code ASC
+     *  - 인증: ESG 페이지 진입자 (본사/매장 관리자) 누구나 호출 가능
+     */
+    @GetMapping("/material-factors")
+    public ResponseEntity<BaseResponse<MaterialFactorDto.Response>> getFactors() {
+        return ResponseEntity.ok(BaseResponse.success(service.getActiveFactors()));
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/materialfactor/MaterialFactorService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/materialfactor/MaterialFactorService.java
@@ -1,0 +1,42 @@
+package org.example.stockitbe.hq.esg.materialfactor;
+
+import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.hq.esg.materialfactor.model.MaterialFactorDto;
+import org.example.stockitbe.hq.product.MaterialRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 소재 환산 계수 마스터 조회 서비스.
+ *  - ESG 점수/탄소 절감량 산식의 입력값(SSOT) 제공.
+ *  - FE 가 첫 ESG 진입 시 1회 호출 → store 캐싱.
+ *  - 본사 운영자가 material 테이블의 carbon_factor 만 갱신하면 즉시 반영 (FE 재배포 불필요).
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MaterialFactorService {
+
+    private final MaterialRepository materialRepository;
+
+    /**
+     * active=true 인 소재 마스터 전체를 code 오름차순으로 조회.
+     *  - BLEND 행 포함 (혼방 거래의 fallback factor)
+     *  - 비활성 소재(active=false)는 응답에서 제외 → 운영 단계에서 deprecated 소재 자연 차단
+     */
+    public MaterialFactorDto.Response getActiveFactors() {
+        List<MaterialFactorDto.Item> items = materialRepository.findAllByActiveTrueOrderByCodeAsc().stream()
+                .map(m -> MaterialFactorDto.Item.builder()
+                        .code(m.getCode())
+                        .label(m.getNameKo())
+                        .group(m.getMaterialGroup())
+                        .factor(m.getCarbonFactor())
+                        .build())
+                .toList();
+        return MaterialFactorDto.Response.builder()
+                .factors(items)
+                .build();
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/materialfactor/model/MaterialFactorDto.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/materialfactor/model/MaterialFactorDto.java
@@ -1,0 +1,40 @@
+package org.example.stockitbe.hq.esg.materialfactor.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 소재 환산 계수 마스터 응답 DTO.
+ *  - FE utils/esgScore.js 의 MATERIAL_FACTORS 와 1:1 매칭
+ *  - active=true 인 material row 만 노출
+ *  - carbon_factor 단위: kgCO₂e / kg fiber (Higg MSI v3 / EU PEF 표준, 동물성 섬유는 cap 적용)
+ *
+ * 응답 예시:
+ *   { "factors": [
+ *       { "code": "COTTON",   "label": "면",   "group": "NATURAL_SINGLE", "factor": 6.000 },
+ *       { "code": "POLYESTER","label": "폴리에스터","group": "SYNTHETIC","factor": 6.500 },
+ *       { "code": "BLEND",    "label": "혼방", "group": "BLEND",          "factor": 5.500 }
+ *     ]
+ *   }
+ */
+public class MaterialFactorDto {
+
+    @Getter
+    @Builder
+    public static class Response {
+        // active 소재 마스터의 전체 목록
+        private final List<Item> factors;
+    }
+
+    @Getter
+    @Builder
+    public static class Item {
+        private final String code;          // material.code (예: COTTON, POLYESTER, BLEND)
+        private final String label;         // material.name_ko (한글명)
+        private final String group;         // material_group (NATURAL_SINGLE / SYNTHETIC / BLEND)
+        private final BigDecimal factor;    // material.carbon_factor (kgCO₂e/kg)
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/esg/scoreevents/ScoreEventsController.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/scoreevents/ScoreEventsController.java
@@ -16,11 +16,30 @@ public class ScoreEventsController {
 
     private final ScoreEventsService service;
 
-    /** 친환경 나무 키우기 점수 — 연간 sale 거래 이벤트 조회 */
+    /**
+     * 친환경 나무 키우기 점수 — 풀세트 응답 (이벤트 페이지 + 통계 + 차트 데이터).
+     *  파라미터:
+     *   - year     : 연도. 기본 현재 연도.
+     *   - page     : 0-based 페이지 번호. 기본 0.
+     *   - size     : 페이지 크기. 기본 20. 서버 측에서 최대 200 으로 클램프.
+     *   - dateFrom : "yyyy-MM-dd" 시작일. dateTo 와 함께 지정 시 연도 범위보다 우선.
+     *   - dateTo   : "yyyy-MM-dd" 종료일 (포함).
+     *   - category : ALL | saleExecution | carbon | newBuyer | localPartner. 기본 ALL.
+     *
+     *  응답: 이벤트 페이지 슬라이스 + summary/monthlyBreakdown/categoryBreakdown (필터 적용 후 전체 기준).
+     *  FE 측에서 KPI/도넛/막대 차트를 직접 계산하지 않고 BE 응답을 그대로 사용.
+     */
     @GetMapping("/score-events")
     public ResponseEntity<BaseResponse<ScoreEventsDto.Response>> getEvents(
-            @RequestParam(required = false) Integer year
+            @RequestParam(required = false) Integer year,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size,
+            @RequestParam(required = false) String dateFrom,
+            @RequestParam(required = false) String dateTo,
+            @RequestParam(required = false, defaultValue = "ALL") String category
     ) {
-        return ResponseEntity.ok(BaseResponse.success(service.getEvents(year)));
+        return ResponseEntity.ok(BaseResponse.success(
+                service.getEvents(year, page, size, dateFrom, dateTo, category)
+        ));
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/esg/scoreevents/ScoreEventsService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/scoreevents/ScoreEventsService.java
@@ -3,15 +3,24 @@ package org.example.stockitbe.hq.esg.scoreevents;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.hq.circularbuyer.repository.CircularBuyerTransactionRepository;
 import org.example.stockitbe.hq.esg.scoreevents.model.ScoreEventsDto;
+import org.example.stockitbe.hq.product.MaterialRepository;
+import org.example.stockitbe.hq.product.model.Material;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,46 +28,354 @@ import java.util.List;
 public class ScoreEventsService {
 
     private final CircularBuyerTransactionRepository txRepo;
+    // Phase 2: carbon_factor 룩업용. 응답마다 1회 조회해서 N+1 회피.
+    private final MaterialRepository materialRepository;
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ISO_LOCAL_DATE;
 
+    // ─────────── 점수 산식 상수 (Phase 2 — FE esgScore.js 의 SCORE_RULES 와 동기화된 SSOT) ───────────
+    /** 점수 부여 최소 무게(kg) — 어뷰징 방지: 작은 거래로 정액 점수 펌핑 차단 */
+    private static final int MIN_WEIGHT_KG = 10;
+    /** 판매 실행 기본 점수 — 거래 1건당 */
+    private static final int SALE_BASE = 100;
+    /** 신규 거래처 보너스 — 해당 buyer 의 최초 거래 1회 한정 */
+    private static final int NEW_BUYER_BONUS = 150;
+    /** 지역 파트너 보너스 — partner_type=local_small / social_enterprise */
+    private static final int LOCAL_PARTNER_BONUS = 150;
+    /** 탄소 점수 보정계수 — Higg MSI v3 표준 carbon_factor(kgCO₂e/kg) 적용에 따른 균형 조정 */
+    private static final BigDecimal CARBON_SCALE = new BigDecimal("0.1");
+
+    // ─────────── 카테고리 필터 상수 (FE filterCategory 와 동일 값) ───────────
+    private static final String CAT_ALL            = "ALL";
+    private static final String CAT_SALE_EXECUTION = "saleExecution";
+    private static final String CAT_CARBON         = "carbon";
+    private static final String CAT_NEW_BUYER      = "newBuyer";
+    private static final String CAT_LOCAL_PARTNER  = "localPartner";
+
+    // ─────────── BE material.material_group 어휘 → FE 어휘 정규화 ───────────
+    //  - BE: 'NATURAL' (ProductMasterService.MATERIAL_GROUP_NATURAL 상수와 일치)
+    //  - FE: 'NATURAL_SINGLE' (esgScore.js / esgStore 기준)
+    //  - 응답 직전에만 변환 — DB 어휘는 유지
+    private static final Map<String, String> GROUP_NORMALIZATION = Map.of(
+            "NATURAL", "NATURAL_SINGLE"
+    );
+    private static String normalizeGroup(String raw) {
+        if (raw == null) return null;
+        return GROUP_NORMALIZATION.getOrDefault(raw, raw);
+    }
+
     /**
-     * 지정 연도의 sale 거래 이벤트 조회.
-     *  - 각 거래에 buyer 의 최초 거래일을 동시 조회해서 isNewBuyer derive
-     *  - 결과는 거래일 내림차순 (FE 도 sortedEvents 에서 같은 정렬)
+     * 친환경 나무 키우기 점수 — 풀세트 응답 (Phase 3 / A''-1).
+     *  파라미터:
+     *   - year     : 연도 (null 시 현재 연도). dateFrom/dateTo 가 있으면 그 값이 우선.
+     *   - page/size: 0-based 페이지. size 는 안전상 1~200 사이로 클램프.
+     *   - dateFrom/dateTo: "yyyy-MM-dd" 부분 범위. 둘 다 있으면 [dateFrom 00:00, dateTo+1day 00:00) 사용.
+     *   - category : ALL / saleExecution / carbon / newBuyer / localPartner.
+     *                ALL 이외는 "해당 카테고리에 점수가 1 이상인 이벤트" 만 통과.
+     *
+     *  처리 순서:
+     *   ① 기간 범위 결정 → ② carbon factor 맵 1회 로딩 → ③ 거래 row 조회
+     *   → ④ 각 row 당 점수 4종 계산 (EventDto 생성)
+     *   → ⑤ 카테고리 필터 적용 → ⑥ 통계(summary/monthly/category) 집계
+     *   → ⑦ 페이지 슬라이스 후 응답 빌드
+     *
+     *  주의: 통계는 "필터 적용 후 전체" 기준이므로 페이지를 넘겨도 KPI/차트는 그대로 유지됨.
      */
-    public ScoreEventsDto.Response getEvents(Integer year) {
+    public ScoreEventsDto.Response getEvents(
+            Integer year, Integer page, Integer size,
+            String dateFrom, String dateTo, String category) {
+
         int targetYear = (year != null) ? year : LocalDate.now().getYear();
 
-        // row: { id, transacted_at, company_name, material_code, weight_kg, first_tx_at }
-        List<Object[]> rows = txRepo.findEventsForYear(targetYear);
+        // 페이지 파라미터 정규화 — 음수/0 방지 + 과도한 size 방어 (서버 부하)
+        int safePage = (page == null || page < 0) ? 0 : page;
+        int safeSize = (size == null || size <= 0) ? 20 : Math.min(size, 200);
+        String safeCategory = (category == null || category.isBlank()) ? CAT_ALL : category;
 
-        List<ScoreEventsDto.EventDto> events = new ArrayList<>(rows.size());
-        for (Object[] r : rows) {
-            Long id              = ((Number) r[0]).longValue();
-            LocalDateTime txAt   = ((Timestamp) r[1]).toLocalDateTime();
-            String buyer         = (String) r[2];
-            String material      = (String) r[3];
-            Integer weightKg     = ((Number) r[4]).intValue();
-            LocalDateTime firstAt = ((Timestamp) r[5]).toLocalDateTime();
-
-            boolean isNewBuyer = txAt.equals(firstAt);
-
-            events.add(ScoreEventsDto.EventDto.builder()
-                    .id(id)
-                    .date(txAt.toLocalDate().format(DATE_FMT))
-                    .type("sale")
-                    .buyer(buyer)
-                    .material(material)
-                    .weightKg(weightKg)
-                    .isNewBuyer(isNewBuyer)
-                    .isLocalPartner(false)  // partner_type 미구현
-                    .build());
+        // ① 기간 범위 — dateFrom/dateTo 가 있으면 그 값이 우선 (FE 의 dateFilter UI 대응)
+        //    없으면 연도 전체 [yyyy-01-01, (yyyy+1)-01-01)
+        Date from;
+        Date to;
+        if (dateFrom != null && !dateFrom.isBlank() && dateTo != null && !dateTo.isBlank()) {
+            LocalDate ldFrom = LocalDate.parse(dateFrom);
+            LocalDate ldTo   = LocalDate.parse(dateTo);
+            from = Date.from(ldFrom.atStartOfDay(ZoneId.systemDefault()).toInstant());
+            // 종료일 포함을 위해 +1 day exclusive
+            to   = Date.from(ldTo.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } else {
+            from = Date.from(LocalDate.of(targetYear, 1, 1)
+                    .atStartOfDay(ZoneId.systemDefault()).toInstant());
+            to   = Date.from(LocalDate.of(targetYear + 1, 1, 1)
+                    .atStartOfDay(ZoneId.systemDefault()).toInstant());
         }
+
+        // ② material 마스터 1회 로딩 → factor 맵 + group 맵 (Phase 3 B: 카본 분포 계산용 group 추가)
+        List<Material> materials = materialRepository.findAllByActiveTrueOrderByCodeAsc();
+        Map<String, BigDecimal> factorMap = materials.stream()
+                .collect(Collectors.toMap(Material::getCode, Material::getCarbonFactor));
+        // code → normalized group ("NATURAL_SINGLE" / "SYNTHETIC" / "BLEND")
+        Map<String, String> groupMap = materials.stream()
+                .collect(Collectors.toMap(Material::getCode, m -> normalizeGroup(m.getMaterialGroup())));
+
+        // ③ row: r[0] id, r[1] transacted_at, r[2] company_name, r[3] material_code,
+        //         r[4] weight_kg, r[5] first_tx_at,
+        //         r[6] partner_type, r[7] main_material_code, r[8] main_material_ratio
+        List<Object[]> rows = txRepo.findEventsForYear(from, to);
+
+        // ④ row → EventDto 변환 (전체 산출. 필터는 다음 단계에서.)
+        List<ScoreEventsDto.EventDto> allEvents = new ArrayList<>(rows.size());
+        for (Object[] r : rows) {
+            allEvents.add(buildEventDto(r, factorMap));
+        }
+
+        // ⑤ 카테고리 필터 — 해당 카테고리 점수 > 0 인 이벤트만 통과
+        List<ScoreEventsDto.EventDto> filtered = applyCategoryFilter(allEvents, safeCategory);
+
+        // ⑥ 통계 집계 (필터 적용 후 전체 기준 — KPI / 도넛 / 월별 막대 차트 데이터)
+        ScoreEventsDto.Summary summary             = buildSummary(filtered);
+        ScoreEventsDto.CategoryBreakdown catBreak  = buildCategoryBreakdown(filtered);
+        List<ScoreEventsDto.MonthlyBucket> monthly = buildMonthlyBreakdown(filtered);
+
+        // ⑥-B (Phase 3 B): ESG 대시보드용 카본 절감량 분포 — 필터/페이지 무관, 연도 전체 기준.
+        //   FE 의 computeCarbonReductionByMaterial/Group/Monthly + totalCarbonReductionKg 를 BE 로 이관.
+        ScoreEventsDto.CarbonReduction carbonReduction = buildCarbonReduction(allEvents, factorMap, groupMap);
+
+        // ⑦ 페이지 슬라이스 — Repository 정렬(id DESC) 그대로 사용
+        long totalElements = filtered.size();
+        int totalPages = (int) Math.ceil((double) totalElements / safeSize);
+        int fromIdx = Math.min(safePage * safeSize, filtered.size());
+        int toIdx   = Math.min(fromIdx + safeSize, filtered.size());
+        List<ScoreEventsDto.EventDto> pageSlice = (fromIdx >= toIdx)
+                ? Collections.emptyList()
+                : new ArrayList<>(filtered.subList(fromIdx, toIdx));
 
         return ScoreEventsDto.Response.builder()
                 .year(targetYear)
-                .events(events)
+                .events(pageSlice)
+                .summary(summary)
+                .monthlyBreakdown(monthly)
+                .categoryBreakdown(catBreak)
+                .carbonReduction(carbonReduction)
+                .page(safePage)
+                .size(safeSize)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
                 .build();
+    }
+
+    // ─────────────────────────────── 내부 헬퍼 ───────────────────────────────
+
+    /** native row 1개를 EventDto 로 변환 + 점수 4종 계산. */
+    private ScoreEventsDto.EventDto buildEventDto(Object[] r, Map<String, BigDecimal> factorMap) {
+        Long id                  = ((Number) r[0]).longValue();
+        LocalDateTime txAt       = ((Timestamp) r[1]).toLocalDateTime();
+        String buyer             = (String) r[2];
+        String material          = (String) r[3];
+        Integer weightKg         = ((Number) r[4]).intValue();
+        LocalDateTime firstAt    = ((Timestamp) r[5]).toLocalDateTime();
+        String partnerType       = (String) r[6];
+        String mainMaterialCode  = (String) r[7];   // nullable
+        BigDecimal mainRatio     = (BigDecimal) r[8]; // nullable
+
+        boolean isNewBuyer = txAt.equals(firstAt);
+        // local_small (지역 소상공인) / social_enterprise (사회적기업) 모두 지역 파트너로 인정.
+        // general 은 일반 거래처라 보너스 미적용.
+        boolean isLocalPartner = "local_small".equals(partnerType)
+                              || "social_enterprise".equals(partnerType);
+
+        // effective factor — 혼방이면 (70% 주 소재 factor × ratio), 단일이면 자기 factor
+        BigDecimal factor = resolveFactor(material, mainMaterialCode, mainRatio, factorMap);
+
+        // 점수 4종 계산
+        boolean scoreValid = weightKg != null && weightKg >= MIN_WEIGHT_KG;
+        int saleExecution = scoreValid ? SALE_BASE : 0;
+        int carbon = scoreValid
+                ? BigDecimal.valueOf(weightKg).multiply(factor).multiply(CARBON_SCALE).intValue()
+                : 0;
+        int newBuyerScore     = (scoreValid && isNewBuyer)     ? NEW_BUYER_BONUS     : 0;
+        int localPartnerScore = (scoreValid && isLocalPartner) ? LOCAL_PARTNER_BONUS : 0;
+        int total = saleExecution + carbon + newBuyerScore + localPartnerScore;
+
+        return ScoreEventsDto.EventDto.builder()
+                .id(id)
+                .date(txAt.toLocalDate().format(DATE_FMT))
+                .type("sale")
+                .buyer(buyer)
+                .material(material)
+                .weightKg(weightKg)
+                .isNewBuyer(isNewBuyer)
+                .isLocalPartner(isLocalPartner)
+                .mainMaterialCode(mainMaterialCode)
+                .mainMaterialRatio(mainRatio)
+                .saleExecution(saleExecution)
+                .carbon(carbon)
+                .newBuyer(newBuyerScore)
+                .localPartner(localPartnerScore)
+                .total(total)
+                .scoreValid(scoreValid)
+                .build();
+    }
+
+    /** 카테고리 필터 — ALL 은 그대로, 그 외는 해당 카테고리 점수가 1 이상인 이벤트만 통과. */
+    private List<ScoreEventsDto.EventDto> applyCategoryFilter(
+            List<ScoreEventsDto.EventDto> events, String category) {
+        if (CAT_ALL.equals(category)) {
+            return events;
+        }
+        return events.stream().filter(e -> switch (category) {
+            case CAT_SALE_EXECUTION -> e.getSaleExecution() > 0;
+            case CAT_CARBON         -> e.getCarbon()        > 0;
+            case CAT_NEW_BUYER      -> e.getNewBuyer()      > 0;
+            case CAT_LOCAL_PARTNER  -> e.getLocalPartner()  > 0;
+            // 알 수 없는 카테고리는 ALL 과 동일하게 통과 (FE 가 새 값을 보내도 500 안 나도록)
+            default -> true;
+        }).collect(Collectors.toList());
+    }
+
+    /** Summary 집계 — 상단 KPI 카드. */
+    private ScoreEventsDto.Summary buildSummary(List<ScoreEventsDto.EventDto> events) {
+        long saleSum = 0, carbonSum = 0, newBuyerSum = 0, localPartnerSum = 0;
+        long totalKg = 0;
+        long validCnt = 0;
+        for (ScoreEventsDto.EventDto e : events) {
+            saleSum         += e.getSaleExecution();
+            carbonSum       += e.getCarbon();
+            newBuyerSum     += e.getNewBuyer();
+            localPartnerSum += e.getLocalPartner();
+            if (e.getWeightKg() != null) totalKg += e.getWeightKg();
+            if (e.isScoreValid()) validCnt++;
+        }
+        long totalScore = saleSum + carbonSum + newBuyerSum + localPartnerSum;
+        long cnt = events.size();
+        long avg = cnt > 0 ? Math.round((double) totalScore / cnt) : 0L;
+
+        return ScoreEventsDto.Summary.builder()
+                .totalScore(totalScore)
+                .saleExecutionSum(saleSum)
+                .carbonSum(carbonSum)
+                .newBuyerSum(newBuyerSum)
+                .localPartnerSum(localPartnerSum)
+                .totalEventCount(cnt)
+                .validEventCount(validCnt)
+                .totalKg(totalKg)
+                .avgScore(avg)
+                .build();
+    }
+
+    /** 도넛 차트용 카테고리별 합계. */
+    private ScoreEventsDto.CategoryBreakdown buildCategoryBreakdown(List<ScoreEventsDto.EventDto> events) {
+        long sale = 0, carbon = 0, newBuyer = 0, localPartner = 0;
+        for (ScoreEventsDto.EventDto e : events) {
+            sale         += e.getSaleExecution();
+            carbon       += e.getCarbon();
+            newBuyer     += e.getNewBuyer();
+            localPartner += e.getLocalPartner();
+        }
+        return ScoreEventsDto.CategoryBreakdown.builder()
+                .saleExecution(sale)
+                .carbon(carbon)
+                .newBuyer(newBuyer)
+                .localPartner(localPartner)
+                .build();
+    }
+
+    /**
+     * 카본 절감량 분포 계산 (Phase 3 B) — ESG 대시보드 KPI/차트 SSOT.
+     *  단위: kg CO₂. 산식: 거래별 (weight × effectiveFactor), 점수의 CARBON_SCALE(0.1) 미적용.
+     *  - byMaterial: code → 누적 kg. 모든 active material code 키를 0 으로 시드해서 누락 방지.
+     *  - byGroup   : 정규화된 group (NATURAL_SINGLE/SYNTHETIC/BLEND) → 누적 kg.
+     *  - monthly   : 12개 List (1~12월). 거래 없는 달은 0.
+     *  - total     : byMaterial 합계 = 전체 절감량.
+     *
+     *  카테고리 필터/페이지와 무관 → 인자로 받는 events 는 항상 전체(allEvents).
+     */
+    private ScoreEventsDto.CarbonReduction buildCarbonReduction(
+            List<ScoreEventsDto.EventDto> events,
+            Map<String, BigDecimal> factorMap,
+            Map<String, String> groupMap) {
+
+        // 모든 material 코드 키 0 시드 — FE 막대 그래프가 미존재 키에서 NaN 안 나도록.
+        Map<String, Long> byMaterial = new LinkedHashMap<>();
+        for (String code : factorMap.keySet()) byMaterial.put(code, 0L);
+
+        // 그룹 키 3종 0 시드 — FE store 의 carbonReductionByGroupKg 기본 shape 와 동일.
+        Map<String, Long> byGroup = new LinkedHashMap<>();
+        byGroup.put("NATURAL_SINGLE", 0L);
+        byGroup.put("SYNTHETIC", 0L);
+        byGroup.put("BLEND", 0L);
+
+        long[] monthlyKg = new long[12];
+        long total = 0L;
+
+        for (ScoreEventsDto.EventDto e : events) {
+            if (e.getWeightKg() == null) continue;
+            // effective factor — 혼방이면 mainFactor × ratio, 단일이면 자기 factor (buildEventDto 와 동일 산식)
+            BigDecimal factor = resolveFactor(e.getMaterial(), e.getMainMaterialCode(),
+                    e.getMainMaterialRatio(), factorMap);
+            // weight × factor → 반올림하여 kg 정수. (Higg MSI factor 는 소수 → 반올림 영향 미미)
+            long reduction = BigDecimal.valueOf(e.getWeightKg())
+                    .multiply(factor)
+                    .setScale(0, java.math.RoundingMode.HALF_UP)
+                    .longValueExact();
+
+            // byMaterial — 키 누락된 코드는 건너뜀 (active 가 풀린 material 거래 등 예외)
+            if (byMaterial.containsKey(e.getMaterial())) {
+                byMaterial.merge(e.getMaterial(), reduction, Long::sum);
+            }
+
+            // byGroup — material 의 group 으로 분류. 매핑 없으면 BLEND 폴백 (기존 InventoryService 흐름과 동일).
+            String group = groupMap.getOrDefault(e.getMaterial(), "BLEND");
+            byGroup.merge(group, reduction, Long::sum);
+
+            // monthly — date 의 월 (1~12) → 0-based index
+            int monthIdx = Integer.parseInt(e.getDate().substring(5, 7)) - 1;
+            if (monthIdx >= 0 && monthIdx < 12) monthlyKg[monthIdx] += reduction;
+
+            total += reduction;
+        }
+
+        List<Long> monthlyList = new ArrayList<>(12);
+        for (long v : monthlyKg) monthlyList.add(v);
+
+        return ScoreEventsDto.CarbonReduction.builder()
+                .byMaterial(byMaterial)
+                .byGroup(byGroup)
+                .monthly(monthlyList)
+                .total(total)
+                .build();
+    }
+
+    /** 12개월 막대그래프 데이터 — 이벤트가 없는 달도 score=0 으로 채워서 반환. */
+    private List<ScoreEventsDto.MonthlyBucket> buildMonthlyBreakdown(List<ScoreEventsDto.EventDto> events) {
+        long[] byMonth = new long[12];
+        for (ScoreEventsDto.EventDto e : events) {
+            // e.getDate() = "yyyy-MM-dd"
+            int month = Integer.parseInt(e.getDate().substring(5, 7));
+            byMonth[month - 1] += e.getTotal();
+        }
+        List<ScoreEventsDto.MonthlyBucket> out = new ArrayList<>(12);
+        for (int i = 0; i < 12; i++) {
+            out.add(ScoreEventsDto.MonthlyBucket.builder()
+                    .month(i + 1)
+                    .score(byMonth[i])
+                    .build());
+        }
+        return out;
+    }
+
+    /**
+     * 거래의 effective carbon factor 산출.
+     *  - 혼방 거래(material='BLEND') + main_material_code 존재 → 70% 주 소재 factor × ratio
+     *    (예: COTTON 6.0 × 0.7 = 4.2)
+     *  - 그 외 (단일 거래 또는 main 정보 누락된 BLEND) → 자기 material_code 의 factor 그대로
+     *    (BLEND 자체의 fallback factor 5.5 또는 단일 소재 factor)
+     */
+    private BigDecimal resolveFactor(String materialCode, String mainCode,
+                                      BigDecimal mainRatio, Map<String, BigDecimal> factorMap) {
+        if ("BLEND".equals(materialCode) && mainCode != null && mainRatio != null) {
+            BigDecimal mainFactor = factorMap.getOrDefault(mainCode, BigDecimal.ZERO);
+            return mainFactor.multiply(mainRatio);
+        }
+        return factorMap.getOrDefault(materialCode, BigDecimal.ZERO);
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/esg/scoreevents/model/ScoreEventsDto.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/scoreevents/model/ScoreEventsDto.java
@@ -3,22 +3,99 @@ package org.example.stockitbe.hq.esg.scoreevents.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 public class ScoreEventsDto {
 
-    /** GET 응답 — 연간 sale 거래 이벤트 리스트 */
+    /**
+     * GET 응답 — 친환경 나무 키우기 점수 페이지 풀세트.
+     *  - events: 페이지 슬라이스 (필터 적용 후 페이지에 해당하는 이벤트만)
+     *  - summary / monthlyBreakdown / categoryBreakdown: 페이지와 무관하게 "필터 적용 후 전체" 기준 통계
+     *  - page/size/totalElements/totalPages: 서버 페이징 메타
+     */
     @Getter
     @Builder
     public static class Response {
         private final int year;
         private final List<EventDto> events;
+
+        // ── Phase 3 (A''-1) — BE 가 직접 계산한 통계 묶음 ──
+        private final Summary summary;
+        private final List<MonthlyBucket> monthlyBreakdown;     // 1~12월 12개 (필터 후 기준)
+        private final CategoryBreakdown categoryBreakdown;      // 도넛 차트 4종 합계
+
+        // ── Phase 3 (B) — ESG 대시보드 카본 절감량 분포 묶음 ──
+        //   필터/페이지와 무관하게 "연도 전체" 기준. 단위: kg CO₂. 점수의 carbon (×0.1) 과 다른 산식.
+        private final CarbonReduction carbonReduction;
+
+        // ── 서버 페이징 메타 ──
+        private final int page;            // 0-based
+        private final int size;
+        private final long totalElements;  // 필터 적용 후 총 건수
+        private final int totalPages;
+    }
+
+    /**
+     * 카본 절감량 분포 (kg CO₂) — ESG 대시보드 KPI/차트 SSOT.
+     *  - 산식: 거래별 weight × effectiveFactor (혼방은 mainFactor × ratio 가중)
+     *  - 점수의 carbon (×CARBON_SCALE 0.1) 과 다른 값 — 실제 감축 환산 단위
+     *  - 카테고리 필터/페이지와 무관하게 연도 전체 이벤트 합산
+     *  - byGroup 키 어휘: FE 와 통일 ("NATURAL_SINGLE" / "SYNTHETIC" / "BLEND")
+     *    BE 어휘 'NATURAL' 은 응답 직전 'NATURAL_SINGLE' 로 정규화
+     */
+    @Getter
+    @Builder
+    public static class CarbonReduction {
+        private final Map<String, Long> byMaterial;   // { COTTON: kg, WOOL: kg, ... }
+        private final Map<String, Long> byGroup;      // { NATURAL_SINGLE: kg, SYNTHETIC: kg, BLEND: kg }
+        private final List<Long> monthly;             // 12개 (1~12월). kg CO₂.
+        private final long total;                     // byMaterial 합계와 동일
+    }
+
+    /**
+     * 점수 요약 KPI (필터 적용 후 전체 기준).
+     *  - 화면 상단 카드 + 평균 점수 표시에 사용
+     */
+    @Getter
+    @Builder
+    public static class Summary {
+        private final long totalScore;          // 4종 점수의 합 (모든 이벤트)
+        private final long saleExecutionSum;
+        private final long carbonSum;
+        private final long newBuyerSum;
+        private final long localPartnerSum;
+
+        private final long totalEventCount;     // 필터 적용 후 이벤트 수
+        private final long validEventCount;     // scoreValid=true 인 이벤트 수
+        private final long totalKg;             // 합산 weight (어뷰징 방지 무게 미달 포함)
+        private final long avgScore;            // totalScore / totalEventCount (없으면 0)
+    }
+
+    /** 12개월 막대그래프용 — month=1~12, score=해당 월 합계 (필터 적용 후) */
+    @Getter
+    @Builder
+    public static class MonthlyBucket {
+        private final int month;
+        private final long score;
+    }
+
+    /** 도넛 차트용 — 4종 점수의 (필터 적용 후) 누적 합계 */
+    @Getter
+    @Builder
+    public static class CategoryBreakdown {
+        private final long saleExecution;
+        private final long carbon;
+        private final long newBuyer;
+        private final long localPartner;
     }
 
     /**
      * 거래 이벤트 1건 (FE EsgTreeScoreView 의 event 객체 형태와 1:1 매칭).
      *  - donationType / method 는 sale 만 다루므로 미포함
-     *  - isLocalPartner 는 현재 항상 false (partner_type 컬럼 없음)
+     *  - Phase 2: isLocalPartner 가 circular_buyer.partner_type 기반으로 매핑 (이전: 항상 false)
+     *  - Phase 2: 거래별 점수 4종을 BE 가 직접 계산해서 응답 (FE 의 esgScore.js 산식 함수 폐기 준비)
      */
     @Getter
     @Builder
@@ -27,9 +104,21 @@ public class ScoreEventsDto {
         private final String date;          // "yyyy-MM-dd"
         private final String type;          // "sale" 고정 (donation 미지원)
         private final String buyer;         // circular_buyer.company_name
-        private final String material;      // material_code (e.g. "POLYESTER")
+        private final String material;      // material_code (e.g. "POLYESTER", "BLEND")
         private final Integer weightKg;
         private final boolean isNewBuyer;   // 본 거래가 해당 buyer 의 최초 거래인지
-        private final boolean isLocalPartner;  // 현재 false 고정
+        private final boolean isLocalPartner;  // Phase 2: partner_type=local_small/social_enterprise → true
+
+        // Phase 2 — 혼방 거래 메타 (FE 디버그/상세 표시용. 단일 거래는 null)
+        private final String mainMaterialCode;       // 혼방 70% 주 소재 코드 (예: "COTTON")
+        private final BigDecimal mainMaterialRatio;  // 주 소재 비율 (예: 0.70)
+
+        // Phase 2 — BE 가 계산한 거래별 점수 4종
+        private final int saleExecution;   // 100 (scoreValid 시), 0 (미달 시)
+        private final int carbon;          // weight × effectiveFactor × CARBON_SCALE(0.1)
+        private final int newBuyer;        // 150 (신규 거래처 & scoreValid)
+        private final int localPartner;    // 150 (지역 파트너 & scoreValid)
+        private final int total;           // 위 4종 합계
+        private final boolean scoreValid;  // weight >= MIN_WEIGHT_KG(10kg)
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryService.java
@@ -1283,7 +1283,9 @@ public class InventoryService {
         if (material == null || material.getMaterialGroup() == null) return ProductMaterialType.BLEND;
 
         String group = material.getMaterialGroup().trim().toUpperCase(Locale.ROOT);
-        if ("NATURAL".equals(group)) return ProductMaterialType.NATURAL_SINGLE;
+        // Phase 1: material.material_group 어휘를 'NATURAL' → 'NATURAL_SINGLE' 로 통일하면서
+        //          기존 'NATURAL' 도 안전망으로 함께 수용 (시드 적용 전/후 호환).
+        if ("NATURAL_SINGLE".equals(group) || "NATURAL".equals(group)) return ProductMaterialType.NATURAL_SINGLE;
         if ("SYNTHETIC".equals(group)) return ProductMaterialType.SYNTHETIC;
         return ProductMaterialType.BLEND;
     }

--- a/src/main/java/org/example/stockitbe/hq/product/model/Material.java
+++ b/src/main/java/org/example/stockitbe/hq/product/model/Material.java
@@ -41,7 +41,8 @@ public class Material extends BaseEntity {
     private String description;
 
     @Builder
-    private Material(String code, String nameKo, String materialGroup, Boolean active, String description) {
+    private Material(String code, String nameKo, String materialGroup,
+                     BigDecimal carbonFactor, Boolean active, String description) {
         this.code = code;
         this.nameKo = nameKo;
         this.materialGroup = materialGroup;

--- a/src/main/java/org/example/stockitbe/notification/NotificationService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationService.java
@@ -6,6 +6,8 @@ import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.notification.event.NotificationEvent;
 import org.example.stockitbe.notification.model.dto.NotificationDto;
 import org.example.stockitbe.notification.model.entity.Notification;
+import org.example.stockitbe.notification.model.entity.NotificationRead;
+import org.example.stockitbe.notification.repository.NotificationReadRepository;
 import org.example.stockitbe.notification.repository.NotificationRepository;
 import org.example.stockitbe.user.UserRepository;
 import org.example.stockitbe.user.model.entity.AuthUserDetails;
@@ -14,11 +16,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import org.springframework.transaction.annotation.Propagation;
 
-
+import java.time.ZoneId;
 import java.util.Date;
 
 @Service
@@ -26,6 +28,7 @@ import java.util.Date;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationReadRepository notificationReadRepository;   // 개별 읽음 추적용 (B3 해결)
     private final NotificationSseService sseService;
     private final UserRepository userRepository;
 
@@ -37,13 +40,19 @@ public class NotificationService {
     @Transactional(readOnly = true)
     public NotificationDto.NotificationListRes list(AuthUserDetails me, int page, int size, Boolean unreadOnly) {
         User u = findUserOrThrow(me);
+        Date activatedAt = getActivatedAt(u);                                  // 본인 활성화 시점 — 권한 기반 알림 노출 기준선
         Pageable pageable = PageRequest.of(Math.max(0, page), Math.max(1, size));
-        Page<Notification> p = notificationRepository.findReceivable(
-                u.getId(), u.getRole().name(), u.getLocationCode(), pageable);
 
+        // unreadOnly=true 면 NOT EXISTS 기반 쿼리로 페이지 크기 정확 보장 (V1 stream filter 의 버그 해결)
+        Page<NotificationRepository.ReceivableRow> p = Boolean.TRUE.equals(unreadOnly)
+                ? notificationRepository.findReceivableUnreadV2(
+                        u.getId(), u.getRole().name(), u.getLocationCode(), activatedAt, pageable)
+                : notificationRepository.findReceivableV2(
+                        u.getId(), u.getRole().name(), u.getLocationCode(), activatedAt, pageable);
+
+        // projection 의 readAt (본인 기준) 을 DTO 로 매핑 — null 이면 미읽음
         var items = p.getContent().stream()
-                .filter(n -> !Boolean.TRUE.equals(unreadOnly) || !n.isRead())
-                .map(NotificationDto.NotificationRes::from)
+                .map(row -> NotificationDto.NotificationRes.from(row.getN(), row.getReadAt()))
                 .toList();
 
         return NotificationDto.NotificationListRes.builder()
@@ -58,24 +67,42 @@ public class NotificationService {
     @Transactional(readOnly = true)
     public NotificationDto.UnreadCountRes unreadCount(AuthUserDetails me) {
         User u = findUserOrThrow(me);
-        long count = notificationRepository.countUnreadReceivable(
-                u.getId(), u.getRole().name(), u.getLocationCode());
+        Date activatedAt = getActivatedAt(u);
+        long count = notificationRepository.countUnreadReceivableV2(
+                u.getId(), u.getRole().name(), u.getLocationCode(), activatedAt);
         return NotificationDto.UnreadCountRes.builder().count(count).build();
     }
 
     @Transactional
     public void read(Long id, AuthUserDetails me) {
         User u = findUserOrThrow(me);
-        Notification n = findReceivableOrThrow(id, u);
-        if (n.isRead()) return;
-        n.markAsRead(new Date());
+        Notification n = findReceivableOrThrow(id, u);                         // 본인 수신분 검증 (broadcast + 직접 수신 모두 허용)
+
+        // 권한 기반 (broadcast) 알림은 본인 활성화 시점 이전 발행분이면 접근 거부.
+        // 직접 수신 (targetUserId == 본인) 은 시점 무관 (개인 알림은 시점 이후 발행밖에 없음).
+        if (n.getTargetUserId() == null && n.getCreatedAt().before(getActivatedAt(u))) {
+            throw BaseException.from(BaseResponseStatus.NOTIFICATION_FORBIDDEN);
+        }
+
+        // 이미 본인 읽음 행이 있으면 무시 — idempotent (한 알림 두 번 클릭 OK)
+        if (notificationReadRepository.existsByNotificationIdAndUserId(id, u.getId())) {
+            return;
+        }
+        notificationReadRepository.save(NotificationRead.builder()
+                .notificationId(id)
+                .userId(u.getId())
+                .readAt(new Date())
+                .build());
     }
 
     @Transactional
     public void readAll(AuthUserDetails me) {
         User u = findUserOrThrow(me);
-        notificationRepository.markAllReceivableRead(
-                u.getId(), u.getRole().name(), u.getLocationCode(), new Date());
+        Date activatedAt = getActivatedAt(u);
+        // 본인 수신분 중 아직 안 읽은 알림에 대해 notification_read 행 일괄 생성.
+        // INSERT IGNORE 로 동시 호출/이미 읽은 알림에 안전.
+        notificationRepository.markAllReceivableReadV2(
+                u.getId(), u.getRole().name(), u.getLocationCode(), activatedAt, new Date());
     }
 
     /** 이벤트 리스너에서 호출 — 알림 1건 영속화 */
@@ -117,5 +144,15 @@ public class NotificationService {
             throw BaseException.from(BaseResponseStatus.NOTIFICATION_FORBIDDEN);
         }
         return n;
+    }
+
+    // 사용하는 메서드: list, unreadCount, read, readAll
+    // 권한 기반 알림에 한해 본인 활성화 시점 (processedAt) 이후 발행분만 노출하기 위한 기준선 변환.
+    // User.processedAt 은 LocalDateTime — Notification.createDate (Date) 와 비교 위해 Date 로 변환.
+    // null 인 경우 fallback: Date(0) — 모든 알림 보임 (시스템 초기 admin / 기존 데이터 호환)
+    private Date getActivatedAt(User u) {
+        return u.getProcessedAt() != null
+                ? Date.from(u.getProcessedAt().atZone(ZoneId.systemDefault()).toInstant())
+                : new Date(0);
     }
 }

--- a/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.stockitbe.notification.model.dto.NotificationDto;
 import org.example.stockitbe.notification.model.entity.Notification;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -19,6 +20,14 @@ public class NotificationSseService {
     private static final long EMITTER_TIMEOUT_MS = 30 * 60 * 1000L; // 30분
 
     private final Map<Long, EmitterEntry> emitters = new ConcurrentHashMap<>();
+
+    // SSE push 비동기 fan-out 전용 스레드 풀 (AsyncConfig#notificationExecutor)
+    // 1500+ HQ admin fan-out 시 사용자별 emitter.send 를 별도 스레드에서 병렬 실행.
+    private final ThreadPoolTaskExecutor notificationExecutor;
+
+    public NotificationSseService(ThreadPoolTaskExecutor notificationExecutor) {
+        this.notificationExecutor = notificationExecutor;
+    }
 
     @PreDestroy
     void shutdown() {
@@ -43,21 +52,34 @@ public class NotificationSseService {
         return emitter;
     }
 
+    // 알림 fan-out 디스패치.
+    // 도메인 응답 스레드(EventListener) 는 emitter 목록 순회 + executor.execute(submit) 만 수행 → 즉시 반환.
+    // 실제 emitter.send 는 notificationExecutor 풀에서 사용자별 병렬 실행.
+    //   - 1500명 fan-out 시 동기 직렬: 50ms × 1500 = 75초 (도메인 응답 묶임)
+    //   - 비동기 병렬 (32 스레드): 도메인 응답 즉시 반환 + send 실제 시간 ~2.3초
     public void push(Notification n) {
         NotificationDto.SsePayload payload = NotificationDto.SsePayload.from(n);
 
         if (n.getTargetUserId() != null) {
+            // 직접 수신 — 해당 사용자 emitter 만 비동기 send
             EmitterEntry entry = emitters.get(n.getTargetUserId());
-            if (entry != null) sendOne(n.getTargetUserId(), entry, payload);
+            if (entry != null) {
+                final Long uid = n.getTargetUserId();
+                notificationExecutor.execute(() -> sendOne(uid, entry, payload));
+            }
             return;
         }
         if (n.getTargetRole() == null) return;
+
+        // broadcast — 권한군의 모든 emitter 에 비동기 fan-out
         for (Map.Entry<Long, EmitterEntry> kv : emitters.entrySet()) {
             EmitterEntry e = kv.getValue();
             if (!n.getTargetRole().equals(e.role)) continue;
             if (n.getTargetLocationCode() != null
                     && !n.getTargetLocationCode().equals(e.locationCode)) continue;
-            sendOne(kv.getKey(), e, payload);
+            // 사용자별 send 를 별도 스레드 풀로 위임 (병렬 실행)
+            final Long uid = kv.getKey();
+            notificationExecutor.execute(() -> sendOne(uid, e, payload));
         }
     }
 

--- a/src/main/java/org/example/stockitbe/notification/model/dto/NotificationDto.java
+++ b/src/main/java/org/example/stockitbe/notification/model/dto/NotificationDto.java
@@ -14,28 +14,29 @@ public class NotificationDto {
     @AllArgsConstructor
     @Builder
     public static class NotificationRes {
+        // 응답 필드 최소화 (2026-05-23) — FE 가 실제로 사용하는 7개만 응답.
+        // 제거된 필드: refType, refId, readAt (FE 미사용 — 통신량 약 25%↓ + 페이로드 의도 명확화)
+        // 제거 정책 근거: docs/plan/notification/응답 필드 최소화.md (예정) — DB 컬럼/Entity 필드는 유지.
         private Long id;
         private String type;
         private String severity;
         private String title;
         private String message;
-        private String refType;
-        private String refId;
         private boolean read;
-        private Date readAt;
         private Date createdAt;
 
-        public static NotificationRes from(Notification e) {
+        // 본인 기준 읽음 상태와 함께 변환.
+        // myReadAt 가 null 이면 본인이 아직 읽지 않은 알림 → read=false.
+        // (개별 읽음 추적: notification_read 매핑 테이블에서 LEFT JOIN 으로 가져온 본인 read_at)
+        // 시그니처 (Notification, Date) 는 유지 — Service.list 의 V2 호출부 호환성 보장.
+        public static NotificationRes from(Notification e, Date myReadAt) {
             return NotificationRes.builder()
                     .id(e.getId())
                     .type(e.getType().name())
                     .severity(e.getSeverity().name())
                     .title(e.getTitle())
                     .message(e.getMessage())
-                    .refType(e.getRefType())
-                    .refId(e.getRefId())
-                    .read(e.isRead())
-                    .readAt(e.getReadAt())
+                    .read(myReadAt != null)
                     .createdAt(e.getCreatedAt())
                     .build();
         }

--- a/src/main/java/org/example/stockitbe/notification/model/entity/Notification.java
+++ b/src/main/java/org/example/stockitbe/notification/model/entity/Notification.java
@@ -6,17 +6,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.stockitbe.common.model.BaseEntity;
-import org.example.stockitbe.notification.model.entity.NotificationSeverity;
-import org.example.stockitbe.notification.model.entity.NotificationType;
 
-import java.util.Date;
-
+// 알림 본문 (broadcast 패턴 — 권한군에 1행 INSERT).
+// 읽음 상태는 NotificationRead 매핑 테이블에서 사용자별로 추적 (B3 해결).
+//   - 본 엔티티에서 is_read / read_at 필드는 폐기됨 (2026-05-23)
 @Entity
 @Table(name = "notification", indexes = {
-        @Index(name = "idx_notification_role_loc_unread",
-                columnList = "target_role,target_location_code,is_read,create_date"),
-        @Index(name = "idx_notification_user_unread",
-                columnList = "target_user_id,is_read,create_date"),
+        @Index(name = "idx_notification_role_loc",
+                columnList = "target_role,target_location_code,create_date"),
+        @Index(name = "idx_notification_user",
+                columnList = "target_user_id,create_date"),
         @Index(name = "idx_notification_ref",
                 columnList = "ref_type,ref_id")
 })
@@ -56,12 +55,6 @@ public class Notification extends BaseEntity {
     @Column(name = "ref_id", length = 100)
     private String refId;
 
-    @Column(name = "is_read", nullable = false)
-    private boolean read;
-
-    @Column(name = "read_at")
-    private Date readAt;
-
     @Builder
     private Notification(NotificationType type, NotificationSeverity severity,
                          String title, String message,
@@ -76,11 +69,5 @@ public class Notification extends BaseEntity {
         this.targetUserId = targetUserId;
         this.refType = refType;
         this.refId = refId;
-        this.read = false;
-    }
-
-    public void markAsRead(Date now) {
-        this.read = true;
-        this.readAt = now;
     }
 }

--- a/src/main/java/org/example/stockitbe/notification/model/entity/NotificationRead.java
+++ b/src/main/java/org/example/stockitbe/notification/model/entity/NotificationRead.java
@@ -1,0 +1,41 @@
+package org.example.stockitbe.notification.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+// 알림 개별 읽음 추적 (B3 broadcast 읽음 문제 해결)
+//   - 알림 본문(Notification) 은 권한군 broadcast 1행
+//   - 읽음 상태는 (notification_id, user_id) 사용자별 매핑
+//   - 한 admin 이 읽어도 다른 admin 의 미읽음 상태는 유지됨
+@Entity
+@Table(name = "notification_read", indexes = {
+        @Index(name = "idx_notification_read_user", columnList = "user_id,notification_id")
+})
+@IdClass(NotificationReadId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationRead {
+
+    @Id
+    @Column(name = "notification_id", nullable = false)
+    private Long notificationId;
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "read_at", nullable = false)
+    private Date readAt;
+
+    @Builder
+    private NotificationRead(Long notificationId, Long userId, Date readAt) {
+        this.notificationId = notificationId;
+        this.userId = userId;
+        this.readAt = readAt;
+    }
+}

--- a/src/main/java/org/example/stockitbe/notification/model/entity/NotificationReadId.java
+++ b/src/main/java/org/example/stockitbe/notification/model/entity/NotificationReadId.java
@@ -1,0 +1,19 @@
+package org.example.stockitbe.notification.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+// NotificationRead 의 복합 PK 클래스 — (notification_id, user_id)
+// @IdClass 사용 시 PK 가 여러 컬럼이면 동일 필드명/타입을 갖는 별도 클래스 필요.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class NotificationReadId implements Serializable {
+    private Long notificationId;
+    private Long userId;
+}

--- a/src/main/java/org/example/stockitbe/notification/model/entity/NotificationType.java
+++ b/src/main/java/org/example/stockitbe/notification/model/entity/NotificationType.java
@@ -1,10 +1,16 @@
 package org.example.stockitbe.notification.model.entity;
 
+// 알림 종류 (총 4종)
+//  - INVENTORY_SHORTAGE       : 재고 부족
+//  - INVENTORY_OUT_OF_STOCK   : 재고 소진
+//  - USER_SIGNUP_PENDING      : 회원가입 승인 대기
+//  - CIRCULAR_CANDIDATE       : 순환 재고 후보
+//
+// 2026-05-22 폐기:
+//  - ESG_QUOTA_WARNING / ESG_QUOTA_EXCEEDED — 탄소 배출 한도 알림 (탄소 배출 관리 기능 폐기에 따른 정리)
 public enum NotificationType {
     INVENTORY_SHORTAGE,
     INVENTORY_OUT_OF_STOCK,
     USER_SIGNUP_PENDING,
-    CIRCULAR_CANDIDATE,
-    ESG_QUOTA_WARNING,
-    ESG_QUOTA_EXCEEDED
+    CIRCULAR_CANDIDATE
 }

--- a/src/main/java/org/example/stockitbe/notification/repository/NotificationReadRepository.java
+++ b/src/main/java/org/example/stockitbe/notification/repository/NotificationReadRepository.java
@@ -1,0 +1,14 @@
+package org.example.stockitbe.notification.repository;
+
+import org.example.stockitbe.notification.model.entity.NotificationRead;
+import org.example.stockitbe.notification.model.entity.NotificationReadId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 사용자별 알림 읽음 매핑 Repository.
+// 단건 읽음 처리 시 중복 INSERT 방지용 exists 체크 메서드 제공.
+// 전체 읽음 / 미읽음 카운트 / 목록 조회는 NotificationRepository 에서 JOIN 으로 처리.
+public interface NotificationReadRepository
+        extends JpaRepository<NotificationRead, NotificationReadId> {
+
+    boolean existsByNotificationIdAndUserId(Long notificationId, Long userId);
+}

--- a/src/main/java/org/example/stockitbe/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/stockitbe/notification/repository/NotificationRepository.java
@@ -10,41 +10,93 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Date;
 
+// 알림 본문 + 사용자별 읽음 상태 조회/처리 Repository.
+// 개별 읽음 추적 (notification_read 매핑 테이블) 기반.
+//  - LEFT JOIN 으로 본인 readAt 동반 반환 (projection)
+//  - 권한 기반 알림은 본인 processedAt(activatedAt) 이후 발행분만 노출
+//  - 직접 수신 (targetUserId = me) 은 activatedAt 조건 무시 (개인 알림)
+//  - 전체 읽음은 INSERT IGNORE 로 idempotent
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    // projection — Notification 본문 + 본인 readAt (null 이면 미읽음).
+    interface ReceivableRow {
+        Notification getN();
+        Date getReadAt();
+    }
+
+    // 본인 수신분 전체 (읽음/미읽음 모두) + 본인 readAt 동반.
+    // unreadOnly=true 인 경우는 findReceivableUnreadV2 사용 (페이지 크기 정확).
     @Query("""
-        SELECT n FROM Notification n
+        SELECT n AS n, r.readAt AS readAt
+        FROM Notification n
+        LEFT JOIN NotificationRead r
+               ON r.notificationId = n.id AND r.userId = :userId
         WHERE n.targetUserId = :userId
            OR (n.targetRole = :role
-               AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode))
+               AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode)
+               AND n.createdAt >= :activatedAt)
         ORDER BY n.id DESC
     """)
-    Page<Notification> findReceivable(@Param("userId") Long userId,
-                                      @Param("role") String role,
-                                      @Param("locationCode") String locationCode,
-                                      Pageable pageable);
+    Page<ReceivableRow> findReceivableV2(@Param("userId") Long userId,
+                                        @Param("role") String role,
+                                        @Param("locationCode") String locationCode,
+                                        @Param("activatedAt") Date activatedAt,
+                                        Pageable pageable);
 
+    // 본인 수신분 중 미읽음만. LEFT JOIN + IS NULL 패턴으로 페이지 크기 정확 보장.
+    @Query("""
+        SELECT n AS n, r.readAt AS readAt
+        FROM Notification n
+        LEFT JOIN NotificationRead r
+               ON r.notificationId = n.id AND r.userId = :userId
+        WHERE r.notificationId IS NULL
+          AND (n.targetUserId = :userId
+               OR (n.targetRole = :role
+                   AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode)
+                   AND n.createdAt >= :activatedAt))
+        ORDER BY n.id DESC
+    """)
+    Page<ReceivableRow> findReceivableUnreadV2(@Param("userId") Long userId,
+                                               @Param("role") String role,
+                                               @Param("locationCode") String locationCode,
+                                               @Param("activatedAt") Date activatedAt,
+                                               Pageable pageable);
+
+    // 미읽음 카운트. NOT EXISTS 로 본인 읽음 기록이 없는 알림 세기.
     @Query("""
         SELECT COUNT(n) FROM Notification n
-        WHERE n.read = false
-          AND (n.targetUserId = :userId
+        WHERE (n.targetUserId = :userId
                OR (n.targetRole = :role
-                   AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode)))
+                   AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode)
+                   AND n.createdAt >= :activatedAt))
+          AND NOT EXISTS (
+              SELECT 1 FROM NotificationRead r
+              WHERE r.notificationId = n.id AND r.userId = :userId)
     """)
-    long countUnreadReceivable(@Param("userId") Long userId,
-                               @Param("role") String role,
-                               @Param("locationCode") String locationCode);
+    long countUnreadReceivableV2(@Param("userId") Long userId,
+                                 @Param("role") String role,
+                                 @Param("locationCode") String locationCode,
+                                 @Param("activatedAt") Date activatedAt);
 
+    // 전체 읽음 — 본인 수신분 중 아직 안 읽은 알림에 대해 notification_read 행 일괄 생성.
+    // INSERT IGNORE: PK 충돌 시 무시 (동시 호출/중복 호출에 안전).
+    // MariaDB 전용 구문 — native query.
     @Modifying
-    @Query("""
-        UPDATE Notification n SET n.read = true, n.readAt = :now
-        WHERE n.read = false
-          AND (n.targetUserId = :userId
-               OR (n.targetRole = :role
-                   AND (n.targetLocationCode IS NULL OR n.targetLocationCode = :locationCode)))
-    """)
-    int markAllReceivableRead(@Param("userId") Long userId,
-                              @Param("role") String role,
-                              @Param("locationCode") String locationCode,
-                              @Param("now") Date now);
+    @Query(value = """
+        INSERT IGNORE INTO notification_read (notification_id, user_id, read_at)
+        SELECT n.id, :userId, :now
+        FROM notification n
+        WHERE (n.target_user_id = :userId
+               OR (n.target_role = :role
+                   AND (n.target_location_code IS NULL OR n.target_location_code = :locationCode)
+                   AND n.create_date >= :activatedAt))
+          AND NOT EXISTS (
+              SELECT 1 FROM notification_read r
+              WHERE r.notification_id = n.id AND r.user_id = :userId)
+    """, nativeQuery = true)
+    int markAllReceivableReadV2(@Param("userId") Long userId,
+                                @Param("role") String role,
+                                @Param("locationCode") String locationCode,
+                                @Param("activatedAt") Date activatedAt,
+                                @Param("now") Date now);
 }

--- a/src/main/java/org/example/stockitbe/user/UserService.java
+++ b/src/main/java/org/example/stockitbe/user/UserService.java
@@ -13,6 +13,7 @@ import org.example.stockitbe.user.model.entity.User;
 import org.example.stockitbe.user.model.entity.UserRole;
 import org.example.stockitbe.user.model.dto.UserDto;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,17 +21,23 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.regex.Pattern;
+
 
 
 @Service
 @RequiredArgsConstructor
 public class UserService implements UserDetailsService {
 
+    // 정규식 Pattern 1회 컴파일 후 재사용 — 매 매칭마다 컴파일 비용 회피.
+    // String.matches() 는 내부적으로 매 호출 시 Pattern.compile() 수행 → 회원가입 폭주 시 누적 부담.
+    // Pattern 인스턴스는 thread-safe 이므로 static final 로 안전하게 공유.
+
     // 전화번호: 하이픈 없이 010 + 숫자 8자리 (총 11자리)
-    private static final String PHONE_REGEX = "^010\\d{8}$";
+    private static final Pattern PHONE_PATTERN = Pattern.compile("^010\\d{8}$");
     // 비밀번호 정책: 대소문자, 숫자, 특수문자(!@#$%^&*) 포함 8자 이상
-    private static final String PASSWORD_REGEX =
-            "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$";
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$");
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -51,11 +58,11 @@ public class UserService implements UserDetailsService {
             throw BaseException.from(BaseResponseStatus.SIGNUP_DUPLICATE_EMAIL);
         }
 
-        if (dto.getPassword() == null || !dto.getPassword().matches(PASSWORD_REGEX)) {
+        if (dto.getPassword() == null || !PASSWORD_PATTERN.matcher(dto.getPassword()).matches()) {
             throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PASSWORD);
         }
 
-        if (dto.getPhoneNumber() == null || !dto.getPhoneNumber().matches(PHONE_REGEX)) {
+        if (dto.getPhoneNumber() == null || !PHONE_PATTERN.matcher(dto.getPhoneNumber()).matches()) {
             throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PHONE);
         }
 
@@ -98,47 +105,59 @@ public class UserService implements UserDetailsService {
     /**
      * 전화번호 수정.
      * - FE 에서 하이픈 없이 11자리 숫자 전송 (예: "01012345678")
+     * - User 의 @Version 으로 동시 UPDATE 충돌 자동 감지 → OptimisticLockingFailureException 발생 시
+     *   USER_CONCURRENT_MODIFICATION 으로 변환하여 친화 메시지 전달.
      */
     @Transactional
     public UserDto.MypageRes updatePhone(String employeeCode, String phoneNumber) {
-        User user = userRepository.findByEmployeeCode(employeeCode)
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.USER_NOT_FOUND));
+        try {
+            User user = userRepository.findByEmployeeCode(employeeCode)
+                    .orElseThrow(() -> BaseException.from(BaseResponseStatus.USER_NOT_FOUND));
 
-        if (phoneNumber == null || !phoneNumber.matches(PHONE_REGEX)) {
-            throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PHONE);
+            if (phoneNumber == null || !PHONE_PATTERN.matcher(phoneNumber).matches()) {
+                throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PHONE);
+            }
+
+            user.updatePhone(phoneNumber);
+            return UserDto.MypageRes.from(user);
+        } catch (OptimisticLockingFailureException ex) {
+            // 두 탭/디바이스 동시 UPDATE 충돌 — 본인 정보 수정의 lost update 방지.
+            throw BaseException.from(BaseResponseStatus.USER_CONCURRENT_MODIFICATION);
         }
-
-        user.updatePhone(phoneNumber);
-        return UserDto.MypageRes.from(user);
     }
 
     /**
      * 비밀번호 변경.
      * - 현재 비밀번호 검증 → 새 비밀번호 정책 검증 → 동일 비번 차단 → 인코딩 저장
      * - (보안) 본인 포함 모든 Refresh Token 삭제 → 모든 디바이스 강제 로그아웃
+     * - User 의 @Version 으로 동시 UPDATE 충돌 자동 감지.
      */
     @Transactional
     public void updatePassword(String employeeCode, String currentPassword, String newPassword) {
-        User user = userRepository.findByEmployeeCode(employeeCode)
-                .orElseThrow(() -> BaseException.from(BaseResponseStatus.USER_NOT_FOUND));
+        try {
+            User user = userRepository.findByEmployeeCode(employeeCode)
+                    .orElseThrow(() -> BaseException.from(BaseResponseStatus.USER_NOT_FOUND));
 
-        // 1) 현재 비밀번호 검증
-        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw BaseException.from(BaseResponseStatus.PASSWORD_WRONG);
-        }
-        // 2) 새 비밀번호 정책 검증 (대소문자/숫자/특수문자 포함 8자 이상)
-        if (newPassword == null || !newPassword.matches(PASSWORD_REGEX)) {
-            throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PASSWORD);
-        }
-        // 3) 동일 비밀번호 차단
-        if (passwordEncoder.matches(newPassword, user.getPassword())) {
-            throw BaseException.from(BaseResponseStatus.USER_PASSWORD_SAME);
-        }
+            // 1) 현재 비밀번호 검증
+            if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+                throw BaseException.from(BaseResponseStatus.PASSWORD_WRONG);
+            }
+            // 2) 새 비밀번호 정책 검증 (대소문자/숫자/특수문자 포함 8자 이상)
+            if (newPassword == null || !PASSWORD_PATTERN.matcher(newPassword).matches()) {
+                throw BaseException.from(BaseResponseStatus.SIGNUP_INVALID_PASSWORD);
+            }
+            // 3) 동일 비밀번호 차단
+            if (passwordEncoder.matches(newPassword, user.getPassword())) {
+                throw BaseException.from(BaseResponseStatus.USER_PASSWORD_SAME);
+            }
 
-        user.updatePassword(passwordEncoder.encode(newPassword));
+            user.updatePassword(passwordEncoder.encode(newPassword));
 
-        // (보안) 모든 디바이스 강제 로그아웃 — 본인 디바이스도 포함
-        jwtRefreshRepository.deleteAllByEmployeeCode(employeeCode);
+            // (보안) 모든 디바이스 강제 로그아웃 — 본인 디바이스도 포함
+            jwtRefreshRepository.deleteAllByEmployeeCode(employeeCode);
+        } catch (OptimisticLockingFailureException ex) {
+            throw BaseException.from(BaseResponseStatus.USER_CONCURRENT_MODIFICATION);
+        }
     }
 
     /**

--- a/src/main/java/org/example/stockitbe/user/model/entity/User.java
+++ b/src/main/java/org/example/stockitbe/user/model/entity/User.java
@@ -55,6 +55,12 @@ public class User {
 
     private LocalDateTime processedAt; // 본사 관리자의 회원가입 처리일시
 
+    // 동시 승인 방지용 낙관적 락 (2026-05-23).
+    // 두 admin 이 같은 PENDING 신청을 동시에 승인 시도 시 OptimisticLockingFailureException 발생 →
+    // 사번 시퀀스 중복 발급(lost update) 방지. nullable 로 둬서 기존 행 호환.
+    @Version
+    private Long version;
+
 
     //  본사 관리자가 가입 신청을 승인할 때 호출
     public void approve(String employeeCode) {

--- a/src/main/resources/sql/04-product_master_dummy_data.sql
+++ b/src/main/resources/sql/04-product_master_dummy_data.sql
@@ -4,18 +4,27 @@
 INSERT INTO material
 (code, name_ko, material_group, carbon_factor, active, create_date, update_date)
 VALUES
-('COTTON','면','NATURAL', 1.800,1,NOW(),NOW()),
-('WOOL','울','NATURAL',1.200, 1,NOW(),NOW()),
-('CASHMERE','캐시미어','NATURAL',1.300, 1,NOW(),NOW()),
-('SILK','실크','NATURAL',1.300, 1,NOW(),NOW()),
-('LINEN','린넨','NATURAL',1.700, 1,NOW(),NOW()),
-('POLYESTER','폴리에스터','SYNTHETIC', 2.300, 1,NOW(),NOW()),
-('ACRYLIC','아크릴','SYNTHETIC',2.400, 1,NOW(),NOW()),
-('POLYAMIDE','나일론','SYNTHETIC',2.500, 1,NOW(),NOW()),
-('ELASTANE','스판덱스','SYNTHETIC',2.200, 1,NOW(),NOW()),
-('RAYON','레이온','SYNTHETIC',2.700,1,NOW(),NOW())
-ON DUPLICATE KEY UPDATE
-name_ko=VALUES(name_ko), material_group=VALUES(material_group), active=VALUES(active), update_date=NOW();
+    -- material_group 어휘는 ProductMasterService.MATERIAL_GROUP_NATURAL='NATURAL' 상수 호환을 위해
+    -- 'NATURAL' 유지 (Phase 1 옵션 C — 팀원 코드 기준에 맞춤). FE 는 esgStore.fetchMaterialFactors 에서
+    -- NATURAL → NATURAL_SINGLE 로 정규화하여 일관성 유지.
+    ('COTTON',    '면',         'NATURAL',   6.000, 1, NOW(), NOW()),
+    ('WOOL',      '울',         'NATURAL',   5.000, 1, NOW(), NOW()),  -- cap 적용
+    ('CASHMERE',  '캐시미어',   'NATURAL',   8.000, 1, NOW(), NOW()),  -- cap 적용
+    ('SILK',      '실크',       'NATURAL',   5.000, 1, NOW(), NOW()),  -- cap 적용
+    ('LINEN',     '린넨',       'NATURAL',   1.800, 1, NOW(), NOW()),
+    ('POLYESTER', '폴리에스터', 'SYNTHETIC', 6.500, 1, NOW(), NOW()),
+    ('ACRYLIC',   '아크릴',     'SYNTHETIC', 5.700, 1, NOW(), NOW()),
+    ('POLYAMIDE', '나일론',     'SYNTHETIC', 8.000, 1, NOW(), NOW()),
+    ('ELASTANE',  '스판덱스',   'SYNTHETIC', 12.000, 1, NOW(), NOW()),
+    ('RAYON',     '레이온',     'SYNTHETIC', 4.500, 1, NOW(), NOW()),
+    ('BLEND',     '혼방',       'BLEND',     5.500, 1, NOW(), NOW())
+    ON DUPLICATE KEY UPDATE
+                         name_ko = VALUES(name_ko),
+                         material_group = VALUES(material_group),
+                         carbon_factor = VALUES(carbon_factor),
+                         active = VALUES(active),
+                         update_date = NOW();
+
 
 INSERT INTO product_master
 (code, name, category_code, base_price, lead_time_days, warehouse_safety_stock, store_safety_stock, main_vendor_code, status, create_date, update_date)

--- a/src/main/resources/sql/11-circular_buyer_transaction_seed.sql
+++ b/src/main/resources/sql/11-circular_buyer_transaction_seed.sql
@@ -5,20 +5,30 @@
 -- 분포 규칙:
 --   - buyer.primary_material_fit 와 매칭되는 material 만 거래
 --     · synthetic (100명)      → POLYESTER/ACRYLIC/POLYAMIDE/ELASTANE 중 buyer id 기반 deterministic
---     · blended (100명)        → BLEND 고정
+--     · blended (100명)        → BLEND (혼방). main_material_code 에 70% 주 소재 분배 (Phase 2)
 --     · natural-single (100명) → COTTON/WOOL/CASHMERE/SILK/LINEN 중 선택
 --   - 단가는 circular_material_price_policy.price_per_kg 정책 단가 (거래 시점 스냅샷)
 --   - weight_kg: 200~5000 kg deterministic 분포
 --   - transacted_at: 2026-01-01 ~ 2026-05-10 분포 (약 130일)
 --
+-- Phase 2 추가: main_material_code / main_material_ratio
+--   - BLEND 거래일 때만 70% 주 소재 코드 (COTTON / POLYAMIDE / LINEN / WOOL) + ratio 0.70 채움
+--   - 단일 거래는 NULL (혼방 산식 미적용 대상)
+--   - ScoreEventsService 가 (material.carbon_factor[main_material_code] × main_material_ratio) 로 가중 점수 산출
+--
 -- 실행 전제:
 --   - circular_buyer 시드 (08) 적용됨 (300건)
 --   - circular_material_price_policy 시드 (06) 적용됨 (10건)
 --   - circular_buyer_transaction 테이블 생성됨 (BE 재기동 시 Hibernate 가 자동 생성)
+--   - Phase 2 마이그레이션 적용됨 (main_material_code, main_material_ratio 컬럼 존재)
+--
+-- 재실행 시: id IDENTITY 라 중복 INSERT 방지 위해 TRUNCATE 권장.
+--   TRUNCATE TABLE circular_buyer_transaction;
 -- ============================================================
 
 INSERT INTO circular_buyer_transaction
-(buyer_id, material_code, weight_kg, unit_price, total_amount, transacted_at, create_date)
+(buyer_id, material_code, weight_kg, unit_price, total_amount, transacted_at, create_date,
+ main_material_code, main_material_ratio)
 SELECT
     src.buyer_id,
     src.material_code,
@@ -26,7 +36,16 @@ SELECT
     pp.price_per_kg AS unit_price,
     src.weight_kg * pp.price_per_kg AS total_amount,
     src.transacted_at,
-    NOW() AS create_date
+    NOW() AS create_date,
+    -- Phase 2: BLEND 거래일 때만 70% 주 소재 코드 분배 (4가지 product 조합 패턴)
+    --   COTTON+POLY / POLYAMIDE+RAYON / LINEN+RAYON / WOOL+POLY 의 주 소재
+    CASE
+        WHEN src.material_code = 'BLEND'
+          THEN ELT(((src.buyer_id - 1) MOD 4) + 1, 'COTTON', 'POLYAMIDE', 'LINEN', 'WOOL')
+        ELSE NULL
+    END AS main_material_code,
+    -- Phase 2: 혼방은 0.70 비율, 단일 거래는 NULL
+    CASE WHEN src.material_code = 'BLEND' THEN 0.70 ELSE NULL END AS main_material_ratio
 FROM (
          -- 거래 1 (큰 거래, 1~5월 분포)
          SELECT

--- a/src/main/resources/sql/migration-2026-05-feedback-work.sql
+++ b/src/main/resources/sql/migration-2026-05-feedback-work.sql
@@ -1,0 +1,166 @@
+-- ================================================================================================
+-- migration-2026-05-feedback-work.sql
+-- 통합 마이그레이션 (feat/feedback-work 브랜치) — 2026-05-22 ~ 2026-05-23 작업분 일괄 정리
+--
+-- 포함된 개별 마이그레이션 (원본 6개 파일을 한 파일로 통합):
+--   ① inventory UK 정합 (2026-05-22)              — 옛 commit 보완
+--   ② circular_buyer_transaction Phase 2 컬럼     (2026-05-22)
+--   ③ NotificationType ENUM 6→4 축소              (2026-05-22)
+--   ④ notification_read 매핑 테이블 신설          (2026-05-23 step1)
+--   ⑤ notification is_read/read_at 제거 + 인덱스   (2026-05-23 step4 cleanup)
+--   ⑥ user @Version 컬럼 초기화                    (2026-05-23)
+--
+-- 실행 순서 의존성:
+--   - ②/③/④ 는 서로 독립적이라 순서 무관 (BE 부팅 전이라면 어떤 순서든 OK)
+--   - ⑤ 는 ④ 가 선행되어야 함 (notification_read 가 없으면 사용자별 추적 불가)
+--   - ⑤ 는 BE 코드(Notification.read 필드 제거) 가 배포된 후 실행해야 함
+--     (안 그러면 ddl-auto: update 가 컬럼을 다시 만들어버려 무효화됨)
+--   - ⑥ 은 BE 부팅으로 ddl-auto 가 version 컬럼을 추가한 직후 실행
+--
+-- 적용 환경:
+--   - dev : ddl-auto: update 가 컬럼/인덱스 자동 처리하는 항목이 많아 사실상 ⑥ 만 필수.
+--           나머지는 ENUM 좁힘 / 옛 인덱스 정리 / 데이터 cleanup 등 명시적 통제용.
+--   - prod: 본 파일을 트랜잭션 묶음으로 검토 후 수동 실행. DB 백업 권장.
+--
+-- 적용 후 통합 검증:
+--   SHOW INDEX FROM inventory;                          -- uk_inventory_sku_location_status 만 남아 있어야
+--   SHOW COLUMNS FROM circular_buyer_transaction;       -- main_material_code / main_material_ratio 존재
+--   SHOW COLUMNS FROM notification LIKE 'type';         -- ENUM 4종만
+--   SHOW COLUMNS FROM notification;                     -- is_read / read_at 없음
+--   SHOW TABLES LIKE 'notification_read';               -- 존재
+--   SELECT COUNT(*) FROM user WHERE version IS NULL;    -- 0
+-- ================================================================================================
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ① inventory 옛 유니크 키 정리 (2026-05-22)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 배경:
+--   commit c27490072d4a3cc0322546bddcc8a81b4465109c (2026-05-05) 에서
+--   Inventory.java 의 유니크 키를 (sku_id, location_id) → (sku_id, location_id, inventory_status) 로
+--   변경했으나 마이그레이션 SQL 누락. ddl-auto: update 가 옛 인덱스를 자동 삭제 못해 두 인덱스 공존.
+--
+-- 증상:
+--   POST /api/hq/inventories/circular-candidates/convert →
+--   "Duplicate entry 'X-Y' for key 'uk_inventory_sku_location'" 500 에러.
+--
+-- 사전 확인: SHOW INDEX FROM inventory;  -- uk_inventory_sku_location 가 없으면 이 ALTER 건너뜀
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE inventory DROP INDEX uk_inventory_sku_location;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ② circular_buyer_transaction — 혼방 거래 70% 주 소재 메타 컬럼 추가 (2026-05-22)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 배경:
+--   Phase 2 — 혼방 거래 가중 점수 산식 (70% 주 소재 factor × 0.7) 을 BE 가 계산하기 위해
+--   거래 단위로 어떤 70% 소재가 사용되었는지 식별 가능해야 함.
+--
+-- 컬럼:
+--   - main_material_code  : material_code='BLEND' 일 때만 채움. 단일 거래는 NULL.
+--   - main_material_ratio : 주 소재 비율 (예: 0.70). 단일 거래는 NULL.
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE circular_buyer_transaction
+    ADD COLUMN main_material_code  VARCHAR(32) NULL COMMENT '혼방 거래의 70% 주 소재 코드 (단일 거래는 NULL)',
+    ADD COLUMN main_material_ratio DECIMAL(3,2) NULL COMMENT '주 소재 비율 (예: 0.70)';
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ③ NotificationType ENUM 6종 → 4종 축소 (2026-05-22)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 배경:
+--   '탄소 배출 관리' 기능 폐기 → ESG_QUOTA_WARNING / ESG_QUOTA_EXCEEDED 알림 폐기.
+--   notification.type 이 ENUM 컬럼이라 ddl-auto: update 의 자동 좁힘이 안 들어갈 수 있어 명시 ALTER.
+--
+-- 주의: 기존 ESG_QUOTA_* row 가 남아 있으면 MODIFY COLUMN 실패 → DELETE 선행.
+-- ─────────────────────────────────────────────────────────────────────────────
+DELETE FROM notification
+ WHERE type IN ('ESG_QUOTA_WARNING', 'ESG_QUOTA_EXCEEDED');
+
+ALTER TABLE notification
+    MODIFY COLUMN type ENUM(
+        'INVENTORY_SHORTAGE',
+        'INVENTORY_OUT_OF_STOCK',
+        'USER_SIGNUP_PENDING',
+        'CIRCULAR_CANDIDATE'
+    ) NOT NULL;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ④ notification_read 매핑 테이블 신설 (2026-05-23, B3 broadcast 읽음 분리)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 배경:
+--   notification.is_read 가 권한군 broadcast 전체에 공유되어 한 명이 읽으면 모두 읽음 처리되는 버그.
+--   사용자별 읽음 상태를 별도 매핑 테이블로 분리해 해결.
+--
+-- 인덱스 설계:
+--   - PK (notification_id, user_id)  → 같은 사용자가 같은 알림을 두 번 INSERT 못함
+--   - idx_notification_read_user      → 본인 읽음 목록 조회 (LEFT JOIN 효율)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE notification_read (
+    notification_id BIGINT   NOT NULL,
+    user_id         BIGINT   NOT NULL,
+    read_at         DATETIME NOT NULL,
+    PRIMARY KEY (notification_id, user_id),
+    INDEX idx_notification_read_user (user_id, notification_id)
+);
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ⑤ notification 테이블 V1 잔재 정리 (2026-05-23 step4 cleanup)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 전제:
+--   - ④ 완료 (notification_read 존재)
+--   - BE 코드에서 Notification.read / readAt 필드 제거 + 배포 완료
+--     안 되어 있으면 BE 재시작 시 ddl-auto: update 가 컬럼을 다시 만들어 본 SQL 무효화됨.
+--
+-- 작업:
+--   - 기존 broadcast 데이터 폐기 (TRUNCATE — dev clean start 정책)
+--   - is_read 포함 옛 인덱스 2개 DROP
+--   - is_read / read_at 컬럼 DROP
+--   - is_read 미포함 신규 인덱스 2개 CREATE
+-- ─────────────────────────────────────────────────────────────────────────────
+TRUNCATE TABLE notification;
+
+ALTER TABLE notification DROP INDEX idx_notification_role_loc_unread;
+ALTER TABLE notification DROP INDEX idx_notification_user_unread;
+
+ALTER TABLE notification DROP COLUMN is_read;
+ALTER TABLE notification DROP COLUMN read_at;
+
+CREATE INDEX idx_notification_role_loc
+    ON notification(target_role, target_location_code, create_date);
+CREATE INDEX idx_notification_user
+    ON notification(target_user_id, create_date);
+
+-- idx_notification_ref (ref_type, ref_id) 는 read 와 무관 — 그대로 유지.
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ⑥ User @Version 컬럼 초기화 (2026-05-23, 낙관적 락 도입)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 배경:
+--   - 동시 승인 방지 (두 admin 이 같은 PENDING 신청을 동시 승인 시 사번 중복/lost update 방지)
+--   - 본인 정보 수정 (updatePhone / updatePassword) 의 동시 UPDATE 충돌 감지
+--   - 모든 User UPDATE 지점에 OptimisticLockingFailureException → USER_CONCURRENT_MODIFICATION (4805)
+--
+-- 문제 시나리오 (본 UPDATE 누락 시):
+--   - ddl-auto: update 가 version BIGINT NULL 로 컬럼만 추가
+--   - 기존 행 모두 version = NULL → 첫 UPDATE 시 Hibernate NPE
+--     ("Cannot invoke java.lang.Long.longValue() because current is null")
+--   - 마이페이지 전화번호 수정 / 계정 승인 등 모든 User UPDATE 500 에러.
+--
+-- prod 권장 (한 번에 처리):
+--   ALTER TABLE user ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+-- dev 권장 (ddl-auto 가 컬럼 추가한 뒤):
+--   본 UPDATE 실행
+-- ─────────────────────────────────────────────────────────────────────────────
+UPDATE user
+   SET version = 0
+ WHERE version IS NULL;
+-- 실측 (dev, 2026-05-23 18:00): 1685 row(s) affected
+
+
+-- ================================================================================================
+-- 통합 마이그레이션 끝
+-- ================================================================================================


### PR DESCRIPTION
## 📌 요약
- 

<br><br>

## 🎯 작업 내용
### 1. feat(notification): broadcast 읽음 사용자별 분리 + SSE fan-out 비동기화
- B3 버그 (한 명이 읽으면 권한군 전체 읽음 처리) 해결을 위해 `notification_read` 매핑 테이블 신설
- `Notification.is_read / read_at` 컬럼 제거 + 인덱스 교체 (`is_read` 포함 → 미포함)
- `NotificationType` ENUM 6종 → 4종 축소 (ESG_QUOTA_* 폐기)
- `EmissionQuotaService` 의 알림 발송 로직 제거
- `AsyncConfig` 신설 + `notificationExecutor`(core 8 / max 32 / queue 2000) 도입 → SSE 1500명 fan-out 병렬화

### 2. fix(user): 동시 승인/정보 수정 충돌 방지 — @Version 낙관적 락
- `User.@Version` 추가 → 두 admin 동시 승인 시 사번 중복/lost update 방지
- `AccountService.approve/reject/withdraw` 와 `UserService.updatePhone/updatePassword` 에 `OptimisticLockingFailureException` catch
- `BaseResponseStatus.USER_CONCURRENT_MODIFICATION(4805)` 신설
- 정규식 캐싱 (`Pattern.compile` 정적 상수화)

### 3. feat(esg/material-factor): MaterialFactor API + 혼방 거래 메타 컬럼
- `MaterialFactor` API 신설 → FE 가 material.carbon_factor 마스터를 BE 응답으로 가져옴 (산식 SSOT 이관 준비)
- `CircularBuyerTransaction` 에 `main_material_code` / `main_material_ratio` 컬럼 추가 → 혼방 거래의 70% 주 소재 추적
- material 시드 갱신 + BLEND row 신규 (Higg MSI v3 / EU PEF 기준)

### 4. feat(esg/score-events): 서버 페이징/필터/통계/카본분포 BE 이관 + YEAR() 인덱스 활용
- Response 확장: `events`(페이지 슬라이스), `summary`, `monthlyBreakdown`, `categoryBreakdown`, `carbonReduction`, 페이지 메타
- 점수 4종(saleExecution/carbon/newBuyer/localPartner) + 카본 절감량 분포(byMaterial/byGroup/monthly/total) 전부 BE 계산 → FE 자체 산식 폐기
- 필터/카테고리/페이지 파라미터(`page/size/dateFrom/dateTo/category`) 처리
- `circular_buyer_transaction` 쿼리에서 `WHERE YEAR(transacted_at) = ?` → `>= :from AND < :to` 범위 조건으로 변경 → 인덱스 활용 가능
- ESG 대시보드 KPI/차트도 BE `carbonReduction` 응답 그대로 사용

### 5. chore(migration): 마이그레이션 6종을 통합 파일로 정리
- 개별 SQL 6개를 `migration-2026-05-feedback-work.sql` 한 파일로 통합
- ① inventory UK 정합 → ② CBT 혼방 컬럼 → ③ NotificationType ENUM 축소 → ④ notification_read 신설 → ⑤ notification cleanup → ⑥ user.version 초기화 순서
- 각 단계별 의도/의존성/검증 SQL 주석으로 명시

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
