### PR TITLE
fix(notification): SSE emitter 생명주기/동시성 안정화

### DIFF
--- a/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
@@ -11,15 +11,32 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * SSE 알림 fan-out 서비스 (v2 — emitter 생명주기/동시성 안정화).
+ *
+ * 운영 장애 패턴 ("RecycleRequiredException + heartbeat 실패 + taskScheduler queue 누적") 의
+ * 근본 원인 4가지를 모두 정리:
+ *  1. sessionId 기반 다중 emitter — 사용자가 다중 탭/새로고침/EventSource 재연결 해도
+ *     이전 emitter 가 leak 없이 공존 (이전: Map<Long, EmitterEntry> 라 덮어쓰면서 leak).
+ *  2. compare-and-remove — onCompletion/onTimeout/onError 콜백에서 (sessionId, entry) 매칭으로 제거.
+ *     같은 userId 의 옛 emitter 콜백이 새 emitter 를 silent 하게 삭제하는 race condition 차단.
+ *  3. per-emitter ReentrantLock — heartbeat × push 가 같은 emitter 에 동시 send() 시
+ *     출력 스트림 interleaved write 로 깨지지 않도록 직렬화.
+ *  4. heartbeat 도 notificationExecutor 로 비동기 fan-out — 단일 @Scheduled 스레드 점유 해소.
+ *     1500명 × 50ms = 75초 누적되어 taskScheduler queue 가 쌓이던 문제 제거.
+ */
 @Service
 @Slf4j
 public class NotificationSseService {
 
     private static final long EMITTER_TIMEOUT_MS = 30 * 60 * 1000L; // 30분
 
-    private final Map<Long, EmitterEntry> emitters = new ConcurrentHashMap<>();
+    // key = sessionId (UUID). 같은 userId 에 대해 여러 emitter (다중 탭 등) 공존 허용.
+    private final Map<String, EmitterEntry> emitters = new ConcurrentHashMap<>();
 
     // SSE push 비동기 fan-out 전용 스레드 풀 (AsyncConfig#notificationExecutor)
     // 1500+ HQ admin fan-out 시 사용자별 emitter.send 를 별도 스레드에서 병렬 실행.
@@ -31,90 +48,146 @@ public class NotificationSseService {
 
     @PreDestroy
     void shutdown() {
-        emitters.values().forEach(e -> { try { e.emitter.complete(); } catch (Exception ignored) {} });
+        // graceful — 각 emitter 에 lock 잡고 complete() 호출 (동시 send 중인 emitter 와 충돌 방지)
+        for (EmitterEntry entry : emitters.values()) {
+            entry.lock.lock();
+            try {
+                try { entry.emitter.complete(); } catch (Exception ignored) {}
+            } finally {
+                entry.lock.unlock();
+            }
+        }
         emitters.clear();
     }
 
     public SseEmitter subscribe(Long userId, String role, String locationCode) {
+        // 매 구독마다 고유 sessionId — 같은 userId 가 새 탭으로 다시 구독해도 별도 entry 로 보관.
+        final String sessionId = UUID.randomUUID().toString();
         SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
-        EmitterEntry entry = new EmitterEntry(emitter, role, locationCode);
-        emitters.put(userId, entry);
+        EmitterEntry entry = new EmitterEntry(emitter, userId, role, locationCode);
+        emitters.put(sessionId, entry);
 
-        emitter.onCompletion(() -> emitters.remove(userId));
-        emitter.onTimeout(() -> { emitters.remove(userId); emitter.complete(); });
-        emitter.onError((e) -> emitters.remove(userId));
+        // compare-and-remove — emitters.remove(K, V) 가 false 면 이미 다른 콜백이 정리한 상태이거나
+        // 같은 sessionId 에 새 entry 가 들어간 상태라 안전하게 통과.
+        // onError/onTimeout 모두 complete() 명시 호출 — 안 하면 Tomcat async request 가 정상 종료 안 돼
+        // 'RecycleRequiredException' (Encountered a non-recycled request) 발화 가능.
+        emitter.onCompletion(() -> emitters.remove(sessionId, entry));
+        emitter.onTimeout(() -> {
+            emitters.remove(sessionId, entry);
+            try { emitter.complete(); } catch (Exception ignored) {}
+        });
+        emitter.onError((e) -> {
+            emitters.remove(sessionId, entry);
+            try { emitter.complete(); } catch (Exception ignored) {}
+        });
 
+        // 초기 connect 이벤트 — lock 보호 (이론상 첫 send 는 단일 스레드지만 일관성 위해)
+        entry.lock.lock();
         try {
             emitter.send(SseEmitter.event().name("connect").data("ok"));
         } catch (IOException e) {
-            emitters.remove(userId);
+            emitters.remove(sessionId, entry);
+        } finally {
+            entry.lock.unlock();
         }
         return emitter;
     }
 
-    // 알림 fan-out 디스패치.
-    // 도메인 응답 스레드(EventListener) 는 emitter 목록 순회 + executor.execute(submit) 만 수행 → 즉시 반환.
-    // 실제 emitter.send 는 notificationExecutor 풀에서 사용자별 병렬 실행.
-    //   - 1500명 fan-out 시 동기 직렬: 50ms × 1500 = 75초 (도메인 응답 묶임)
-    //   - 비동기 병렬 (32 스레드): 도메인 응답 즉시 반환 + send 실제 시간 ~2.3초
+    /**
+     * 알림 fan-out 디스패치.
+     *  - 도메인 응답 스레드는 emitter 목록 순회 + executor.execute(submit) 만 수행 → 즉시 반환.
+     *  - 실제 emitter.send 는 notificationExecutor 풀에서 사용자별 병렬 실행.
+     */
     public void push(Notification n) {
         NotificationDto.SsePayload payload = NotificationDto.SsePayload.from(n);
 
         if (n.getTargetUserId() != null) {
-            // 직접 수신 — 해당 사용자 emitter 만 비동기 send
-            EmitterEntry entry = emitters.get(n.getTargetUserId());
-            if (entry != null) {
-                final Long uid = n.getTargetUserId();
-                notificationExecutor.execute(() -> sendOne(uid, entry, payload));
+            // 직접 수신 — 해당 userId 의 모든 emitter (다중 탭) 에 비동기 send
+            final Long targetUid = n.getTargetUserId();
+            for (Map.Entry<String, EmitterEntry> kv : emitters.entrySet()) {
+                EmitterEntry e = kv.getValue();
+                if (!targetUid.equals(e.userId)) continue;
+                final String sid = kv.getKey();
+                notificationExecutor.execute(() -> sendOne(sid, e, payload));
             }
             return;
         }
         if (n.getTargetRole() == null) return;
 
         // broadcast — 권한군의 모든 emitter 에 비동기 fan-out
-        for (Map.Entry<Long, EmitterEntry> kv : emitters.entrySet()) {
+        for (Map.Entry<String, EmitterEntry> kv : emitters.entrySet()) {
             EmitterEntry e = kv.getValue();
             if (!n.getTargetRole().equals(e.role)) continue;
             if (n.getTargetLocationCode() != null
                     && !n.getTargetLocationCode().equals(e.locationCode)) continue;
             // 사용자별 send 를 별도 스레드 풀로 위임 (병렬 실행)
-            final Long uid = kv.getKey();
-            notificationExecutor.execute(() -> sendOne(uid, e, payload));
+            final String sid = kv.getKey();
+            notificationExecutor.execute(() -> sendOne(sid, e, payload));
         }
     }
 
-    private void sendOne(Long userId, EmitterEntry entry, NotificationDto.SsePayload payload) {
+    /** 단일 emitter 에 알림 이벤트 send — per-emitter lock 으로 직렬화. */
+    private void sendOne(String sessionId, EmitterEntry entry, NotificationDto.SsePayload payload) {
+        entry.lock.lock();
         try {
             entry.emitter.send(SseEmitter.event().name("notification").data(payload));
         } catch (Exception ex) {
-            log.warn("[NotificationSseService] push 실패 userId={} — emitter 정리", userId);
-            emitters.remove(userId);
+            log.warn("[NotificationSseService] push 실패 sessionId={} userId={} — emitter 정리",
+                    sessionId, entry.userId);
+            // compare-and-remove — 같은 sessionId 에 다른 entry 가 들어간 경우 건드리지 않음
+            emitters.remove(sessionId, entry);
             try { entry.emitter.complete(); } catch (Exception ignored) {}
+        } finally {
+            entry.lock.unlock();
         }
     }
 
+    /**
+     * heartbeat — 모든 emitter 에 30초마다 ping comment 전송.
+     *  v1 의 단일 스레드 직렬 send 를 폐기하고 notificationExecutor 로 비동기 fan-out.
+     *  → 1500명 × 50ms 직렬(75초) 누적 문제 해결 + push 와 동일 패턴 일관성.
+     */
     @Scheduled(fixedRate = 30_000L)
     void sendHeartbeat() {
         if (emitters.isEmpty()) return;
-        for (Map.Entry<Long, EmitterEntry> kv : emitters.entrySet()) {
-            try {
-                kv.getValue().emitter.send(SseEmitter.event().comment("ping"));
-            } catch (Exception ex) {
-                // 클라이언트 끊김 — emitter 정리 + complete 호출 (다음 cycle 부터 깨끗)
-                log.warn("[NotificationSseService] heartbeat 실패 userId={} — emitter 정리",
-                        kv.getKey());
-                emitters.remove(kv.getKey());
-                try { kv.getValue().emitter.complete(); } catch (Exception ignored) {}
-            }
+        for (Map.Entry<String, EmitterEntry> kv : emitters.entrySet()) {
+            final String sid = kv.getKey();
+            final EmitterEntry entry = kv.getValue();
+            notificationExecutor.execute(() -> sendHeartbeatOne(sid, entry));
         }
     }
 
+    /** 단일 emitter 에 heartbeat ping — per-emitter lock 으로 push 와의 동시 send 직렬화. */
+    private void sendHeartbeatOne(String sessionId, EmitterEntry entry) {
+        entry.lock.lock();
+        try {
+            entry.emitter.send(SseEmitter.event().comment("ping"));
+        } catch (Exception ex) {
+            log.warn("[NotificationSseService] heartbeat 실패 sessionId={} userId={} — emitter 정리",
+                    sessionId, entry.userId);
+            emitters.remove(sessionId, entry);
+            try { entry.emitter.complete(); } catch (Exception ignored) {}
+        } finally {
+            entry.lock.unlock();
+        }
+    }
+
+    /**
+     * Emitter 1개의 메타 정보 + 동시 send 직렬화용 lock.
+     *  - userId : 사용자별 fan-out 필터링용 (key 가 sessionId 이므로 별도 보관 필요)
+     *  - role / locationCode : broadcast 권한군 매칭용
+     *  - lock : heartbeat × push 동시 send 시 SseEmitter 출력 스트림 직렬화 보장
+     */
     private static class EmitterEntry {
         final SseEmitter emitter;
+        final Long userId;
         final String role;
         final String locationCode;
-        EmitterEntry(SseEmitter emitter, String role, String locationCode) {
+        final ReentrantLock lock = new ReentrantLock();
+
+        EmitterEntry(SseEmitter emitter, Long userId, String role, String locationCode) {
             this.emitter = emitter;
+            this.userId = userId;
             this.role = role;
             this.locationCode = locationCode;
         }


### PR DESCRIPTION
## 📌 요약
- 운영에서 두 백엔드 Pod 모두 반복 관측된 `RecycleRequiredException + heartbeat 실패 + taskScheduler queue 누적` 패턴의 근본 원인 4가지 모두 정리
- 다중 탭/새로고침/EventSource 자동 재연결 churn 상황에서 emitter leak 및 race condition 차단
- Blackbox Uptime 하락의 유력 원인(SSE 구현 불안정) 해소 목적

<br><br>

## 🎯 작업 내용

### 1. sessionId 기반 다중 emitter 지원
- `Map<Long, EmitterEntry>` → `Map<String, EmitterEntry>` (UUID sessionId 키) 로 변경
- `userId` 는 `EmitterEntry` 필드로 이동, broadcast 필터링은 stream filter 로 처리
- 같은 userId 의 다중 탭/재연결 emitter 가 leak 없이 공존

### 2. 콜백 compare-and-remove + onError complete() 추가
- `emitters.remove(sessionId, entry)` — 옛 emitter 콜백이 새 emitter 까지 silent 삭제하는 race condition 차단
- `onError` 콜백에 `emitter.complete()` 명시 호출 추가 — Tomcat async request 가 정상 종료되도록 보장 (이걸 누락하면 `RecycleRequiredException` 발화)
- `onTimeout` 은 기존부터 호출 중이었음

### 3. per-emitter ReentrantLock 으로 동시 send 직렬화
- `EmitterEntry.lock = new ReentrantLock()` 추가
- 모든 `emitter.send(...)` 호출 (subscribe 초기 connect / sendOne / sendHeartbeatOne / shutdown) 에 lock 보호
- `heartbeat × push` 가 같은 emitter 에 동시 send() 시 SSE 출력 스트림 interleaved write 방지

### 4. heartbeat 도 비동기 fan-out
- `@Scheduled` 단일 스레드 직렬 send (1500명 × 50ms = 75초 누적) → `notificationExecutor.execute(() -> sendHeartbeatOne(...))` 로 위임
- push 와 동일 패턴 → 일관성 + `taskScheduler.queued` 누적 (운영 actuator 지표 = 4) 해소

<br><br>

## ✔️ 참고 사항

### 로컬 검증 결과 (다중 탭 4개 + 반복 새로고침 2분)
| 패턴 | Before | After |
|---|---|---|
| `RecycleRequiredException` | 매 새로고침마다 발화 | **0건** |
| `IOException` ERROR | 매 heartbeat 사이클마다 다수 | **0건** |
| `[NotificationSseService] heartbeat 실패` WARN | 폭주 + 같은 userId 반복 + ERROR 동반 | WARN 1줄 + 자동 정리 (정상 흐름) |

### 운영 배포 후 추적 필요한 메트릭
- Grafana `taskScheduler.queued` — 4 → **0~1** 로 떨어지는지
- Grafana `notificationExecutor.queued` / `active` — heartbeat 사이클 시점에 short burst 후 빠르게 0 회귀
- Pod 로그 `RecycleRequiredException` 발화율 — 0 또는 매우 드물게
- Pod 로그 `heartbeat 실패` WARN — 발화는 OK, 단 **같은 userId 가 매 사이클 반복**되면 leak 잔존 의심
- Blackbox `probe_success` / Uptime — 1주일 추세 추적해서 95%+ 회복 여부

### 영향 범위
- BE: `NotificationSseService.java` 한 파일만 변경
- FE: 수정 없음 — BE 측이 sessionId 기반 다중 emitter 로 클라이언트 churn 흡수
- DB / 마이그레이션: 없음

### 후속 작업 (별도 PR 검토 대상)


<br><br>

## ✔️ 관련 이슈

- Close #이슈번호
