### PR TITLE
Feat/sse explicit unsubscribe

### DIFF
--- a/src/main/java/org/example/stockitbe/notification/NotificationController.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationController.java
@@ -23,6 +23,18 @@ public class NotificationController {
         return service.subscribe(me);
     }
 
+    // SSE 명시적 종료 — FE 가 페이지 unload (탭 닫기/F5/창 닫기) 시 navigator.sendBeacon 으로 호출.
+    // TCP FIN 도달 못 하는 unload 상황에서도 BE Map 에서 즉시 정리되게 함.
+    // sendBeacon 은 POST 만 지원 → DELETE 가 아닌 POST 채택.
+    @PostMapping("/stream/{sessionId}/close")
+    public BaseResponse<Void> closeStream(
+            @AuthenticationPrincipal AuthUserDetails me,
+            @PathVariable String sessionId) {
+        // 1. 요청 받기 2. 서비스 호출 (내부에서 sessionId owner 검증) 3. 응답 반환
+        service.unsubscribeStream(sessionId, me);
+        return BaseResponse.success(null);
+    }
+
     // 본인 수신 알림 목록
     @GetMapping
     public BaseResponse<NotificationDto.NotificationListRes> list(

--- a/src/main/java/org/example/stockitbe/notification/NotificationService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationService.java
@@ -37,6 +37,15 @@ public class NotificationService {
         return sseService.subscribe(u.getId(), u.getRole().name(), u.getLocationCode());
     }
 
+    /**
+     * 명시적 unsubscribe — FE 가 페이지 unload 시 sendBeacon 으로 호출.
+     * sseService.unsubscribeOne 에서 sessionId 의 owner 가 본인 (userId 일치) 인지 검증.
+     */
+    public void unsubscribeStream(String sessionId, AuthUserDetails me) {
+        User u = findUserOrThrow(me);
+        sseService.unsubscribeOne(sessionId, u.getId());
+    }
+
     @Transactional(readOnly = true)
     public NotificationDto.NotificationListRes list(AuthUserDetails me, int page, int size, Boolean unreadOnly) {
         User u = findUserOrThrow(me);

--- a/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
@@ -178,7 +178,9 @@ public class NotificationSseService {
         try {
             entry.emitter.send(SseEmitter.event().name("notification").data(payload));
         } catch (Exception ex) {
-            log.warn("[NotificationSseService] push 실패 sessionId={} userId={} — emitter 정리",
+            // 의미: BE 가 알림을 send 했는데 IOException — 거의 항상 클라이언트가 이미 끊긴 상태.
+            // "실패" 라는 단어가 장애로 오인되어 메시지를 중립적으로 변경 (정상 회수 메커니즘).
+            log.warn("[NotificationSseService] 클라이언트 연결 종료 감지 — emitter 회수 (push 실패) sessionId={} userId={}",
                     sessionId, entry.userId);
             // compare-and-remove — 같은 sessionId 에 다른 entry 가 들어간 경우 건드리지 않음
             emitters.remove(sessionId, entry);
@@ -209,7 +211,10 @@ public class NotificationSseService {
         try {
             entry.emitter.send(SseEmitter.event().comment("ping"));
         } catch (Exception ex) {
-            log.warn("[NotificationSseService] heartbeat 실패 sessionId={} userId={} — emitter 정리",
+            // 의미: 30초 ping 이 IOException — 클라이언트가 close()/탭종료/네트워크끊김 등으로 이미 사라진 상태.
+            // sendBeacon 도달 못 한 케이스 (브라우저 강제종료/노트북 절전 등) 의 안전망 cleanup.
+            // "실패" 라는 단어가 장애로 오인되어 메시지를 중립적으로 변경 (정상 회수 메커니즘).
+            log.warn("[NotificationSseService] 클라이언트 연결 종료 감지 — emitter 회수 (heartbeat 무응답) sessionId={} userId={}",
                     sessionId, entry.userId);
             emitters.remove(sessionId, entry);
             try { entry.emitter.complete(); } catch (Exception ignored) {}

--- a/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationSseService.java
@@ -66,31 +66,77 @@ public class NotificationSseService {
         SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
         EmitterEntry entry = new EmitterEntry(emitter, userId, role, locationCode);
         emitters.put(sessionId, entry);
+        // SSE 생명주기 모니터링 — 평소 운영(INFO)에서는 조용, application-dev.yml 의 DEBUG 설정 시 가시화.
+        // 운영 진단 필요 시 actuator/loggers 로 런타임 토글 가능 (재시작 불필요).
+        log.debug("[SSE] subscribe sessionId={} userId={} role={} (총 emitters={})",
+                sessionId, userId, role, emitters.size());
 
         // compare-and-remove — emitters.remove(K, V) 가 false 면 이미 다른 콜백이 정리한 상태이거나
         // 같은 sessionId 에 새 entry 가 들어간 상태라 안전하게 통과.
         // onError/onTimeout 모두 complete() 명시 호출 — 안 하면 Tomcat async request 가 정상 종료 안 돼
         // 'RecycleRequiredException' (Encountered a non-recycled request) 발화 가능.
-        emitter.onCompletion(() -> emitters.remove(sessionId, entry));
+        emitter.onCompletion(() -> {
+            if (emitters.remove(sessionId, entry)) {
+                // TCP 끊김 감지 경로 — sendBeacon 으로 정리 안 된 경우 (FE close() / 네트워크 끊김)
+                log.debug("[SSE] onCompletion sessionId={} userId={} (남은={})", sessionId, userId, emitters.size());
+            }
+        });
         emitter.onTimeout(() -> {
-            emitters.remove(sessionId, entry);
+            if (emitters.remove(sessionId, entry)) {
+                log.debug("[SSE] onTimeout sessionId={} userId={} (남은={})", sessionId, userId, emitters.size());
+            }
             try { emitter.complete(); } catch (Exception ignored) {}
         });
         emitter.onError((e) -> {
-            emitters.remove(sessionId, entry);
+            if (emitters.remove(sessionId, entry)) {
+                log.debug("[SSE] onError sessionId={} userId={} (남은={})", sessionId, userId, emitters.size());
+            }
             try { emitter.complete(); } catch (Exception ignored) {}
         });
 
         // 초기 connect 이벤트 — lock 보호 (이론상 첫 send 는 단일 스레드지만 일관성 위해)
+        // payload 로 sessionId 전달 — FE 가 받아 보관 후, 페이지 unload 시 sendBeacon 으로
+        // POST /api/notifications/stream/{sessionId}/close 호출하여 BE Map 에서 즉시 정리되게 함.
         entry.lock.lock();
         try {
-            emitter.send(SseEmitter.event().name("connect").data("ok"));
+            emitter.send(SseEmitter.event().name("connect").data(sessionId));
         } catch (IOException e) {
             emitters.remove(sessionId, entry);
         } finally {
             entry.lock.unlock();
         }
         return emitter;
+    }
+
+    /**
+     * 명시적 unsubscribe — FE 가 페이지 unload (탭 닫기/F5/창 닫기) 시 sendBeacon 으로 호출.
+     *  - TCP FIN 도달 못 하는 unload 상황에서도 즉시 Map 에서 정리 → heartbeat 30초 대기 불필요.
+     *  - userId 검증: 다른 사용자의 sessionId 를 임의로 끄지 못하게 (보안).
+     *  - 이미 정리된 sessionId 거나 mismatch 면 silent return — idempotent.
+     */
+    public void unsubscribeOne(String sessionId, Long userId) {
+        if (sessionId == null || userId == null) return;
+        EmitterEntry entry = emitters.get(sessionId);
+        if (entry == null) {
+            // 이미 다른 콜백 (heartbeat / TCP) 이 정리한 상태 — beacon 도착 전 TCP 가 더 빨랐을 때
+            log.debug("[SSE] unsubscribeOne (이미 정리됨) sessionId={} userId={}", sessionId, userId);
+            return;
+        }
+        if (!userId.equals(entry.userId)) {                     // 보안: 타 사용자 sessionId 차단
+            log.warn("[NotificationSseService] unsubscribeOne userId 불일치 sessionId={} entryUserId={} requestUserId={}",
+                    sessionId, entry.userId, userId);
+            return;
+        }
+        entry.lock.lock();
+        try {
+            try { entry.emitter.complete(); } catch (Exception ignored) {}
+        } finally {
+            entry.lock.unlock();
+        }
+        boolean removed = emitters.remove(sessionId, entry);
+        // 명시적 beacon close 가시화 — 가장 중요한 모니터링 라인 (DEBUG 활성화 시)
+        log.debug("[SSE] unsubscribeOne (sendBeacon) sessionId={} userId={} removed={} (남은={})",
+                sessionId, userId, removed, emitters.size());
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,6 +36,11 @@ logging:
   level:
     org.hibernate.SQL: info
     org.hibernate.orm.jdbc.bind: info
+    # SSE 생명주기 가시화 — 로컬 개발 시 subscribe/unsubscribe/onCompletion 등 흐름 추적용.
+    # 운영(prod) 에서는 기본 INFO 라 조용. 운영 진단 필요 시 actuator/loggers 로 런타임 토글:
+    #   curl -X POST host/actuator/loggers/org.example.stockitbe.notification \
+    #     -H 'Content-Type: application/json' -d '{"configuredLevel":"DEBUG"}'
+    org.example.stockitbe.notification: debug
 
 # SYS-001 본사 발주 자동 전환 배치
 purchase-order:


### PR DESCRIPTION
## 📌 요약
- 운영 로그의 "userId=1 의 24초 만에 stale emitter 20+ 누적" 현상을 근본 해결
- FE 가 페이지 unload (탭 닫기 / F5 / 창 닫기) 시 BE 에 명시적 종료 신호를 보낼 수 있는 엔드포인트 추가
- sessionId 단위 정밀 종료로 다중 탭 / 다중 PC 환경에서 다른 탭의 SSE 보존

<br><br>

## 🎯 작업 내용
- `POST /api/notifications/stream/{sessionId}/close` 엔드포인트 신설 (sendBeacon 은 POST 만 지원)
- `connect` 이벤트 data 로 sessionId 전달 (기존 `"ok"` → UUID) — FE 가 보관해 close 호출 시 사용
- `NotificationSseService.unsubscribeOne(sessionId, userId)` — userId 검증 후 sessionId 단위 정밀 종료, idempotent
- `NotificationService.unsubscribeStream` — 인증된 사용자 식별 후 SSE 서비스에 위임
- SSE 생명주기 모니터링 DEBUG 로그 추가 (subscribe / onCompletion / onTimeout / onError / unsubscribeOne) — 운영 INFO 환경에서는 조용, actuator/loggers 로 런타임 토글 가능
- `application-dev.yml`: SSE notification 패키지 로깅 DEBUG 활성화 — 로컬 dev 에서 흐름 가시화 (prod 는 INFO 그대로 → 조용)
- `NotificationSseService` 의 cleanup WARN 로그 문구 명확화 — `"heartbeat 실패"` / `"push 실패"` → `"클라이언트 연결 종료 감지 — emitter 회수 (...)"` (운영자가 장애로 오인하던 케이스 방지)

<br><br>

## ✔️ 참고 사항
- 검증: 로컬에서 탭 닫기 / F5 / 다중 탭 격리 / 8분 heartbeat 지속 모두 통과 — cleanup WARN 0건
- 보안: 타 사용자의 sessionId 로 close 호출 시 차단 (userId 검증) + 시도 시 WARN 로그
- CSRF 비활성 정책 그대로 적용 (REST API + JWT) — sendBeacon 의 쿠키 자동 전송으로 JwtAuthFilter 통과
- 운영 진단 시 DEBUG 활성화 명령:

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
