### PR TITLE
refactor(hq-inventory): _source_excludes 로 by_location 조건부 제외 — 응답 latency 60배 개선

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryQueryService.java
@@ -83,15 +83,20 @@ public class InventoryQueryService {
                     .fields("product_code", "product_name"))));
         }
 
+        boolean excludeByLocation = locationIds == null || locationIds.isEmpty();
         try {
-            SearchResponse<ProductInventoryDoc> response = esClient.search(s -> s
-                    .index(MASTER_INDEX)
-                    .from(from)
-                    .size(pageSize)
-                    .trackTotalHits(t -> t.enabled(true))
-                    .query(q -> q.bool(b -> b.filter(filters).must(musts)))
-                    .sort(so -> so.field(f -> f.field("product_code").order(SortOrder.Asc))),
-                    ProductInventoryDoc.class);
+            SearchResponse<ProductInventoryDoc> response = esClient.search(s -> {
+                s.index(MASTER_INDEX)
+                        .from(from)
+                        .size(pageSize)
+                        .trackTotalHits(t -> t.enabled(true))
+                        .query(q -> q.bool(b -> b.filter(filters).must(musts)))
+                        .sort(so -> so.field(f -> f.field("product_code").order(SortOrder.Asc)));
+                if (excludeByLocation) {
+                    s.source(src -> src.filter(f -> f.excludes("by_location")));
+                }
+                return s;
+            }, ProductInventoryDoc.class);
 
             long total = response.hits().total() == null ? 0L : response.hits().total().value();
             final List<Long> safeLocationIds = locationIds;
@@ -149,15 +154,20 @@ public class InventoryQueryService {
                     .fields("sku_code", "product_code", "product_name"))));
         }
 
+        boolean excludeByLocation = locationIds == null || locationIds.isEmpty();
         try {
-            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> s
-                    .index(SKU_INDEX)
-                    .from(from)
-                    .size(pageSize)
-                    .trackTotalHits(t -> t.enabled(true))
-                    .query(q -> q.bool(b -> b.filter(filters).must(musts)))
-                    .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc))),
-                    SkuInventoryDoc.class);
+            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> {
+                s.index(SKU_INDEX)
+                        .from(from)
+                        .size(pageSize)
+                        .trackTotalHits(t -> t.enabled(true))
+                        .query(q -> q.bool(b -> b.filter(filters).must(musts)))
+                        .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc)));
+                if (excludeByLocation) {
+                    s.source(src -> src.filter(f -> f.excludes("by_location")));
+                }
+                return s;
+            }, SkuInventoryDoc.class);
 
             long total = response.hits().total() == null ? 0L : response.hits().total().value();
             final List<Long> safeLocationIds = locationIds;
@@ -212,14 +222,19 @@ public class InventoryQueryService {
                     .fields("sku_code", "color", "size"))));
         }
 
+        boolean excludeByLocation = locationIds == null || locationIds.isEmpty();
         try {
-            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> s
-                    .index(SKU_INDEX)
-                    .size(1000)
-                    .trackTotalHits(t -> t.enabled(true))
-                    .query(q -> q.bool(b -> b.filter(filters).must(musts)))
-                    .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc))),
-                    SkuInventoryDoc.class);
+            SearchResponse<SkuInventoryDoc> response = esClient.search(s -> {
+                s.index(SKU_INDEX)
+                        .size(1000)
+                        .trackTotalHits(t -> t.enabled(true))
+                        .query(q -> q.bool(b -> b.filter(filters).must(musts)))
+                        .sort(so -> so.field(f -> f.field("sku_code").order(SortOrder.Asc)));
+                if (excludeByLocation) {
+                    s.source(src -> src.filter(f -> f.excludes("by_location")));
+                }
+                return s;
+            }, SkuInventoryDoc.class);
 
             final LocationType lt = locationType;
             final List<Long> safeLocationIds = locationIds;


### PR DESCRIPTION
## 📌 요약
- ES `_source_excludes("by_location")` 조건부 적용으로 무필터/카테고리/매장창고 호출의 응답 latency 60배 단축.

<br><br>

## 🎯 작업 내용
- ES profile 측정 결과 `_source` 전체 = **1045ms**, `_source_excludes=by_location` = **17ms** (60배 차이). by_location 가 거점 단위 132 element/doc nested array 라 JSON serialize + 네트워크 전송이 latency 주 원인.
- `locationIds` (특정 거점) 필터 없는 호출은 BE 가 by_location 안 쓰는데 매번 받아 deserialize 까지 했음. 조건부 제외로 ms 단위 응답 보장.
- `findCompanyWide` / `findCompanyWideSkus` / `findCompanyWideSkuDetails` 3 메서드에 동일 패턴. `findCompanyWideSkuFacets` 는 size=0 + agg 라 영향 없음.
- locationIds 있을 때만 by_location 포함 (BE 가 매칭 합산에 사용).

<br><br>

## ✔️ 참고 사항
- ES profile=true 의 query/fetch nanos 합 (~2.3ms) vs took (1045ms) 의 gap 으로 source serialize + network 가 bottleneck 식별.
- k6 02-load 재측정으로 단계 4 narrative 추가 예정 (예상 p95 220ms → 50ms 이하).

<br><br>

## ✔️ 관련 이슈

- Close #367

<br><br>
