### PR TITLE
refactor: [BATCH-2] ShedLock 테이블 생성 및 스케줄러 중복 실행 방지 적용

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/ShedLockConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/ShedLockConfig.java
@@ -11,16 +11,18 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import javax.sql.DataSource;
 
 @Configuration
-@EnableScheduling
-@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
+@EnableScheduling     // Spring 스케줄러 활성화
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M") // 락 미해제 시 최대 30분 후 자동 해제 (Pod 비정상 종료 대비)
 public class ShedLockConfig {
 
+    // 락 저장소를 MariaDB(shedlock 테이블)로 지정
+    // 다중 Pod 환경에서 하나의 Pod만 배치를 실행하도록 DB를 분산 락 저장소로 활용
     @Bean
     public LockProvider lockProvider(DataSource dataSource) {
         return new JdbcTemplateLockProvider(
             JdbcTemplateLockProvider.Configuration.builder()
                 .withJdbcTemplate(new JdbcTemplate(dataSource))
-                .usingDbTime()
+                .usingDbTime() // 각 Pod의 시스템 시각 편차를 제거하기 위해 DB 서버 시각 기준으로 만료 계산
                 .build()
         );
     }

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
@@ -14,7 +14,10 @@ public class StoreOrderBatchApproveScheduler {
 
     private final StoreOrderBatchApproveService batchApproveService;
 
-    // 발주 자동 배치 스케줄러 (매일 00:00 실행)
+    // 매장 발주 자동 승인 배치 (매일 00:00 실행)
+    // @SchedulerLock: 다중 Pod 중 하나만 실행되도록 분산 락 적용
+    //   - name: shedlock 테이블의 락 식별자 (스케줄러마다 고유해야 함)
+    //   - lockAtMostFor: Pod 비정상 종료 시에도 30분 후 락 자동 해제
     @Scheduled(
             cron = "${store-order.batch.cron:0 0 0 * * *}",
             zone = "${store-order.batch.zone:Asia/Seoul}"

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
@@ -2,6 +2,7 @@ package org.example.stockitbe.store.order.batch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ public class StoreOrderBatchApproveScheduler {
             cron = "${store-order.batch.cron:0 0 0 * * *}",
             zone = "${store-order.batch.zone:Asia/Seoul}"
     )
+    @SchedulerLock(name = "storeOrderBatchApproveJob", lockAtMostFor = "PT30M")
     public void runAutoBatch() {
         StoreOrderBatchDto.RunRes result = batchApproveService.runAutoDaily();
         log.info("[STORE-ORDER-BATCH] scheduler done runId={} requested={} success={} fail={}",

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
     job:
       enabled: false        # 서버 시작 시 Job 자동 실행 방지 (운영 데이터 보호)
     jdbc:
-      initialize-schema: always        # BATCH_ 메타 테이블 6개 자동 생성 / # TODO: 최초 prod 배포 후 never로 변경
+      initialize-schema: never        # BATCH_ 메타 테이블 6개 자동 생성 / # TODO: 최초 prod 배포 후 never로 변경
 
   sql:
     init:


### PR DESCRIPTION
## 📌 요약
- ShedLock을 이용한 다중 Pod 스케줄러 중복 실행 방지 적용

<br><br>

## 🎯 작업 내용
- `shedlock` 테이블 DDL(`CREATE TABLE IF NOT EXISTS`) 작성 및 `classpath:db/shedlock.sql` 배치
- `spring.sql.init` 설정 추가(dev/prod)로 앱 시작 시 shedlock 테이블 자동 생성
- `StoreOrderBatchApproveScheduler.runAutoBatch()`에 `@SchedulerLock(name = "storeOrderBatchApproveJob", lockAtMostFor = "PT30M")` 적용

<br><br>

## ✔️ 참고 사항
- `lockAtMostFor = "PT30M"` — 락 보유 최대 시간 30분. 배치가 비정상 종료되더라도 30분 후 자동 해제됨
- shedlock 테이블은 `IF NOT EXISTS`로 생성되므로 팀원 로컬 DB 및 RDS 환경 모두 앱 기동 시 자동 생성됨 (수동 DDL 불필요)
- k6 VU=2 동시 실행 테스트(락 획득 실패 로그 확인)는 BATCH-4 성능 측정 단계에서 진행

<br><br>

## ✔️ 관련 이슈

- Close #353 

<br><br>