### PR TITLE
refactor: [BATCH-3] Tasklet 기반 StoreOrderBatchApproveJob 구현

### DIFF
--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
@@ -3,7 +3,10 @@ package org.example.stockitbe.store.order.batch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +15,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class StoreOrderBatchApproveScheduler {
 
-    private final StoreOrderBatchApproveService batchApproveService;
+    private final JobLauncher jobLauncher;
+    private final Job storeOrderBatchApproveJob;
 
     // 매장 발주 자동 승인 배치 (매일 00:00 실행)
     // @SchedulerLock: 다중 Pod 중 하나만 실행되도록 분산 락 적용
@@ -24,8 +28,16 @@ public class StoreOrderBatchApproveScheduler {
     )
     @SchedulerLock(name = "storeOrderBatchApproveJob", lockAtMostFor = "PT30M")
     public void runAutoBatch() {
-        StoreOrderBatchDto.RunRes result = batchApproveService.runAutoDaily();
-        log.info("[STORE-ORDER-BATCH] scheduler done runId={} requested={} success={} fail={}",
-                result.getRunId(), result.getRequestedCount(), result.getSuccessCount(), result.getFailCount());
+        try {
+            // Spring Batch는 동일한 파라미터로 성공한 Job의 재실행을 거부함
+            // 타임스탬프를 파라미터로 부여해 매 실행을 고유하게 구분
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("runAt", System.currentTimeMillis())
+                    .toJobParameters();
+            jobLauncher.run(storeOrderBatchApproveJob, params);
+        } catch (Exception e) {
+            log.error("[STORE-ORDER-BATCH] job launch failed", e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
@@ -1,0 +1,56 @@
+package org.example.stockitbe.store.order.batch.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.store.order.batch.StoreOrderBatchApproveService;
+import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class BatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final StoreOrderBatchApproveService batchApproveService;
+
+    // 배치 작업 전체를 대표하는 단위
+    // 실행될 때마다 BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION 테이블에 이력이 자동 기록됨
+    @Bean
+    public Job storeOrderBatchApproveJob(Step storeOrderBatchApproveStep) {
+        return new JobBuilder("storeOrderBatchApproveJob", jobRepository)
+                .start(storeOrderBatchApproveStep)
+                .build();
+    }
+
+    // Job 안에서 실제로 실행되는 단계
+    // 현재는 단계가 하나지만 필요 시 전처리 → 처리 → 후처리 형태로 Step 추가 가능
+    @Bean
+    public Step storeOrderBatchApproveStep() {
+        return new StepBuilder("storeOrderBatchApproveStep", jobRepository)
+                .tasklet(storeOrderBatchApproveTasklet(), transactionManager)
+                .build();
+    }
+
+    // Step이 실행할 실제 코드 조각
+    // RepeatStatus.FINISHED 반환 시 Step 완료로 처리됨
+    @Bean
+    public Tasklet storeOrderBatchApproveTasklet() {
+        return (contribution, chunkContext) -> {
+            StoreOrderBatchDto.RunRes result = batchApproveService.runAutoDaily();
+            log.info("[STORE-ORDER-BATCH] job done runId={} requested={} success={} fail={}",
+                    result.getRunId(), result.getRequestedCount(), result.getSuccessCount(), result.getFailCount());
+            return RepeatStatus.FINISHED;
+        };
+    }
+}


### PR DESCRIPTION
## 📌 요약
- Tasklet 기반 StoreOrderBatchApproveJob 구현 — 배치 실행 이력 DB 저장

<br><br>

## 🎯 작업 내용
- `BatchConfig.java` 생성 — `storeOrderBatchApproveJob` / `storeOrderBatchApproveStep` / `storeOrderBatchApproveTasklet` Bean 정의
- Tasklet에서 기존 `runAutoDaily()` 위임 호출 (비즈니스 로직 변경 없음)
- `StoreOrderBatchApproveScheduler` — `StoreOrderBatchApproveService` 의존성 제거, `JobLauncher.run()` 호출 방식으로 전환
- `runAt(timestamp)` JobParameter 추가로 매 실행마다 고유 식별 보장

<br><br>

## ✔️ 참고 사항
- Tasklet은 기존 `runAutoDaily()` for-loop 로직을 그대로 위임 — 처리 결과(SUCCESS/FAIL 건수) 동일
- 배치 실행 후 `BATCH_JOB_EXECUTION` 테이블에 이력 자동 저장 (`initialize-schema: always`)
- `runAt` 파라미터가 없으면 Spring Batch가 동일 파라미터 재실행을 차단하므로 반드시 포함

<br><br>

## ✔️ 관련 이슈

- Close #354 

<br><br>