### PR TITLE
fix(notification,k8s): SSE 안정성 강화 + 자원/graceful 인프라 동기화"

### DIFF
--- a/CICD/k8s/back-deployment-blue.yaml
+++ b/CICD/k8s/back-deployment-blue.yaml
@@ -23,7 +23,9 @@ spec:
         prometheus.io/path: "/actuator/prometheus"
         prometheus.istio.io/merge-metrics: "true"
     spec:
-      terminationGracePeriodSeconds: 25
+      # graceful shutdown 강화 — Blue/Green 전환 시 1500+ SSE emitter complete() 시간 확보
+      # 부하 테스트 중 강제 종료로 인한 RecycleRequiredException 차단 목적
+      terminationGracePeriodSeconds: 90
       containers:
         - name: stockit-be
           image: sunyeoplee/stockit-backend:latest
@@ -34,6 +36,11 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod
+            # JVM heap 명시 — memory limit (4Gi) 의 75% 를 heap 으로 명시 (이전 25% 자동 할당의 한계 제거).
+            # G1GC + MaxGCPauseMillis 200ms 로 부하 시 GC pause 최소화 → heartbeat 지연 차단.
+            # HeapDumpOnOutOfMemoryError 로 OOM 진단 자료 확보.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx3000m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
             - name: DB_URL
               valueFrom:
                 configMapKeyRef:
@@ -117,12 +124,15 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
           lifecycle:
+            # preStop sleep 30 — Service selector 가 다른 pod 으로 옮겨갈 시간 확보.
+            # 30초 동안 새 요청은 다른 pod 으로 라우팅 → 현 pod 의 진행 중 SSE 정리 시간 보장.
+            # 이전 7초는 부하 시 SSE 1500 emitter graceful 정리에 부족.
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - -c
-                  - sleep 7
+                  - sleep 30
           startupProbe:
             httpGet:
               path: /actuator/health/readiness
@@ -132,9 +142,13 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 60
           resources:
+            # CPU 자원 — 운영 동기화 + 부하 대응 강화.
+            # 이전 git: cpu limit 500m → 운영에서 직접 cpu '2' 로 수정한 상태였음.
+            # 이번 PR 의 JVM heap 3GB 활용 + Tomcat thread max 200 + GC 병렬 처리 위해 cpu '2' 필수.
+            # 다음 Jenkins 배포 시 운영이 500m 으로 회귀하는 사고 방지 목적.
             requests:
-              cpu: 250m
-              memory: 1536Mi
+              cpu: '500m'
+              memory: 2Gi
             limits:
-              cpu: 500m
+              cpu: '2'
               memory: 4Gi

--- a/CICD/k8s/back-deployment-green.yaml
+++ b/CICD/k8s/back-deployment-green.yaml
@@ -23,7 +23,9 @@ spec:
         prometheus.io/path: "/actuator/prometheus"
         prometheus.istio.io/merge-metrics: "true"
     spec:
-      terminationGracePeriodSeconds: 25
+      # graceful shutdown 강화 — Blue/Green 전환 시 1500+ SSE emitter complete() 시간 확보
+      # 부하 테스트 중 강제 종료로 인한 RecycleRequiredException 차단 목적
+      terminationGracePeriodSeconds: 90
       containers:
         - name: stockit-be
           image: sunyeoplee/stockit-backend:latest
@@ -34,6 +36,11 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod
+            # JVM heap 명시 — memory limit (4Gi) 의 75% 를 heap 으로 명시 (이전 25% 자동 할당의 한계 제거).
+            # G1GC + MaxGCPauseMillis 200ms 로 부하 시 GC pause 최소화 → heartbeat 지연 차단.
+            # HeapDumpOnOutOfMemoryError 로 OOM 진단 자료 확보.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx3000m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
             - name: DB_URL
               valueFrom:
                 configMapKeyRef:
@@ -117,12 +124,15 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
           lifecycle:
+            # preStop sleep 30 — Service selector 가 다른 pod 으로 옮겨갈 시간 확보.
+            # 30초 동안 새 요청은 다른 pod 으로 라우팅 → 현 pod 의 진행 중 SSE 정리 시간 보장.
+            # 이전 7초는 부하 시 SSE 1500 emitter graceful 정리에 부족.
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - -c
-                  - sleep 7
+                  - sleep 30
           startupProbe:
             httpGet:
               path: /actuator/health/readiness
@@ -132,9 +142,13 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 60
           resources:
+            # CPU 자원 — 운영 동기화 + 부하 대응 강화.
+            # 이전 git: cpu limit 500m → 운영에서 직접 cpu '2' 로 수정한 상태였음.
+            # 이번 PR 의 JVM heap 3GB 활용 + Tomcat thread max 200 + GC 병렬 처리 위해 cpu '2' 필수.
+            # 다음 Jenkins 배포 시 운영이 500m 으로 회귀하는 사고 방지 목적.
             requests:
-              cpu: 250m
-              memory: 1536Mi
+              cpu: '500m'
+              memory: 2Gi
             limits:
-              cpu: 500m
+              cpu: '2'
               memory: 4Gi

--- a/src/main/java/org/example/stockitbe/notification/NotificationController.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationController.java
@@ -1,5 +1,6 @@
 package org.example.stockitbe.notification;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.notification.model.dto.NotificationDto;
@@ -18,7 +19,13 @@ public class NotificationController {
 
     // SSE 구독
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal AuthUserDetails me) {
+    public SseEmitter subscribe(@AuthenticationPrincipal AuthUserDetails me,
+                                 HttpServletResponse response) {
+        // SSE 실시간 전송 보장 — nginx/istio 등 프록시의 응답 버퍼링 비활성화.
+        // X-Accel-Buffering: no → ingress-nginx 가 chunked response 를 즉시 클라이언트로 흘려보냄.
+        // 없으면 nginx 가 데이터를 모아두려고 해서 heartbeat (:ping) 도달 지연 → 클라이언트 끊김 인식.
+        response.setHeader("X-Accel-Buffering", "no");
+        response.setHeader("Cache-Control", "no-cache");
         // 1. 요청 받기 2. 서비스 호출 3. text/event-stream 반환
         return service.subscribe(me);
     }


### PR DESCRIPTION
## 📌 요약
- 운영 부하 테스트 중 BE 의 RecycleRequiredException + SSE emitter cleanup 50+ 발생
- 1500명 본사 admin 알림 일시 끊김 현상 해결
- 4가지 변경: SSE 응답 헤더 + JVM heap 명시 + graceful shutdown + CPU 운영 동기화

## 🎯 작업 내용

### Controller — SSE 응답 헤더
- `NotificationController#subscribe` 에 `X-Accel-Buffering: no` + `Cache-Control: no-cache` 추가
- nginx ingress 가 SSE chunked response 를 즉시 전달 → heartbeat 지연 차단

### Deployment — JVM heap 명시
- `JAVA_TOOL_OPTIONS: -Xmx3000m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError`
- 자동 heap (1GB) → 명시 (3GB) 로 GC pause 최소화

### Deployment — graceful shutdown 강화
- `terminationGracePeriodSeconds: 25 → 90`
- `preStop sleep: 7 → 30` — Blue/Green 전환 시 SSE emitter complete() 시간 확보

### Deployment — CPU/Memory 자원 동기화
- `cpu limit: 500m → '2'` (운영에서 이미 '2' 로 사용 중, git 동기화)
- `cpu request: 250m → '500m'` (안정 스케줄링)
- `memory request: 1536Mi → 2Gi` (안정성 ↑)

## ✔️ 참고 사항
- 운영 변경 추적: managedFields 분석으로 2026-05-20 16:00 KST 에 k8s Dashboard 에서 cpu '2' 변경 확인됨
- 모든 변경은 비즈니스 로직 무관 — endpoint 동작 변경 없음
- 다른 기능에 영향 없음 (코드 검증 완료)
- mvp 브랜치 (EC2 모놀리식 baseline) 에는 별도 PR 로 Controller 변경만 적용 예정


<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
