### PR TITLE
fix: 수동 배치 API가 Spring Batch를 우회하던 문제 수정

### DIFF
--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
@@ -4,7 +4,16 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
+import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchScope;
+import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchTriggerType;
 import org.example.stockitbe.user.model.entity.AuthUserDetails;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/hq/store-orders/batch-approve")
@@ -20,14 +30,38 @@ import java.util.List;
 public class StoreOrderBatchApproveController {
 
     private final StoreOrderBatchApproveService batchApproveService;
+    private final JobLauncher jobLauncher;
+    private final Job storeOrderBatchApproveJob;
 
-    // 발주 승인 배치 처리
+    // 발주 승인 배치 처리 (Spring Batch Job으로 실행 → BATCH_JOB_EXECUTION 이력 자동 기록)
     @PostMapping("/run")
     public BaseResponse<StoreOrderBatchDto.RunRes> run(
             @AuthenticationPrincipal AuthUserDetails me,
             @Valid @RequestBody(required = false) StoreOrderBatchDto.RunReq req
     ) {
-        return BaseResponse.success(batchApproveService.runManual(req, me));
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("runAt", System.currentTimeMillis())
+                    .addString("triggerType", "MANUAL")
+                    .toJobParameters();
+            JobExecution jobExecution = jobLauncher.run(storeOrderBatchApproveJob, params);
+
+            // Tasklet이 ExecutionContext에 저장한 처리 결과를 HTTP 응답으로 반환
+            StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+            ExecutionContext ec = stepExecution.getExecutionContext();
+
+            return BaseResponse.success(StoreOrderBatchDto.RunRes.builder()
+                    .runId(ec.getString("runId", UUID.randomUUID().toString()))
+                    .triggerType(StoreOrderBatchTriggerType.MANUAL)
+                    .scope(StoreOrderBatchScope.ALL)
+                    .requestedCount(ec.getInt("requestedCount", 0))
+                    .successCount(ec.getInt("successCount", 0))
+                    .failCount(ec.getInt("failCount", 0))
+                    .results(List.of())
+                    .build());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // 승인 대기 발주건이 있는 매장 조회

--- a/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
@@ -10,6 +10,7 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,13 +44,34 @@ public class BatchConfig {
     }
 
     // Step이 실행할 실제 코드 조각
-    // RepeatStatus.FINISHED 반환 시 Step 완료로 처리됨
+    // triggerType 파라미터로 수동(MANUAL) / 자동(AUTO) 실행 경로를 분기
     @Bean
     public Tasklet storeOrderBatchApproveTasklet() {
         return (contribution, chunkContext) -> {
-            StoreOrderBatchDto.RunRes result = batchApproveService.runAutoDaily();
-            log.info("[STORE-ORDER-BATCH] job done runId={} requested={} success={} fail={}",
-                    result.getRunId(), result.getRequestedCount(), result.getSuccessCount(), result.getFailCount());
+            String triggerType = chunkContext.getStepContext()
+                    .getStepExecution().getJobParameters()
+                    .getString("triggerType", "AUTO");
+
+            StoreOrderBatchDto.RunRes result;
+            if ("MANUAL".equals(triggerType)) {
+                // 수동 실행: 날짜 필터 없이 전체 REQUESTED 처리
+                result = batchApproveService.runManual(null, null);
+            } else {
+                // 자동 실행(스케줄러): 전일 날짜 범위의 REQUESTED만 처리
+                result = batchApproveService.runAutoDaily();
+            }
+
+            // Controller가 HTTP 응답으로 반환할 수 있도록 ExecutionContext에 결과 저장
+            ExecutionContext ec = chunkContext.getStepContext()
+                    .getStepExecution().getExecutionContext();
+            ec.putString("runId", result.getRunId());
+            ec.putInt("requestedCount", result.getRequestedCount());
+            ec.putInt("successCount", result.getSuccessCount());
+            ec.putInt("failCount", result.getFailCount());
+
+            log.info("[STORE-ORDER-BATCH] job done trigger={} runId={} requested={} success={} fail={}",
+                    triggerType, result.getRunId(), result.getRequestedCount(),
+                    result.getSuccessCount(), result.getFailCount());
             return RepeatStatus.FINISHED;
         };
     }


### PR DESCRIPTION
문제 1 — Controller가 Spring Batch를 거치지 않음
POST /run 엔드포인트가 batchApproveService.runManual()을 직접 호출하고 있어 Spring Batch Job이 실행되지 않았고, BATCH_JOB_EXECUTION 이력이 기록되지 않았음

문제 2 — Tasklet이 수동/자동 실행을 구분하지 않음
Tasklet이 triggerType 구분 없이 runAutoDaily()만 호출하여
전일 날짜 범위로 필터링되는 문제 발생
수동 실행 시 오늘 데이터가 조회되지 않아 항상 0건 처리됨

변경 사항
- Controller: jobLauncher.run()으로 교체하여 Spring Batch Job을 통해 실행 처리 결과는 Tasklet이 ExecutionContext에 저장 후 Controller에서 읽어 반환
- Tasklet: triggerType JobParameter 읽어서 실행 경로 분기 MANUAL → runManual() (날짜 필터 없이 전체 REQUESTED 처리)
  AUTO   → runAutoDaily() (전일 날짜 범위 REQUESTED만 처리)

결과
수동 API 호출 시에도 BATCH_JOB_EXECUTION 이력이 정상 기록됨

## 📌 요약
- 위 오류를 고치고 테스트를 진행하였습니다.
- 자세한 내용은 연결된 이슈에서 확인

## ✔️ 관련 이슈

- Close #355

<br><br>
