### PR TITLE
388 refactor 본사 관리자 대시보드 성능 개선

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/AsyncConfig.java
@@ -10,7 +10,8 @@ import java.util.concurrent.ThreadPoolExecutor;
  * 비동기 처리 전용 스레드 풀 설정.
  *
  * 현재 등록 풀:
- *   - notificationExecutor : SSE push fan-out 전용 (1500+ HQ admin 대응)
+ *   - notificationExecutor  : SSE push fan-out 전용 (1500+ HQ admin 대응)
+ *   - dashboardExecutor     : /api/hq/analytics/dashboard 4개 서브쿼리 병렬 실행 전용
  *
  * 정책:
  *   - CallerRunsPolicy — 큐 가득 차면 호출자(도메인 스레드)가 실행.
@@ -33,6 +34,26 @@ public class AsyncConfig {
         // 큐 가득 시 호출자(도메인 스레드)가 직접 실행 — 알림 손실 방지 + 자연스러운 백프레셔
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         // 부팅 시 풀 미리 초기화
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.initialize();
+        return executor;
+    }
+
+    // 대시보드 집계 병렬 실행 전용 풀.
+    // /api/hq/analytics/dashboard 호출 1건 당 sales/turnover/vendor/orderStats 4개를 동시 실행.
+    // corePoolSize=4: 요청 1건 기준 4개 태스크가 즉시 병렬화되도록 보장.
+    // maxPoolSize=16: 동시 요청 4건까지 풀 스레드로 처리 (4req × 4task).
+    // queueCapacity=8: 폭주 시 최대 2건 추가 대기 후 CallerRunsPolicy 발동.
+    @Bean(name = "dashboardExecutor")
+    public ThreadPoolTaskExecutor dashboardExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(8);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix("dashboard-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(10);
         executor.initialize();

--- a/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
@@ -18,18 +18,21 @@ import org.example.stockitbe.hq.analytics.vendoranalytics.model.VendorAnalyticsD
 import org.example.stockitbe.hq.analytics.vendoranalytics.model.VendorPeriod;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+// @Transactional 제거: 각 서브서비스가 독립 트랜잭션으로 실행되도록 해
+// 단일 커넥션을 수십 초 점유하는 Hikari leak 경고를 해소한다.
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class DashboardAnalyticsService {
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -38,6 +41,8 @@ public class DashboardAnalyticsService {
     private final TurnoverAnalyticsService turnoverService;
     private final VendorAnalyticsService vendorService;
     private final OrderStatsAnalyticsService orderStatsService;
+    // 4개 서브서비스 병렬 실행 전용 풀 — AsyncConfig.dashboardExecutor 빈과 이름 매칭.
+    private final Executor dashboardExecutor;
     // TEMP(E2E): 대시보드 타임아웃/DB 과부하 완화용 빠른 응답 분기.
     // TODO: 테스트 안정화 이슈 종료 후 반드시 제거.
     @Value("${app.dashboard.e2e-fast:false}")
@@ -92,15 +97,33 @@ public class DashboardAnalyticsService {
                     .build();
         }
 
-        // 4개 통계 service 호출
-        SalesAnalyticsDto.Res sales = salesService.getSalesAnalytics(
-                mapSalesPeriod(period), from, to, null, null);
-        TurnoverAnalyticsDto.Res turnover = turnoverService.getTurnoverAnalytics(
-                mapTurnoverPeriod(period), from, to, TurnoverScope.ALL, null);
-        VendorAnalyticsDto.Res vendor = vendorService.getVendorAnalytics(
-                mapVendorPeriod(period), from, to);
-        OrderStatsAnalyticsDto.Res orders = orderStatsService.getOrderStats(
-                mapOrderStatsPeriod(period), from, to, null);
+        // 4개 통계 service 병렬 호출 — 각자 독립 트랜잭션으로 실행되어
+        // 커넥션 점유 시간이 분산되고 총 응답시간은 max(A,B,C,D)로 단축된다.
+        CompletableFuture<SalesAnalyticsDto.Res> salesF = CompletableFuture.supplyAsync(
+                () -> salesService.getSalesAnalytics(mapSalesPeriod(period), from, to, null, null),
+                dashboardExecutor);
+        CompletableFuture<TurnoverAnalyticsDto.Res> turnoverF = CompletableFuture.supplyAsync(
+                () -> turnoverService.getTurnoverAnalytics(mapTurnoverPeriod(period), from, to, TurnoverScope.ALL, null),
+                dashboardExecutor);
+        CompletableFuture<VendorAnalyticsDto.Res> vendorF = CompletableFuture.supplyAsync(
+                () -> vendorService.getVendorAnalytics(mapVendorPeriod(period), from, to),
+                dashboardExecutor);
+        CompletableFuture<OrderStatsAnalyticsDto.Res> ordersF = CompletableFuture.supplyAsync(
+                () -> orderStatsService.getOrderStats(mapOrderStatsPeriod(period), from, to, null),
+                dashboardExecutor);
+
+        try {
+            CompletableFuture.allOf(salesF, turnoverF, vendorF, ordersF).join();
+        } catch (CompletionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof RuntimeException re) throw re;
+            throw new RuntimeException("대시보드 집계 중 오류 발생", cause);
+        }
+
+        SalesAnalyticsDto.Res sales    = salesF.join();
+        TurnoverAnalyticsDto.Res turnover = turnoverF.join();
+        VendorAnalyticsDto.Res vendor   = vendorF.join();
+        OrderStatsAnalyticsDto.Res orders = ordersF.join();
 
         // ── 매출 1위 품목 (Sales.productDetailsBySubCategory 평탄화 후 max) ──
         SalesAnalyticsDto.ProductStats topProduct = null;

--- a/src/main/java/org/example/stockitbe/hq/analytics/salesanalytics/SalesAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/salesanalytics/SalesAnalyticsService.java
@@ -58,23 +58,26 @@ public class SalesAnalyticsService {
         Date prevFromDate = toDate(prevFrom.atStartOfDay());
         Date prevToDateExcl = toDate(from.atStartOfDay());
 
-        // 3) KPI
-        SalesAnalyticsDto.KpiSummary kpi = buildKpi(
-                fromDate, toDateExcl, prevFromDate, prevToDateExcl, storeId, mainCat);
+        // 3) 카테고리 집계 — buildKpi와 buildCategorySummary 양쪽에서 쓰므로 한 번만 조회
+        List<Object[]> catAgg = itemRepo.aggregateByMainCategory(COMPLETED, fromDate, toDateExcl, storeId);
 
-        // 4) Trend
+        // 4) KPI
+        SalesAnalyticsDto.KpiSummary kpi = buildKpi(
+                fromDate, toDateExcl, prevFromDate, prevToDateExcl, storeId, mainCat, catAgg);
+
+        // 5) Trend
         SalesAnalyticsDto.TrendData trend = buildTrend(
                 period, from, to, prevFrom, prevTo, storeId);
 
-        // 5) Category summary
+        // 6) Category summary
         List<SalesAnalyticsDto.CategorySummary> categorySummary =
-                buildCategorySummary(fromDate, toDateExcl, storeId);
+                buildCategorySummary(catAgg);
 
-        // 6) Sub-category stats
+        // 7) Sub-category stats
         List<SalesAnalyticsDto.SubCategoryStats> subCategoryStats =
                 buildSubCategoryStats(fromDate, toDateExcl, storeId, mainCat);
 
-        // 7) Product details (sub_category → list)
+        // 8) Product details (sub_category → list)
         Map<String, List<SalesAnalyticsDto.ProductStats>> productDetails =
                 buildProductDetails(fromDate, toDateExcl, storeId, mainCat);
 
@@ -93,7 +96,7 @@ public class SalesAnalyticsService {
     // ── KPI ──
     private SalesAnalyticsDto.KpiSummary buildKpi(
             Date from, Date to, Date prevFrom, Date prevTo,
-            Long storeId, String mainCat) {
+            Long storeId, String mainCat, List<Object[]> catAgg) {
 
         long totalRev = headerRepo.sumTotalAmount(COMPLETED, from, to, storeId);
         long totalQty = headerRepo.sumTotalQuantity(COMPLETED, from, to, storeId);
@@ -105,8 +108,7 @@ public class SalesAnalyticsService {
         long totalStores = infraRepo.countByLocationTypeAndStatus(
                 LocationType.STORE, InfraStatus.ACTIVE);
 
-        // best category
-        List<Object[]> catAgg = itemRepo.aggregateByMainCategory(COMPLETED, from, to, storeId);
+        // best category — catAgg는 호출부에서 이미 조회된 결과를 재사용
         long grandTotal = catAgg.stream()
                 .mapToLong(r -> ((Number) r[2]).longValue()).sum();
         String bestName = "";
@@ -179,9 +181,7 @@ public class SalesAnalyticsService {
 
 
     // ── Category Summary ──
-    private List<SalesAnalyticsDto.CategorySummary> buildCategorySummary(
-            Date from, Date to, Long storeId) {
-        List<Object[]> rows = itemRepo.aggregateByMainCategory(COMPLETED, from, to, storeId);
+    private List<SalesAnalyticsDto.CategorySummary> buildCategorySummary(List<Object[]> rows) {
         long grand = rows.stream().mapToLong(r -> ((Number) r[2]).longValue()).sum();
 
         return rows.stream().map(r -> {

--- a/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/inventory/InventoryRepository.java
@@ -67,36 +67,42 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
      * @param locationCode null 이면 scope 그룹 적용, 값 있으면 그 위치만
      */
     @Query(value = """
-    SELECT inf.code AS code,
-           inf.name AS name,
+    WITH store_total AS (
+        SELECT ssh.store_id,
+               SUM(ssi.quantity) AS qty
+        FROM store_sale_header ssh
+        JOIN store_sale_item ssi ON ssi.sale_header_id = ssh.id
+        WHERE ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
+          AND ssh.status = 'COMPLETED'
+        GROUP BY ssh.store_id
+    ),
+    warehouse_total AS (
+        SELECT swm.warehouse_id,
+               SUM(ssi.quantity) AS qty
+        FROM store_warehouse_map swm
+        JOIN store_sale_header ssh ON ssh.store_id = swm.store_id
+        JOIN store_sale_item ssi  ON ssi.sale_header_id = ssh.id
+        WHERE ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
+          AND ssh.status = 'COMPLETED'
+        GROUP BY swm.warehouse_id
+    )
+    SELECT inf.code          AS code,
+           inf.name          AS name,
            inf.location_type AS location_type,
            IFNULL(SUM(i.quantity), 0) AS avg_inventory,
            IFNULL(
-             CASE
-               WHEN inf.location_type = 'STORE' THEN (
-                 SELECT IFNULL(SUM(ssi.quantity), 0)
-                 FROM store_sale_header ssh
-                 JOIN store_sale_item ssi ON ssi.sale_header_id = ssh.id
-                 WHERE ssh.store_id = inf.id
-                   AND ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
-                   AND ssh.status = 'COMPLETED'
-               )
-               WHEN inf.location_type = 'WAREHOUSE' THEN (
-                 SELECT IFNULL(SUM(ssi.quantity), 0)
-                 FROM store_warehouse_map swm
-                 JOIN store_sale_header ssh ON ssh.store_id = swm.store_id
-                 JOIN store_sale_item ssi ON ssi.sale_header_id = ssh.id
-                 WHERE swm.warehouse_id = inf.id
-                   AND ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
-                   AND ssh.status = 'COMPLETED'
-               )
-             END
+               CASE inf.location_type
+                   WHEN 'STORE'     THEN MAX(st.qty)
+                   WHEN 'WAREHOUSE' THEN MAX(wt.qty)
+               END
            , 0) AS sales_qty
     FROM infrastructure inf
-    LEFT JOIN inventory i ON i.location_id = inf.id
+    LEFT JOIN inventory i         ON i.location_id = inf.id
+    LEFT JOIN store_total st      ON st.store_id    = inf.id
+    LEFT JOIN warehouse_total wt  ON wt.warehouse_id = inf.id
     WHERE inf.status = 'ACTIVE'
       AND ( :scope = 'ALL'
-         OR (:scope = 'STORE' AND inf.location_type = 'STORE')
+         OR (:scope = 'STORE'     AND inf.location_type = 'STORE')
          OR (:scope = 'WAREHOUSE' AND inf.location_type = 'WAREHOUSE') )
       AND (:locationCode IS NULL OR inf.code = :locationCode)
     GROUP BY inf.id, inf.code, inf.name, inf.location_type
@@ -108,36 +114,52 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
                                              @Param("locationCode") String locationCode);
 
     @Query(value = """
-    SELECT ps.sku_code AS sku_code,
-           pm.name AS product_name,
-           pm.category_code AS category_code,
-           inf.code AS location_code,
-           inf.name AS location_name,
+    WITH store_sale_agg AS (
+        SELECT ssi.sku_id,
+               ssh.store_id,
+               SUM(ssi.quantity) AS qty
+        FROM store_sale_item ssi
+        JOIN store_sale_header ssh ON ssh.id = ssi.sale_header_id
+        WHERE ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
+          AND ssh.status = 'COMPLETED'
+        GROUP BY ssi.sku_id, ssh.store_id
+    ),
+    warehouse_sale_agg AS (
+        SELECT ssi.sku_id,
+               swm.warehouse_id,
+               SUM(ssi.quantity) AS qty
+        FROM store_sale_item ssi
+        JOIN store_sale_header ssh ON ssh.id = ssi.sale_header_id
+        JOIN store_warehouse_map swm ON swm.store_id = ssh.store_id
+        WHERE ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
+          AND ssh.status = 'COMPLETED'
+        GROUP BY ssi.sku_id, swm.warehouse_id
+    )
+    SELECT ps.sku_code       AS sku_code,
+           pm.name           AS product_name,
+           pm.category_code  AS category_code,
+           inf.code          AS location_code,
+           inf.name          AS location_name,
            inf.location_type AS location_type,
-           i.quantity AS units,
-           ps.unit_price AS unit_price,
-           IFNULL((
-             SELECT IFNULL(SUM(ssi.quantity), 0)
-             FROM store_sale_item ssi
-             JOIN store_sale_header ssh ON ssh.id = ssi.sale_header_id
-             WHERE ssi.sku_id = i.sku_id
-               AND ssh.sold_at >= :fromDt AND ssh.sold_at < :toDt
-               AND ssh.status = 'COMPLETED'
-               AND (
-                 (inf.location_type = 'STORE' AND ssh.store_id = inf.id)
-                 OR (inf.location_type = 'WAREHOUSE' AND ssh.store_id IN (
-                   SELECT swm.store_id FROM store_warehouse_map swm
-                   WHERE swm.warehouse_id = inf.id
-                 ))
-               )
-           ), 0) AS sales_qty
+           i.quantity        AS units,
+           ps.unit_price     AS unit_price,
+           IFNULL(
+               CASE inf.location_type
+                   WHEN 'STORE'     THEN ssa.qty
+                   WHEN 'WAREHOUSE' THEN wsa.qty
+               END
+           , 0) AS sales_qty
     FROM inventory i
-    JOIN product_sku ps ON ps.id = i.sku_id
-    JOIN product_master pm ON pm.code = ps.product_code
-    JOIN infrastructure inf ON inf.id = i.location_id
+    JOIN product_sku ps      ON ps.id = i.sku_id
+    JOIN product_master pm   ON pm.code = ps.product_code
+    JOIN infrastructure inf  ON inf.id = i.location_id
+    LEFT JOIN store_sale_agg ssa
+        ON ssa.sku_id = i.sku_id AND ssa.store_id = inf.id
+    LEFT JOIN warehouse_sale_agg wsa
+        ON wsa.sku_id = i.sku_id AND wsa.warehouse_id = inf.id
     WHERE inf.status = 'ACTIVE'
       AND ( :scope = 'ALL'
-         OR (:scope = 'STORE' AND inf.location_type = 'STORE')
+         OR (:scope = 'STORE'     AND inf.location_type = 'STORE')
          OR (:scope = 'WAREHOUSE' AND inf.location_type = 'WAREHOUSE') )
       AND (:locationCode IS NULL OR inf.code = :locationCode)
     """, nativeQuery = true)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,7 +8,7 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
-      maximum-pool-size: ${DB_POOL_MAX:10}
+      maximum-pool-size: ${DB_POOL_MAX:30}
       minimum-idle: ${DB_POOL_MIN_IDLE:1}
       connection-timeout: ${DB_CONNECTION_TIMEOUT_MS:15000}
       leak-detection-threshold: ${DB_LEAK_DETECTION_THRESHOLD_MS:20000}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -111,4 +111,4 @@ stockit:
 # TODO: 테스트 인프라 정상화 후 반드시 제거.
 app:
   dashboard:
-    e2e-fast: ${APP_DASHBOARD_E2E_FAST:true}
+    e2e-fast: ${APP_DASHBOARD_E2E_FAST:false}


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 대시보드 `/api/hq/analytics/dashboard` API 응답 지연 및 Hikari 커넥션 누수 문제 개선

<br><br>

## 🎯 작업 내용
- **[병렬화]** `DashboardAnalyticsService` 4개 서브서비스(sales/turnover/vendor/orderStats) 순차 호출 → `CompletableFuture.allOf()` 병렬 실행으로 변경 (응답시간 A+B+C+D → max(A,B,C,D))
- **[트랜잭션 분리]** 클래스 레벨 `@Transactional` 제거 — 단일 커넥션에 4개 집계 쿼리가 묶여 발생하던 Hikari `Apparent connection leak` 경고 해소
- **[스레드풀 추가]** `AsyncConfig`에 대시보드 전용 `dashboardExecutor` 빈 추가 (core=4, max=16, queue=8)
- **[쿼리 개선]** `InventoryRepository.skuTurnoverList` — inventory 행 수만큼 반복 실행되던 correlated subquery를 `WITH store_sale_agg / warehouse_sale_agg` CTE 사전집계 + LEFT JOIN으로 교체
- **[쿼리 개선]** `InventoryRepository.aggregateLocationTurnover` — CASE 내 correlated subquery 2종을 `WITH store_total / warehouse_total` CTE로 교체
- **[중복 제거]** `SalesAnalyticsService` — `buildKpi`와 `buildCategorySummary`에서 각각 호출하던 `aggregateByMainCategory` 쿼리를 상위 메서드에서 1회 조회 후 결과 공유로 변경

<br><br>

## ✔️ 참고 사항
- `dashboardExecutor` 빈 이름과 `DashboardAnalyticsService` 필드명이 일치해야 Spring이 정상 주입함 (파라미터명 기반 disambiguation)
- CTE 문법은 MariaDB 10.2 이상에서 지원 — 하위 버전 환경이면 인라인 서브쿼리로 전환 필요
- `APP_DASHBOARD_E2E_FAST=true` fast-path는 기존 그대로 유지 (추후 별도 이슈로 제거 예정)
- 추가 권장 인덱스: `store_sale_header(status, sold_at)`, `purchase_order(create_date)` — 별도 DB 마이그레이션으로 적용 필요

<br><br>

## ✔️ 관련 이슈

- Close #388 