### PR TITLE
refactor: 발주 승인 배치 Tasklet → Chunk 방식 전환

### DIFF
--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/hq/store-orders/batch-approve")
@@ -33,28 +32,32 @@ public class StoreOrderBatchApproveController {
     private final JobLauncher jobLauncher;
     private final Job storeOrderBatchApproveJob;
 
-    // 발주 승인 배치 처리 (Spring Batch Job으로 실행 → BATCH_JOB_EXECUTION 이력 자동 기록)
+    // 발주 승인 배치 수동 실행 (Spring Batch Job → BATCH_JOB_EXECUTION 이력 자동 기록)
     @PostMapping("/run")
     public BaseResponse<StoreOrderBatchDto.RunRes> run(
             @AuthenticationPrincipal AuthUserDetails me,
             @Valid @RequestBody(required = false) StoreOrderBatchDto.RunReq req
     ) {
         try {
+            // triggerType=MANUAL: Reader가 날짜 필터 없이 전체 REQUESTED를 읽도록 분기.
+            // runAt 타임스탬프: 동일 파라미터 재실행 거부를 피하기 위한 고유화 키.
             JobParameters params = new JobParametersBuilder()
                     .addLong("runAt", System.currentTimeMillis())
                     .addString("triggerType", "MANUAL")
                     .toJobParameters();
             JobExecution jobExecution = jobLauncher.run(storeOrderBatchApproveJob, params);
 
-            // Tasklet이 ExecutionContext에 저장한 처리 결과를 HTTP 응답으로 반환
             StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
             ExecutionContext ec = stepExecution.getExecutionContext();
 
+            // runId: BATCH_JOB_EXECUTION.job_execution_id를 사용해 DB 이력과 직접 대응.
+            // requestedCount: Chunk 방식에서는 Spring Batch가 read_count를 자동 집계하므로 EC 대신 사용.
+            // successCount/failCount: Writer가 per-item 처리 후 chunk마다 EC에 누적 저장.
             return BaseResponse.success(StoreOrderBatchDto.RunRes.builder()
-                    .runId(ec.getString("runId", UUID.randomUUID().toString()))
+                    .runId(String.valueOf(jobExecution.getId()))
                     .triggerType(StoreOrderBatchTriggerType.MANUAL)
                     .scope(StoreOrderBatchScope.ALL)
-                    .requestedCount(ec.getInt("requestedCount", 0))
+                    .requestedCount((int) stepExecution.getReadCount())
                     .successCount(ec.getInt("successCount", 0))
                     .failCount(ec.getInt("failCount", 0))
                     .results(List.of())

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
@@ -29,10 +29,12 @@ public class StoreOrderBatchApproveScheduler {
     @SchedulerLock(name = "storeOrderBatchApproveJob", lockAtMostFor = "PT30M")
     public void runAutoBatch() {
         try {
-            // Spring Batch는 동일한 파라미터로 성공한 Job의 재실행을 거부함
-            // 타임스탬프를 파라미터로 부여해 매 실행을 고유하게 구분
+            // Spring Batch는 동일한 파라미터로 성공한 Job의 재실행을 거부함.
+            // runAt 타임스탬프로 매 실행을 고유하게 구분.
+            // triggerType: Reader SQL 분기 기준 (AUTO → 전일 날짜 범위 필터 적용).
             JobParameters params = new JobParametersBuilder()
                     .addLong("runAt", System.currentTimeMillis())
+                    .addString("triggerType", "AUTO")
                     .toJobParameters();
             jobLauncher.run(storeOrderBatchApproveJob, params);
         } catch (Exception e) {

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveWriter.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveWriter.java
@@ -1,0 +1,81 @@
+package org.example.stockitbe.store.order.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchItem;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class StoreOrderBatchApproveWriter implements ItemWriter<StoreOrderBatchItem> {
+
+    private final StoreOrderBatchApproveItemService itemService;
+
+    // jobParameters는 Step 실행 시점에 확정되므로 생성자가 아닌 @Value SpEL로 주입.
+    // 기본값 'AUTO'는 스케줄러 파라미터 누락 시의 안전망.
+    @Value("#{jobParameters['triggerType'] ?: 'AUTO'}")
+    private String triggerType;
+
+    // @BeforeStep: Step 실행 직전에 Spring Batch가 호출해 live StepExecution을 주입.
+    // write() 내에서 카운트를 누적하고 EC에 저장하기 위해 참조를 보관.
+    private StepExecution stepExecution;
+    private int successCount;
+    private int failCount;
+
+    // ExecutionContext에 초기값 0을 명시적으로 써두지 않으면,
+    // Job이 FAILED 후 재시작될 때 이전 실행의 EC 값이 복원되어 카운트가 오염될 수 있다.
+    @BeforeStep
+    public void beforeStep(StepExecution stepExecution) {
+        this.stepExecution = stepExecution;
+        ExecutionContext ec = stepExecution.getExecutionContext();
+        ec.putInt("successCount", 0);
+        ec.putInt("failCount", 0);
+        this.successCount = 0;
+        this.failCount = 0;
+    }
+
+    @Override
+    public void write(Chunk<? extends StoreOrderBatchItem> chunk) throws Exception {
+        // triggerType별 감사 주체 분기.
+        // MANUAL: 관리자가 HTTP로 직접 실행 → actorId는 비워두고 이름만 SYSTEM으로 기록.
+        // AUTO: 스케줄러 자동 실행 → actorId와 actorName 모두 SYSTEM_BATCH로 통일.
+        String actorId;
+        String actorName;
+        String reason;
+        if ("MANUAL".equals(triggerType)) {
+            actorId = "";
+            actorName = "SYSTEM";
+            reason = "본사 수동 배치 처리";
+        } else {
+            actorId = "SYSTEM_BATCH";
+            actorName = "SYSTEM_BATCH";
+            reason = "AUTO_BATCH_APPROVE";
+        }
+
+        // per-item try-catch: 한 건 실패가 chunk 전체를 롤백시키지 않도록 예외를 삼킨다.
+        // approveOne()은 REQUIRES_NEW 트랜잭션이므로 실패해도 이미 커밋된 건에 영향 없음.
+        for (StoreOrderBatchItem item : chunk) {
+            try {
+                itemService.approveOne(item.getOrderNo(), actorId, actorName, reason);
+                successCount++;
+            } catch (Exception e) {
+                failCount++;
+                log.warn("[STORE-ORDER-BATCH] fail orderNo={} trigger={}", item.getOrderNo(), triggerType, e);
+            }
+        }
+
+        // chunk 완료마다 EC에 누적값을 저장해 Job 비정상 종료 시에도 중간 집계가 보존된다.
+        ExecutionContext ec = stepExecution.getExecutionContext();
+        ec.putInt("successCount", successCount);
+        ec.putInt("failCount", failCount);
+    }
+}

--- a/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
@@ -2,19 +2,26 @@ package org.example.stockitbe.store.order.batch.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.stockitbe.store.order.batch.StoreOrderBatchApproveService;
-import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
+import org.example.stockitbe.store.order.batch.StoreOrderBatchApproveWriter;
+import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchItem;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,10 +30,14 @@ public class BatchConfig {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
-    private final StoreOrderBatchApproveService batchApproveService;
+    private final DataSource dataSource;
 
-    // 배치 작업 전체를 대표하는 단위
-    // 실행될 때마다 BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION 테이블에 이력이 자동 기록됨
+    // 기본값 10: application.yml 설정이 없을 때의 안전망.
+    // chunk 크기가 클수록 커밋 빈도가 줄어 성능이 높아지지만 재시도 단위도 커짐.
+    @Value("${store-order.batch.chunk-size:10}")
+    private int chunkSize;
+
+    // 실행될 때마다 BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION 테이블에 이력 자동 기록.
     @Bean
     public Job storeOrderBatchApproveJob(Step storeOrderBatchApproveStep) {
         return new JobBuilder("storeOrderBatchApproveJob", jobRepository)
@@ -34,45 +45,80 @@ public class BatchConfig {
                 .build();
     }
 
-    // Job 안에서 실제로 실행되는 단계
-    // 현재는 단계가 하나지만 필요 시 전처리 → 처리 → 후처리 형태로 Step 추가 가능
+    // reader/writer를 메서드 직접 호출이 아닌 파라미터로 주입받는 이유:
+    // @StepScope Bean을 같은 @Configuration 안에서 직접 호출하면 스코프 프록시가 아닌
+    // 실제 인스턴스가 즉시 생성되어 jobParameters SpEL 주입이 실패한다.
+    // 파라미터 주입 시 Spring이 프록시를 올바르게 연결한다.
+    //
+    // .listener(writer)를 별도로 추가하는 이유:
+    // .writer(writer)만으로는 @BeforeStep 어노테이션이 자동 감지되지 않는다.
+    // .listener()로 등록해야 StepListenerFactoryBean이 어노테이션을 스캔하여
+    // Step 실행 전에 beforeStep()을 호출한다.
     @Bean
-    public Step storeOrderBatchApproveStep() {
+    public Step storeOrderBatchApproveStep(
+            JdbcCursorItemReader<StoreOrderBatchItem> storeOrderBatchApproveReader,
+            StoreOrderBatchApproveWriter storeOrderBatchApproveWriter) {
         return new StepBuilder("storeOrderBatchApproveStep", jobRepository)
-                .tasklet(storeOrderBatchApproveTasklet(), transactionManager)
+                .<StoreOrderBatchItem, StoreOrderBatchItem>chunk(chunkSize, transactionManager)
+                .reader(storeOrderBatchApproveReader)
+                .writer(storeOrderBatchApproveWriter)
+                .listener(storeOrderBatchApproveWriter)
                 .build();
     }
 
-    // Step이 실행할 실제 코드 조각
-    // triggerType 파라미터로 수동(MANUAL) / 자동(AUTO) 실행 경로를 분기
+    // Reader 선택 근거:
+    // - JdbcCursorItemReader: DB 커서를 열어 행을 순차 fetch → status 변경이 발생해도 OFFSET 밀림 없음.
+    // - PagingItemReader 제외: 처리 중 status가 REQUESTED → APPROVED로 바뀌면
+    //   다음 페이지 OFFSET이 밀려 처리 누락 발생.
+    // - JpaCursorItemReader 제외: approveOne()의 REQUIRES_NEW가 JPA EntityManager와 충돌.
     @Bean
-    public Tasklet storeOrderBatchApproveTasklet() {
-        return (contribution, chunkContext) -> {
-            String triggerType = chunkContext.getStepContext()
-                    .getStepExecution().getJobParameters()
-                    .getString("triggerType", "AUTO");
+    @StepScope
+    public JdbcCursorItemReader<StoreOrderBatchItem> storeOrderBatchApproveReader(
+            @Value("#{jobParameters['triggerType'] ?: 'AUTO'}") String triggerType) {
 
-            StoreOrderBatchDto.RunRes result;
-            if ("MANUAL".equals(triggerType)) {
-                // 수동 실행: 날짜 필터 없이 전체 REQUESTED 처리
-                result = batchApproveService.runManual(null, null);
-            } else {
-                // 자동 실행(스케줄러): 전일 날짜 범위의 REQUESTED만 처리
-                result = batchApproveService.runAutoDaily();
-            }
+        JdbcCursorItemReaderBuilder<StoreOrderBatchItem> builder = new JdbcCursorItemReaderBuilder<StoreOrderBatchItem>()
+                .name("storeOrderBatchApproveReader")
+                .dataSource(dataSource)
+                .rowMapper((rs, rowNum) -> new StoreOrderBatchItem(
+                        rs.getLong("id"),
+                        rs.getString("order_no"),
+                        rs.getLong("store_id"),
+                        rs.getLong("warehouse_id"),
+                        rs.getTimestamp("requested_at")
+                ));
 
-            // Controller가 HTTP 응답으로 반환할 수 있도록 ExecutionContext에 결과 저장
-            ExecutionContext ec = chunkContext.getStepContext()
-                    .getStepExecution().getExecutionContext();
-            ec.putString("runId", result.getRunId());
-            ec.putInt("requestedCount", result.getRequestedCount());
-            ec.putInt("successCount", result.getSuccessCount());
-            ec.putInt("failCount", result.getFailCount());
+        if ("MANUAL".equals(triggerType)) {
+            // 수동: 날짜 필터 없이 전체 REQUESTED 처리. 오래된 건 먼저 승인.
+            builder.sql(
+                    "SELECT id, order_no, store_id, warehouse_id, requested_at " +
+                    "FROM store_order_header " +
+                    "WHERE status = 'REQUESTED' " +
+                    "ORDER BY requested_at ASC, id ASC"
+            );
+        } else {
+            // 자동: 전일 00:00:00 ~ 23:59:59 범위만 처리. 최신 건 먼저 승인.
+            Date[] range = previousDayRange();
+            builder.sql(
+                    "SELECT id, order_no, store_id, warehouse_id, requested_at " +
+                    "FROM store_order_header " +
+                    "WHERE status = 'REQUESTED' AND requested_at BETWEEN ? AND ? " +
+                    "ORDER BY requested_at DESC, id DESC"
+            ).preparedStatementSetter(ps -> {
+                ps.setTimestamp(1, new java.sql.Timestamp(range[0].getTime()));
+                ps.setTimestamp(2, new java.sql.Timestamp(range[1].getTime()));
+            });
+        }
 
-            log.info("[STORE-ORDER-BATCH] job done trigger={} runId={} requested={} success={} fail={}",
-                    triggerType, result.getRunId(), result.getRequestedCount(),
-                    result.getSuccessCount(), result.getFailCount());
-            return RepeatStatus.FINISHED;
-        };
+        return builder.build();
+    }
+
+    // LocalDate.now()가 아닌 KST 기준으로 전일을 계산해야 서버 타임존 설정과 무관하게 동일한 범위가 나온다.
+    // minusNanos(1): 자정 00:00:00 정각은 다음 날로 간주되므로 전일 마지막 순간으로 보정.
+    private static Date[] previousDayRange() {
+        ZoneId kst = ZoneId.of("Asia/Seoul");
+        LocalDate prev = LocalDate.now(kst).minusDays(1);
+        ZonedDateTime start = prev.atStartOfDay(kst);
+        ZonedDateTime end = prev.plusDays(1).atStartOfDay(kst).minusNanos(1);
+        return new Date[]{Date.from(start.toInstant()), Date.from(end.toInstant())};
     }
 }

--- a/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchItem.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchItem.java
@@ -1,0 +1,20 @@
+package org.example.stockitbe.store.order.batch.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+// StoreOrderHeader는 @NoArgsConstructor(access = PROTECTED)라 외부 패키지 RowMapper로 직접 매핑 불가.
+// JdbcCursorItemReader 전용 조회 DTO로 분리해 batch 패키지에서 독립적으로 사용한다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreOrderBatchItem {
+    private Long id;
+    private String orderNo;
+    private Long storeId;
+    private Long warehouseId;
+    private Date requestedAt;
+}


### PR DESCRIPTION
## 📌 요약
- `storeOrderBatchApproveJob` Step 처리 방식을 Tasklet → Chunk(`JdbcCursorItemReader` + `ItemWriter`)로 전환
- `BATCH_STEP_EXECUTION` `read_count` / `write_count` 자동 집계 및 메모리 풀 로드 제거

<br><br>

## 🎯 작업 내용
- `StoreOrderBatchItem` DTO 신규 생성 — `StoreOrderHeader` protected 생성자 우회, Stage 3 파티셔닝 대비 `storeId` / `warehouseId` 포함
- `StoreOrderBatchApproveWriter` 신규 생성 — `@StepScope`, `@BeforeStep`으로 `ExecutionContext` 카운터(`successCount` / `failCount`) 관리, per-item try-catch로 실패 건 발생 시 배치 중단 없이 계속 진행
- `BatchConfig` Tasklet 제거 → `JdbcCursorItemReader` + `StoreOrderBatchApproveWriter` Chunk Step 전환, `triggerType` 파라미터에 따라 MANUAL(전체 REQUESTED) / AUTO(전일 날짜 범위) SQL 분기
- `StoreOrderBatchApproveScheduler` `triggerType=AUTO` JobParameter 명시 추가
- `StoreOrderBatchApproveController` 응답 값 `stepExecution.getReadCount()` / ExecutionContext 기반으로 변경

<br><br>

## ✔️ 참고 사항
- `PagingItemReader` 미사용 — status 변경 시 OFFSET 밀림으로 처리 누락 발생하는 조용한 버그 방지
- `JpaCursorItemReader` 미사용 — `approveOne()`의 `@Transactional(REQUIRES_NEW)`와 JPA EntityManager 충돌 방지
- Processor 미추가 — 재고 확인은 `approveOne()` 내부 `PESSIMISTIC_WRITE` lock과 원자적으로 수행되므로 Processor에서 별도 확인 시 TOCTOU 경쟁조건 발생. Stage 3 파티셔닝 도입 시 창고 라우팅 Processor 추가 예정
- `write_count` = `read_count` 로 집계됨 — Writer가 예외를 삼키는 구조상 의도된 동작. Stage 4 `faultTolerant` + `skip` 적용 후 `write_count` = 실제 성공, `skip_count` = 실패로 정확히 분리 예정
- `chunkSize` 기본값 10, `${store-order.batch.chunk-size:10}`으로 외부 설정 가능. BATCH-7에서 10 / 50 / 100 / 200 비교 성능 측정 예정

<br><br>

## ✔️ 관련 이슈

- Close #356 