### PR TITLE
refactor: [BATCH-6] JobParameter로 날짜 범위 외부 주입

### DIFF
--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
@@ -2,7 +2,12 @@ package org.example.stockitbe.store.order.batch;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.stockitbe.common.exception.BaseException;
 import org.example.stockitbe.common.model.BaseResponse;
+import org.example.stockitbe.common.model.BaseResponseStatus;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
+import org.example.stockitbe.hq.infrastructure.model.LocationType;
 import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
 import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchScope;
 import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchTriggerType;
@@ -22,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/hq/store-orders/batch-approve")
@@ -31,32 +37,50 @@ public class StoreOrderBatchApproveController {
     private final StoreOrderBatchApproveService batchApproveService;
     private final JobLauncher jobLauncher;
     private final Job storeOrderBatchApproveJob;
+    private final InfrastructureRepository infrastructureRepository;
 
     // 발주 승인 배치 수동 실행 (Spring Batch Job → BATCH_JOB_EXECUTION 이력 자동 기록)
     @PostMapping("/run")
     public BaseResponse<StoreOrderBatchDto.RunRes> run(
             @AuthenticationPrincipal AuthUserDetails me,
-            @Valid @RequestBody(required = false) StoreOrderBatchDto.RunReq req
+            @Valid @RequestBody StoreOrderBatchDto.RunReq req
     ) {
         try {
-            // triggerType=MANUAL: Reader가 날짜 필터 없이 전체 REQUESTED를 읽도록 분기.
-            // runAt 타임스탬프: 동일 파라미터 재실행 거부를 피하기 위한 고유화 키.
-            JobParameters params = new JobParametersBuilder()
-                    .addLong("runAt", System.currentTimeMillis())
-                    .addString("triggerType", "MANUAL")
-                    .toJobParameters();
+            // runId: JobParameter에 포함해 동일 요청 재실행을 구분하는 고유 키.
+            // MIDNIGHT 스케줄러는 날짜가 고유 키 역할을 하므로 runId가 불필요하지만,
+            // 수동 실행은 같은 날 여러 번 호출될 수 있어 UUID로 고유화한다.
+            String runId = UUID.randomUUID().toString();
+
+            JobParametersBuilder builder = new JobParametersBuilder()
+                    .addString("runType", "MANUAL")
+                    .addString("runId", runId)
+                    .addLocalDateTime("fromDateTime", req.getFromDateTime())
+                    .addLocalDateTime("toDateTime", req.getToDateTime());
+
+            // mode=STORE일 때만 storeCode → storeId 변환 후 파라미터에 추가.
+            // Reader는 storeId=0을 "전체 매장" sentinel로 해석하므로 미전달 시 전체 처리.
+            if (req.getMode() == StoreOrderBatchScope.STORE) {
+                Long storeId = infrastructureRepository
+                        .findByCodeAndLocationType(req.getStoreCode(), LocationType.STORE)
+                        .map(Infrastructure::getId)
+                        .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
+                builder.addLong("storeId", storeId);
+            }
+
+            JobParameters params = builder.toJobParameters();
             JobExecution jobExecution = jobLauncher.run(storeOrderBatchApproveJob, params);
 
             StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
             ExecutionContext ec = stepExecution.getExecutionContext();
 
             // runId: BATCH_JOB_EXECUTION.job_execution_id를 사용해 DB 이력과 직접 대응.
-            // requestedCount: Chunk 방식에서는 Spring Batch가 read_count를 자동 집계하므로 EC 대신 사용.
+            // requestedCount: Chunk 방식에서 Spring Batch가 read_count를 자동 집계.
             // successCount/failCount: Writer가 per-item 처리 후 chunk마다 EC에 누적 저장.
             return BaseResponse.success(StoreOrderBatchDto.RunRes.builder()
                     .runId(String.valueOf(jobExecution.getId()))
                     .triggerType(StoreOrderBatchTriggerType.MANUAL)
-                    .scope(StoreOrderBatchScope.ALL)
+                    .scope(req.getMode())
+                    .storeCode(req.getStoreCode())
                     .requestedCount((int) stepExecution.getReadCount())
                     .successCount(ec.getInt("successCount", 0))
                     .failCount(ec.getInt("failCount", 0))

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveController.java
@@ -37,6 +37,8 @@ public class StoreOrderBatchApproveController {
     private final StoreOrderBatchApproveService batchApproveService;
     private final JobLauncher jobLauncher;
     private final Job storeOrderBatchApproveJob;
+    // storeCode → storeId 변환에 사용. BATCH-6에서 Service의 runManual()이 제거되면서
+    // 동일 변환 로직을 Controller가 Repository를 직접 참조해 수행한다.
     private final InfrastructureRepository infrastructureRepository;
 
     // 발주 승인 배치 수동 실행 (Spring Batch Job → BATCH_JOB_EXECUTION 이력 자동 기록)

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveScheduler.java
@@ -10,6 +10,10 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -29,12 +33,18 @@ public class StoreOrderBatchApproveScheduler {
     @SchedulerLock(name = "storeOrderBatchApproveJob", lockAtMostFor = "PT30M")
     public void runAutoBatch() {
         try {
-            // Spring Batch는 동일한 파라미터로 성공한 Job의 재실행을 거부함.
-            // runAt 타임스탬프로 매 실행을 고유하게 구분.
-            // triggerType: Reader SQL 분기 기준 (AUTO → 전일 날짜 범위 필터 적용).
+            // KST 기준 전일 범위를 계산해 Reader에 전달한다.
+            // fromDateTime/toDateTime이 JobParameter에 포함되어 날짜가 달라지면
+            // 실행 인스턴스가 자동으로 구분되므로 runAt 타임스탬프가 불필요하다.
+            ZoneId kst = ZoneId.of("Asia/Seoul");
+            LocalDate prevDay = LocalDate.now(kst).minusDays(1);
+            LocalDateTime from = prevDay.atStartOfDay();
+            LocalDateTime to   = prevDay.plusDays(1).atStartOfDay().minusNanos(1);
+
             JobParameters params = new JobParametersBuilder()
-                    .addLong("runAt", System.currentTimeMillis())
-                    .addString("triggerType", "AUTO")
+                    .addString("runType", "MIDNIGHT")
+                    .addLocalDateTime("fromDateTime", from)
+                    .addLocalDateTime("toDateTime", to)
                     .toJobParameters();
             jobLauncher.run(storeOrderBatchApproveJob, params);
         } catch (Exception e) {

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveService.java
@@ -24,7 +24,9 @@ public class StoreOrderBatchApproveService {
     private final StoreOrderHeaderRepository headerRepository;
     private final InfrastructureRepository infrastructureRepository;
 
-    // 승인 대기 발주건이 있는 매장 조회
+    // 승인 대기 발주건이 있는 매장 조회.
+    // 두 단계로 분리하는 이유: countPendingByStore()가 storeId와 건수만 반환하므로
+    // 매장명·지역 등 상세 정보는 storeId 목록으로 Infrastructure를 IN 쿼리 한 번에 조회해 N+1을 방지한다.
     @Transactional(readOnly = true)
     public List<StoreOrderBatchDto.PendingStoreRes> listPendingStores() {
         List<StoreOrderHeaderRepository.PendingStoreProjection> rows =

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveService.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveService.java
@@ -2,168 +2,27 @@ package org.example.stockitbe.store.order.batch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.stockitbe.common.exception.BaseException;
-import org.example.stockitbe.common.model.BaseResponseStatus;
 import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
 import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
-import org.example.stockitbe.hq.infrastructure.model.LocationType;
-import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchScope;
-import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchTriggerType;
 import org.example.stockitbe.store.order.batch.model.dto.StoreOrderBatchDto;
 import org.example.stockitbe.store.order.model.enums.StoreOrderStatus;
-import org.example.stockitbe.store.order.model.entity.StoreOrderHeader;
 import org.example.stockitbe.store.order.repository.StoreOrderHeaderRepository;
-import org.example.stockitbe.user.model.entity.AuthUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class StoreOrderBatchApproveService {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private final StoreOrderHeaderRepository headerRepository;
     private final InfrastructureRepository infrastructureRepository;
-    private final StoreOrderBatchApproveItemService batchApproveItemService;
-
-    // 발주 수동 배치
-    public StoreOrderBatchDto.RunRes runManual(StoreOrderBatchDto.RunReq req, AuthUserDetails me) {
-        StoreOrderBatchScope scope = req == null || req.getMode() == null ? StoreOrderBatchScope.ALL : req.getMode();
-        String runId = UUID.randomUUID().toString();
-        String actorId = me == null ? "" : me.getEmployeeCode();
-        String actorName = me == null ? "SYSTEM" : me.getName();
-
-        List<StoreOrderHeader> targets = switch (scope) {
-            case ALL -> headerRepository.findAllByStatusOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED);
-            case STORE -> {
-                String storeCode = trimToNull(req == null ? null : req.getStoreCode());
-                if (storeCode == null) throw BaseException.from(BaseResponseStatus.STORE_ORDER_BATCH_STORE_CODE_REQUIRED);
-                Long storeId = infrastructureRepository.findByCodeAndLocationType(storeCode, LocationType.STORE)
-                        .map(Infrastructure::getId)
-                        .orElseThrow(() -> BaseException.from(BaseResponseStatus.STORE_ORDER_STORE_NOT_FOUND));
-                yield headerRepository.findAllByStatusAndStoreIdOrderByRequestedAtAscIdAsc(StoreOrderStatus.REQUESTED, storeId);
-            }
-            default -> throw BaseException.from(BaseResponseStatus.STORE_ORDER_BATCH_SCOPE_INVALID);
-        };
-
-        log.info("[STORE-ORDER-BATCH] start runId={} trigger=MANUAL scope={} storeCode={} requested={}",
-                runId, scope, req == null ? null : req.getStoreCode(), targets.size());
-
-        List<StoreOrderBatchDto.ItemRes> itemResults = new ArrayList<>();
-        int success = 0;
-        for (StoreOrderHeader header : targets) {
-            try {
-                batchApproveItemService.approveOne(
-                        header.getOrderNo(),
-                        actorId,
-                        actorName,
-                        "본사 수동 배치 처리"
-                );
-                success++;
-                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
-                        .orderNo(header.getOrderNo())
-                        .result("SUCCESS")
-                        .code(BaseResponseStatus.SUCCESS.getCode())
-                        .message("APPROVED")
-                        .build());
-            } catch (Exception e) {
-                BaseResponseStatus status = extractStatus(e);
-                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
-                        .orderNo(header.getOrderNo())
-                        .result("FAIL")
-                        .code(status.getCode())
-                        .message(status.getMessage())
-                        .build());
-                log.warn("[STORE-ORDER-BATCH] fail runId={} orderNo={} code={} msg={}",
-                        runId, header.getOrderNo(), status.getCode(), status.getMessage(), e);
-            }
-        }
-
-        int fail = targets.size() - success;
-        log.info("[STORE-ORDER-BATCH] end runId={} trigger=MANUAL scope={} success={} fail={}",
-                runId, scope, success, fail);
-
-        return StoreOrderBatchDto.RunRes.builder()
-                .runId(runId)
-                .triggerType(StoreOrderBatchTriggerType.MANUAL)
-                .scope(scope)
-                .storeCode(req == null ? null : req.getStoreCode())
-                .requestedCount(targets.size())
-                .successCount(success)
-                .failCount(fail)
-                .results(itemResults)
-                .build();
-    }
-
-    // 발주 자동 배치
-    public StoreOrderBatchDto.RunRes runAutoDaily() {
-        String runId = UUID.randomUUID().toString();
-        Date[] range = previousDayRange();
-
-        List<StoreOrderHeader> targets = headerRepository.findAllByStatusAndRequestedAtBetweenOrderByRequestedAtDescIdDesc(
-                StoreOrderStatus.REQUESTED, range[0], range[1]
-        );
-
-        log.info("[STORE-ORDER-BATCH] start runId={} trigger=AUTO from={} to={} requested={}",
-                runId, range[0], range[1], targets.size());
-
-        List<StoreOrderBatchDto.ItemRes> itemResults = new ArrayList<>();
-        int success = 0;
-        for (StoreOrderHeader header : targets) {
-            try {
-                batchApproveItemService.approveOne(
-                        header.getOrderNo(),
-                        "SYSTEM_BATCH",
-                        "SYSTEM_BATCH",
-                        "AUTO_BATCH_APPROVE"
-                );
-                success++;
-                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
-                        .orderNo(header.getOrderNo())
-                        .result("SUCCESS")
-                        .code(BaseResponseStatus.SUCCESS.getCode())
-                        .message("APPROVED")
-                        .build());
-            } catch (Exception e) {
-                BaseResponseStatus status = extractStatus(e);
-                itemResults.add(StoreOrderBatchDto.ItemRes.builder()
-                        .orderNo(header.getOrderNo())
-                        .result("FAIL")
-                        .code(status.getCode())
-                        .message(status.getMessage())
-                        .build());
-                log.warn("[STORE-ORDER-BATCH] fail runId={} orderNo={} code={} msg={}",
-                        runId, header.getOrderNo(), status.getCode(), status.getMessage(), e);
-            }
-        }
-
-        int fail = targets.size() - success;
-        log.info("[STORE-ORDER-BATCH] end runId={} trigger=AUTO success={} fail={}", runId, success, fail);
-
-        return StoreOrderBatchDto.RunRes.builder()
-                .runId(runId)
-                .triggerType(StoreOrderBatchTriggerType.AUTO)
-                .scope(StoreOrderBatchScope.ALL)
-                .storeCode(null)
-                .requestedCount(targets.size())
-                .successCount(success)
-                .failCount(fail)
-                .results(itemResults)
-                .build();
-    }
 
     // 승인 대기 발주건이 있는 매장 조회
     @Transactional(readOnly = true)
@@ -193,29 +52,5 @@ public class StoreOrderBatchApproveService {
         result.sort(Comparator.comparing(StoreOrderBatchDto.PendingStoreRes::getRequestedCount).reversed()
                 .thenComparing(StoreOrderBatchDto.PendingStoreRes::getStoreName));
         return result;
-    }
-
-    // ---------------------------- 내부 메서드 --------------------------------
-
-    private BaseResponseStatus extractStatus(Exception e) {
-        Throwable cur = e;
-        while (cur != null) {
-            if (cur instanceof BaseException be && be.getStatus() != null) return be.getStatus();
-            cur = cur.getCause();
-        }
-        return BaseResponseStatus.FAIL;
-    }
-
-    private Date[] previousDayRange() {
-        LocalDate prev = LocalDate.now(KST).minusDays(1);
-        ZonedDateTime start = prev.atStartOfDay(KST);
-        ZonedDateTime end = prev.plusDays(1).atStartOfDay(KST).minusNanos(1);
-        return new Date[]{Date.from(start.toInstant()), Date.from(end.toInstant())};
-    }
-
-    private String trimToNull(String value) {
-        if (value == null) return null;
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveWriter.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/StoreOrderBatchApproveWriter.java
@@ -21,9 +21,9 @@ public class StoreOrderBatchApproveWriter implements ItemWriter<StoreOrderBatchI
     private final StoreOrderBatchApproveItemService itemService;
 
     // jobParameters는 Step 실행 시점에 확정되므로 생성자가 아닌 @Value SpEL로 주입.
-    // 기본값 'AUTO'는 스케줄러 파라미터 누락 시의 안전망.
-    @Value("#{jobParameters['triggerType'] ?: 'AUTO'}")
-    private String triggerType;
+    // 기본값 'MIDNIGHT'은 runType 파라미터 누락 시의 안전망.
+    @Value("#{jobParameters['runType'] ?: 'MIDNIGHT'}")
+    private String runType;
 
     // @BeforeStep: Step 실행 직전에 Spring Batch가 호출해 live StepExecution을 주입.
     // write() 내에서 카운트를 누적하고 EC에 저장하기 위해 참조를 보관.
@@ -45,20 +45,20 @@ public class StoreOrderBatchApproveWriter implements ItemWriter<StoreOrderBatchI
 
     @Override
     public void write(Chunk<? extends StoreOrderBatchItem> chunk) throws Exception {
-        // triggerType별 감사 주체 분기.
+        // runType별 감사 주체 분기.
         // MANUAL: 관리자가 HTTP로 직접 실행 → actorId는 비워두고 이름만 SYSTEM으로 기록.
-        // AUTO: 스케줄러 자동 실행 → actorId와 actorName 모두 SYSTEM_BATCH로 통일.
+        // MIDNIGHT: 스케줄러 자동 실행 → actorId와 actorName 모두 SYSTEM_BATCH로 통일.
         String actorId;
         String actorName;
         String reason;
-        if ("MANUAL".equals(triggerType)) {
+        if ("MANUAL".equals(runType)) {
             actorId = "";
             actorName = "SYSTEM";
             reason = "본사 수동 배치 처리";
         } else {
             actorId = "SYSTEM_BATCH";
             actorName = "SYSTEM_BATCH";
-            reason = "AUTO_BATCH_APPROVE";
+            reason = "MIDNIGHT_BATCH_APPROVE";
         }
 
         // per-item try-catch: 한 건 실패가 chunk 전체를 롤백시키지 않도록 예외를 삼킨다.
@@ -69,7 +69,7 @@ public class StoreOrderBatchApproveWriter implements ItemWriter<StoreOrderBatchI
                 successCount++;
             } catch (Exception e) {
                 failCount++;
-                log.warn("[STORE-ORDER-BATCH] fail orderNo={} trigger={}", item.getOrderNo(), triggerType, e);
+                log.warn("[STORE-ORDER-BATCH] fail orderNo={} runType={}", item.getOrderNo(), runType, e);
             }
         }
 

--- a/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
@@ -79,6 +79,8 @@ public class BatchConfig {
             @Value("#{jobParameters['toDateTime']}")   LocalDateTime toDateTime,
             @Value("#{jobParameters['storeId'] ?: 0L}") Long storeId) {
 
+        // storeId > 0이면 STORE 모드(매장별 필터), 0이면 ALL 모드(전체 매장).
+        // PreparedStatement 파라미터 인덱스가 SQL 절 수에 따라 달라지므로 SQL과 setter를 함께 구성한다.
         String sql =
                 "SELECT id, order_no, store_id, warehouse_id, requested_at " +
                 "FROM store_order_header " +
@@ -93,6 +95,7 @@ public class BatchConfig {
                 .preparedStatementSetter(ps -> {
                     ps.setTimestamp(1, Timestamp.valueOf(fromDateTime));
                     ps.setTimestamp(2, Timestamp.valueOf(toDateTime));
+                    // storeId 조건이 SQL에 포함된 경우에만 3번 인덱스를 바인딩한다.
                     if (storeId > 0) {
                         ps.setLong(3, storeId);
                     }

--- a/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/config/BatchConfig.java
@@ -18,10 +18,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Date;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Configuration
 @RequiredArgsConstructor
@@ -71,54 +69,41 @@ public class BatchConfig {
     // - PagingItemReader 제외: 처리 중 status가 REQUESTED → APPROVED로 바뀌면
     //   다음 페이지 OFFSET이 밀려 처리 누락 발생.
     // - JpaCursorItemReader 제외: approveOne()의 REQUIRES_NEW가 JPA EntityManager와 충돌.
+    //
+    // 날짜 범위와 storeId는 모두 호출자(Controller/Scheduler)가 JobParameter로 전달.
+    // storeId=0은 "전체 매장" 의미의 sentinel. STORE 모드일 때만 실제 storeId가 전달됨.
     @Bean
     @StepScope
     public JdbcCursorItemReader<StoreOrderBatchItem> storeOrderBatchApproveReader(
-            @Value("#{jobParameters['triggerType'] ?: 'AUTO'}") String triggerType) {
+            @Value("#{jobParameters['fromDateTime']}") LocalDateTime fromDateTime,
+            @Value("#{jobParameters['toDateTime']}")   LocalDateTime toDateTime,
+            @Value("#{jobParameters['storeId'] ?: 0L}") Long storeId) {
 
-        JdbcCursorItemReaderBuilder<StoreOrderBatchItem> builder = new JdbcCursorItemReaderBuilder<StoreOrderBatchItem>()
+        String sql =
+                "SELECT id, order_no, store_id, warehouse_id, requested_at " +
+                "FROM store_order_header " +
+                "WHERE status = 'REQUESTED' AND requested_at BETWEEN ? AND ?" +
+                (storeId > 0 ? " AND store_id = ?" : "") +
+                " ORDER BY requested_at ASC, id ASC";
+
+        return new JdbcCursorItemReaderBuilder<StoreOrderBatchItem>()
                 .name("storeOrderBatchApproveReader")
                 .dataSource(dataSource)
+                .sql(sql)
+                .preparedStatementSetter(ps -> {
+                    ps.setTimestamp(1, Timestamp.valueOf(fromDateTime));
+                    ps.setTimestamp(2, Timestamp.valueOf(toDateTime));
+                    if (storeId > 0) {
+                        ps.setLong(3, storeId);
+                    }
+                })
                 .rowMapper((rs, rowNum) -> new StoreOrderBatchItem(
                         rs.getLong("id"),
                         rs.getString("order_no"),
                         rs.getLong("store_id"),
                         rs.getLong("warehouse_id"),
                         rs.getTimestamp("requested_at")
-                ));
-
-        if ("MANUAL".equals(triggerType)) {
-            // 수동: 날짜 필터 없이 전체 REQUESTED 처리. 오래된 건 먼저 승인.
-            builder.sql(
-                    "SELECT id, order_no, store_id, warehouse_id, requested_at " +
-                    "FROM store_order_header " +
-                    "WHERE status = 'REQUESTED' " +
-                    "ORDER BY requested_at ASC, id ASC"
-            );
-        } else {
-            // 자동: 전일 00:00:00 ~ 23:59:59 범위만 처리. 최신 건 먼저 승인.
-            Date[] range = previousDayRange();
-            builder.sql(
-                    "SELECT id, order_no, store_id, warehouse_id, requested_at " +
-                    "FROM store_order_header " +
-                    "WHERE status = 'REQUESTED' AND requested_at BETWEEN ? AND ? " +
-                    "ORDER BY requested_at DESC, id DESC"
-            ).preparedStatementSetter(ps -> {
-                ps.setTimestamp(1, new java.sql.Timestamp(range[0].getTime()));
-                ps.setTimestamp(2, new java.sql.Timestamp(range[1].getTime()));
-            });
-        }
-
-        return builder.build();
-    }
-
-    // LocalDate.now()가 아닌 KST 기준으로 전일을 계산해야 서버 타임존 설정과 무관하게 동일한 범위가 나온다.
-    // minusNanos(1): 자정 00:00:00 정각은 다음 날로 간주되므로 전일 마지막 순간으로 보정.
-    private static Date[] previousDayRange() {
-        ZoneId kst = ZoneId.of("Asia/Seoul");
-        LocalDate prev = LocalDate.now(kst).minusDays(1);
-        ZonedDateTime start = prev.atStartOfDay(kst);
-        ZonedDateTime end = prev.plusDays(1).atStartOfDay(kst).minusNanos(1);
-        return new Date[]{Date.from(start.toInstant()), Date.from(end.toInstant())};
+                ))
+                .build();
     }
 }

--- a/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchDto.java
@@ -1,6 +1,7 @@
 package org.example.stockitbe.store.order.batch.model.dto;
 
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchScope;
 import org.example.stockitbe.store.order.batch.model.enums.StoreOrderBatchTriggerType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class StoreOrderBatchDto {
@@ -20,6 +22,12 @@ public class StoreOrderBatchDto {
     public static class RunReq {
         private StoreOrderBatchScope mode;
         private String storeCode;
+
+        @NotNull
+        private LocalDateTime fromDateTime;
+
+        @NotNull
+        private LocalDateTime toDateTime;
 
         @AssertTrue(message = "mode=STORE requires storeCode")
         public boolean isStoreCodeValidForMode() {

--- a/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchDto.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/model/dto/StoreOrderBatchDto.java
@@ -23,12 +23,16 @@ public class StoreOrderBatchDto {
         private StoreOrderBatchScope mode;
         private String storeCode;
 
+        // Reader SQL의 BETWEEN 절에 직접 전달되는 처리 대상 기간.
+        // 호출자(Controller/Scheduler)가 범위를 결정해 전달하므로 BatchConfig 내부에서 날짜를 계산하지 않는다.
         @NotNull
         private LocalDateTime fromDateTime;
 
         @NotNull
         private LocalDateTime toDateTime;
 
+        // Bean Validation으로는 두 필드 조합 검증이 불가능하므로 @AssertTrue로 보완.
+        // isXxx() 네이밍 규칙을 따라야 Bean Validation이 getter로 인식한다.
         @AssertTrue(message = "mode=STORE requires storeCode")
         public boolean isStoreCodeValidForMode() {
             if (mode != StoreOrderBatchScope.STORE) return true;

--- a/src/main/java/org/example/stockitbe/store/order/batch/model/enums/StoreOrderBatchTriggerType.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/model/enums/StoreOrderBatchTriggerType.java
@@ -1,6 +1,6 @@
 package org.example.stockitbe.store.order.batch.model.enums;
 
 public enum StoreOrderBatchTriggerType {
-    AUTO,
+    MIDNIGHT,
     MANUAL
 }

--- a/src/main/java/org/example/stockitbe/store/order/batch/model/enums/StoreOrderBatchTriggerType.java
+++ b/src/main/java/org/example/stockitbe/store/order/batch/model/enums/StoreOrderBatchTriggerType.java
@@ -1,6 +1,8 @@
 package org.example.stockitbe.store.order.batch.model.enums;
 
 public enum StoreOrderBatchTriggerType {
+    // 매일 자정 스케줄러가 전일 발주를 일괄 승인
     MIDNIGHT,
+    // 본사 관리자가 HTTP API를 통해 직접 실행
     MANUAL
 }


### PR DESCRIPTION
## 📌 요약
- BATCH-5에서 묵시적으로 깨진 mode=STORE(매장별 수동 배치 필터링)를 복원
- JobParameter 구조를 runType(MANUAL/MIDNIGHT) 기반으로 재정의하고 runAt 제거
- Reader SQL을 단일 쿼리로 통합하여 MANUAL/AUTO 분기 제거


## 🎯 작업 내용
- StoreOrderBatchTriggerType.AUTO → MIDNIGHT rename
- RunReq에 fromDateTime/toDateTime 추가, mode=STORE 시 storeCode→storeId 변환 후 JobParameter 주입
- BatchConfig Reader: triggerType 분기 제거, 항상 날짜 범위 필터 + storeId 조건 동적 추가
- Scheduler: addLocalDateTime() 기반 KST 전일 범위 계산, runAt 제거
- Controller: UUID runId 추가, runAt 제거, InfrastructureRepository로 storeCode→storeId 변환
- StoreOrderBatchApproveService: runManual() · runAutoDaily() dead code 제거


## ✔️ 참고 사항
- Chunk 방식(JdbcCursorItemReader, @StepScope, per-item REQUIRES_NEW)은 BATCH-5 구조 그대로 유지
- MIDNIGHT 스케줄러는 runId 없이 날짜 파라미터만으로 고유성 보장 → 동일 날짜 재실행 방지
- storeId=0 은 Reader에서 "전체 매장" sentinel로 해석 (mode=ALL 시 파라미터 미전달)
- @RequestBody(required = false) → required = true 변경 필요 (fromDateTime 필수화에 따른 후속 수정)


## ✔️ 관련 이슈
- Close #357 