### PR TITLE
fix: employee_code_sequence 와 user 테이블 동기화 안전망 추가

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/account/AccountService.java
+++ b/src/main/java/org/example/stockitbe/hq/account/AccountService.java
@@ -113,6 +113,16 @@ public class AccountService {
                 .findByRoleCodeForUpdate(prefix)
                 .orElseThrow(() -> BaseException.from(BaseResponseStatus.EMPLOYEE_CODE_SEQUENCE_NOT_FOUND));
         int nextNumber = seq.incrementAndGet();
+
+        // 안전망: 트랜잭션 롤백 누적·시드 불일치·DB 마이그레이션 등으로 sequence 가
+        //         user 테이블 max 보다 뒤처졌을 때 자동 보정 → Duplicate entry 사고 차단.
+        //         비관적 락 안이므로 다른 트랜잭션과 충돌 없음.
+        int userMax = userRepository.findMaxEmployeeCodeNumber(prefix);
+        if (nextNumber <= userMax) {
+            nextNumber = userMax + 1;
+            seq.setLastNumber(nextNumber);
+        }
+
         return String.format("%s%04d", prefix, nextNumber);
     }
 

--- a/src/main/java/org/example/stockitbe/hq/account/EmployeeCodeSequenceInitializer.java
+++ b/src/main/java/org/example/stockitbe/hq/account/EmployeeCodeSequenceInitializer.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.stockitbe.hq.account.model.entity.EmployeeCodeSequence;
 import org.example.stockitbe.hq.account.repository.EmployeeCodeSequenceRepository;
+import org.example.stockitbe.user.UserRepository;
 import org.example.stockitbe.user.model.entity.UserRole;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -14,6 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
  * 사원코드 시퀀스 시드 자동 초기화.
  * BE 부팅 시 1회 실행, 멱등 처리(이미 있으면 skip).
  * 신규 환경 배포·신입 팀원 git pull 모두 자동 대응.
+ *
+ * 초기값 산정:
+ *   user 테이블에 이미 같은 prefix 의 사번이 있으면 그 MAX 로 초기화.
+ *   → 부트스트랩 admin (예: hq0001) 이나 시드 데이터가 먼저 들어와 있어도
+ *     첫 승인이 Duplicate entry 로 실패하는 사고를 사전 차단.
  */
 @Slf4j
 @Component
@@ -21,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmployeeCodeSequenceInitializer implements ApplicationRunner {
 
     private final EmployeeCodeSequenceRepository sequenceRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional
@@ -30,8 +37,10 @@ public class EmployeeCodeSequenceInitializer implements ApplicationRunner {
             if (sequenceRepository.existsById(prefix)) {
                 continue;
             }
-            sequenceRepository.save(EmployeeCodeSequence.of(prefix, 0));
-            log.info("[Seed] employee_code_sequence 초기화: role={}, last_number=0", prefix);
+            // user 테이블의 실제 MAX 로 초기화 — 0 으로 하드코딩하던 기존 버그 수정.
+            int initialNumber = userRepository.findMaxEmployeeCodeNumber(prefix);
+            sequenceRepository.save(EmployeeCodeSequence.of(prefix, initialNumber));
+            log.info("[Seed] employee_code_sequence 초기화: role={}, last_number={}", prefix, initialNumber);
         }
     }
 }

--- a/src/main/java/org/example/stockitbe/hq/account/model/entity/EmployeeCodeSequence.java
+++ b/src/main/java/org/example/stockitbe/hq/account/model/entity/EmployeeCodeSequence.java
@@ -23,6 +23,15 @@ public class EmployeeCodeSequence {
         return ++this.lastNumber;
     }
 
+    /**
+     * 시퀀스 값을 명시적으로 설정 — 안전망 보정 전용.
+     * (AccountService.generateEmployeeCode 에서 user 테이블 max 와 동기화 시 사용)
+     * 비관적 락 + @Transactional 안에서만 호출되어야 함.
+     */
+    public void setLastNumber(int lastNumber) {
+        this.lastNumber = lastNumber;
+    }
+
     public static EmployeeCodeSequence of(String roleCode, int initialNumber) {
         EmployeeCodeSequence seq = new EmployeeCodeSequence();
         seq.roleCode = roleCode;

--- a/src/main/java/org/example/stockitbe/user/UserRepository.java
+++ b/src/main/java/org/example/stockitbe/user/UserRepository.java
@@ -3,6 +3,8 @@ package org.example.stockitbe.user;
 import org.example.stockitbe.user.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,6 +14,16 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     boolean existsByEmail(String email);
     Optional<User> findTopByEmployeeCodeStartingWithOrderByEmployeeCodeDesc(String prefix);
 
-
+    /**
+     * 특정 prefix 의 사원코드 중 가장 큰 숫자 부분을 반환 (없으면 0).
+     * employee_code_sequence 와 user 테이블 데이터가 어긋났을 때 보정/초기화용 안전망.
+     * 예) prefix="hq" + user 에 hq0001, hq0002 → 2 반환.
+     */
+    @Query(value = """
+        SELECT COALESCE(MAX(CAST(SUBSTRING(employee_code, 3) AS UNSIGNED)), 0)
+        FROM user
+        WHERE employee_code REGEXP CONCAT('^', :prefix, '[0-9]+$')
+        """, nativeQuery = true)
+    int findMaxEmployeeCodeNumber(@Param("prefix") String prefix);
 
 }


### PR DESCRIPTION
## 📌 요약
- 본사 관리자 승인 시 발생하던 `Duplicate entry 'hq0001'` 500 에러 재발 방지

<br><br>

## 🎯 작업 내용
- `EmployeeCodeSequenceInitializer`: 시퀀스 초기값을 0 하드코딩 → user 테이블 MAX 기반으로 변경
- `AccountService.generateEmployeeCode`: 시퀀스가 user MAX 보다 뒤처진 경우 자동 보정 안전망 추가
- `UserRepository.findMaxEmployeeCodeNumber(prefix)`: 신규 네이티브 쿼리 메서드
- `EmployeeCodeSequence.setLastNumber`: 보정용 setter 추가

<br><br>

## ✔️ 참고 사항
- 운영 DB 의 시퀀스가 0 으로 갇혀있던 사고는 별도 SQL 로 즉시 복구 완료 (UPDATE employee_code_sequence SET last_number = user_max)
- 이번 PR 은 재발 방지가 목적: 신규 환경 배포 / DB 마이그레이션 / 트랜잭션 롤백 누적 시 자동 보정
- 비관적 락(SELECT FOR UPDATE) 안에서 보정하므로 동시성 안전
- 시그니처 변경 없음 → 기존 호출 모두 정상
- 로컬 검증: dev profile 부팅 OK (이미 시퀀스 row 존재로 Initializer skip, 정상 동작)


<br><br>

## ✔️ 관련 이슈

- Close #398 

<br><br>
