### PR TITLE
397 refactor 순환재고 판매 내역상세조회 디자인 개편 관련 백 리팩토링

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -182,6 +182,8 @@ public class CircularSaleService {
                     .saleNo(header.getSaleNo())
                     .status(header.getStatus())
                     .outboundNo(outbound == null ? null : outbound.getOutboundNo())
+                    .outboundWarehouseCode(outbound == null ? null : outbound.getWarehouseCode())
+                    .outboundWarehouseName(outbound == null ? null : outbound.getWarehouseName())
                     .outboundStatus(outbound == null ? null : outbound.getStatus())
                     .soldAt(header.getSoldAt())
                     .completedAt(header.getCompletedAt())

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -166,6 +166,12 @@ public class CircularSaleService {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet())
         ).stream().collect(Collectors.toMap(WhOutboundHeader::getId, Function.identity()));
+        Map<Long, Infrastructure> warehouseById = infrastructureRepository.findAllById(
+                outboundById.values().stream()
+                        .map(WhOutboundHeader::getWarehouseId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet())
+        ).stream().collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
 
         Map<Long, List<CircularSaleItem>> itemsByHeader = saleItemRepository.findAllBySaleHeaderIdIn(
                 headers.getContent().stream().map(CircularSaleHeader::getId).toList()
@@ -176,14 +182,15 @@ public class CircularSaleService {
         for (CircularSaleHeader header : headers.getContent()) {
             CircularBuyer buyer = buyerById.get(header.getBuyerId());
             WhOutboundHeader outbound = outboundById.get(header.getOutboundHeaderId());
+            Infrastructure outboundWarehouse = outbound == null ? null : warehouseById.get(outbound.getWarehouseId());
             List<CircularSaleItem> items = itemsByHeader.getOrDefault(header.getId(), List.of());
             rows.add(CircularSaleDto.ListRowRes.builder()
                     .saleId(header.getId())
                     .saleNo(header.getSaleNo())
                     .status(header.getStatus())
                     .outboundNo(outbound == null ? null : outbound.getOutboundNo())
-                    .outboundWarehouseCode(outbound == null ? null : outbound.getWarehouseCode())
-                    .outboundWarehouseName(outbound == null ? null : outbound.getWarehouseName())
+                    .outboundWarehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                    .outboundWarehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
                     .outboundStatus(outbound == null ? null : outbound.getStatus())
                     .soldAt(header.getSoldAt())
                     .completedAt(header.getCompletedAt())

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -20,6 +20,8 @@ import org.example.stockitbe.hq.circularsale.repository.CircularSaleHeaderReposi
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleItemMaterialRepository;
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleItemRepository;
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleStatusHistoryRepository;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.inventory.InventoryRepository;
 import org.example.stockitbe.hq.inventory.InventoryService;
 import org.example.stockitbe.hq.inventory.model.Inventory;
@@ -79,6 +81,7 @@ public class CircularSaleService {
     private final CircularSaleItemRepository saleItemRepository;
     private final CircularSaleItemMaterialRepository saleItemMaterialRepository;
     private final CircularSaleStatusHistoryRepository saleStatusHistoryRepository;
+    private final InfrastructureRepository infrastructureRepository;
     private final CircularBuyerRepository circularBuyerRepository;
     // Phase 3: 실제 판매 시 ESG 점수 가산용 거래 row 를 함께 INSERT 하기 위한 Repository
     private final CircularBuyerTransactionRepository transactionRepository;
@@ -103,6 +106,12 @@ public class CircularSaleService {
         // 3) 라인별 SKU/재고/소재 스냅샷 컨텍스트 구성 + 단일 창고 검증
         List<LineContext> contexts = buildLineContexts(request.getItems(), request.getMaterialType(), categoryLookup);
         Long warehouseId = resolveSingleWarehouse(contexts);
+        for (LineContext context : contexts) {
+            context.availableQuantitySnapshot = Math.max(
+                    0,
+                    context.inventory.getAvailableQuantity() == null ? 0 : context.inventory.getAvailableQuantity()
+            );
+        }
 
         // 4) 재고를 즉시 차감하지 않고 예약 수량으로 선반영
         applyInventoryReservations(contexts);
@@ -211,8 +220,37 @@ public class CircularSaleService {
                         CircularSaleItemMaterial::getSaleItemId,
                         Collectors.mapping(CircularSaleDto.MaterialRes::from, Collectors.toList())
                 ));
+        Infrastructure outboundWarehouse = header.getWarehouseId() == null ? null
+                : infrastructureRepository.findById(header.getWarehouseId()).orElse(null);
+
         List<CircularSaleDto.LineRes> lines = items.stream()
-                .map(item -> CircularSaleDto.LineRes.from(item, materialsByItem.getOrDefault(item.getId(), List.of())))
+                .map(item -> {
+                    CircularSaleDto.LineRes base = CircularSaleDto.LineRes.from(item, materialsByItem.getOrDefault(item.getId(), List.of()));
+                    return CircularSaleDto.LineRes.builder()
+                            .itemId(base.getItemId())
+                            .inventoryId(base.getInventoryId())
+                            .skuCode(base.getSkuCode())
+                            .productCode(base.getProductCode())
+                            .productName(base.getProductName())
+                            .mainCategory(base.getMainCategory())
+                            .subCategory(base.getSubCategory())
+                            .color(base.getColor())
+                            .size(base.getSize())
+                            .materialType(base.getMaterialType())
+                            .requestedWeightKg(base.getRequestedWeightKg())
+                            .actualWeightKg(base.getActualWeightKg())
+                            .estimatedQuantity(base.getEstimatedQuantity())
+                            .soldQuantity(base.getSoldQuantity())
+                            .availableQuantity(base.getAvailableQuantity())
+                            .availableWeightKg(base.getAvailableWeightKg())
+                            .warehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                            .warehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
+                            .unitPrice(base.getUnitPrice())
+                            .lineAmount(base.getLineAmount())
+                            .memo(base.getMemo())
+                            .materials(base.getMaterials())
+                            .build();
+                })
                 .toList();
 
         // 3) 상태 이력 조회
@@ -233,6 +271,8 @@ public class CircularSaleService {
                 .soldByMemberId(header.getSoldByMemberId())
                 .soldByName(header.getSoldByName())
                 .outboundHeaderId(header.getOutboundHeaderId())
+                .outboundWarehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                .outboundWarehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
                 .buyerCode(buyer.getCode())
                 .buyerName(buyer.getCompanyName())
                 .buyerIndustryGroup(buyer.getIndustryGroup())
@@ -501,6 +541,8 @@ public class CircularSaleService {
         List<CircularSaleItem> items = new ArrayList<>();
         for (LineContext context : contexts) {
             CircularSaleDto.CreateLineReq reqLine = context.request;
+            int stockQuantitySnapshot = Math.max(0, context.availableQuantitySnapshot == null ? 0 : context.availableQuantitySnapshot);
+            BigDecimal stockWeightKgSnapshot = estimateSnapshotWeightKg(reqLine, stockQuantitySnapshot);
             items.add(CircularSaleItem.builder()
                     .saleHeaderId(header.getId())
                     .inventoryId(reqLine.getInventoryId())
@@ -517,6 +559,8 @@ public class CircularSaleService {
                     .actualWeightKg(scale3(reqLine.getActualWeightKg() == null ? reqLine.getRequestedWeightKg() : reqLine.getActualWeightKg()))
                     .estimatedQuantity(scale3(reqLine.getEstimatedQuantity() == null ? BigDecimal.valueOf(reqLine.getSoldQuantity()) : reqLine.getEstimatedQuantity()))
                     .soldQuantity(reqLine.getSoldQuantity())
+                    .stockQuantitySnapshot(stockQuantitySnapshot)
+                    .stockWeightKgSnapshot(stockWeightKgSnapshot)
                     .unitPrice(reqLine.getUnitPrice())
                     .lineAmount(reqLine.getLineAmount())
                     .memo(reqLine.getMemo())
@@ -811,6 +855,17 @@ public class CircularSaleService {
         return value.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
     }
 
+    private BigDecimal estimateSnapshotWeightKg(CircularSaleDto.CreateLineReq reqLine, int stockQuantitySnapshot) {
+        if (stockQuantitySnapshot <= 0) return BigDecimal.ZERO.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        BigDecimal soldQty = BigDecimal.valueOf(Math.max(1, reqLine.getSoldQuantity() == null ? 0 : reqLine.getSoldQuantity()));
+        BigDecimal baseWeight = reqLine.getActualWeightKg() == null ? reqLine.getRequestedWeightKg() : reqLine.getActualWeightKg();
+        if (baseWeight == null || baseWeight.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        }
+        BigDecimal unitWeight = baseWeight.divide(soldQty, DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        return unitWeight.multiply(BigDecimal.valueOf(stockQuantitySnapshot)).setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+    }
+
     private Integer sumInt(Collection<LineContext> contexts, Function<LineContext, Integer> extractor) {
         int sum = 0;
         for (LineContext context : contexts) {
@@ -841,6 +896,7 @@ public class CircularSaleService {
         private ProductSku sku;
         private ProductMaster master;
         private Inventory inventory;
+        private Integer availableQuantitySnapshot;
         private String mainCategory;
         private String subCategory;
         private String materialType;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
@@ -234,6 +234,8 @@ public class CircularSaleDto {
         private String saleNo;
         private CircularSaleStatus status;
         private String outboundNo;
+        private String outboundWarehouseCode;
+        private String outboundWarehouseName;
         private OutboundStatus outboundStatus;
         private Date soldAt;
         private Date completedAt;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
@@ -136,6 +136,10 @@ public class CircularSaleDto {
         private BigDecimal actualWeightKg;
         private BigDecimal estimatedQuantity;
         private Integer soldQuantity;
+        private Integer availableQuantity;
+        private BigDecimal availableWeightKg;
+        private String warehouseCode;
+        private String warehouseName;
         private Long unitPrice;
         private Long lineAmount;
         private String memo;
@@ -157,6 +161,10 @@ public class CircularSaleDto {
                     .actualWeightKg(item.getActualWeightKg())
                     .estimatedQuantity(item.getEstimatedQuantity())
                     .soldQuantity(item.getSoldQuantity())
+                    .availableQuantity(item.getStockQuantitySnapshot())
+                    .availableWeightKg(item.getStockWeightKgSnapshot())
+                    .warehouseCode(null)
+                    .warehouseName(null)
                     .unitPrice(item.getUnitPrice())
                     .lineAmount(item.getLineAmount())
                     .memo(item.getMemo())
@@ -257,6 +265,8 @@ public class CircularSaleDto {
         private String soldByMemberId;
         private String soldByName;
         private Long outboundHeaderId;
+        private String outboundWarehouseCode;
+        private String outboundWarehouseName;
         private String buyerCode;
         private String buyerName;
         private String buyerIndustryGroup;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/entity/CircularSaleItem.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/entity/CircularSaleItem.java
@@ -72,6 +72,12 @@ public class CircularSaleItem extends BaseEntity {
     @Column(name = "sold_quantity", nullable = false)
     private Integer soldQuantity;
 
+    @Column(name = "stock_quantity_snapshot", nullable = false)
+    private Integer stockQuantitySnapshot;
+
+    @Column(name = "stock_weight_kg_snapshot", nullable = false, precision = 14, scale = 3, columnDefinition = "DECIMAL(14,3)")
+    private BigDecimal stockWeightKgSnapshot;
+
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
@@ -85,7 +91,8 @@ public class CircularSaleItem extends BaseEntity {
     private CircularSaleItem(Long saleHeaderId, Long inventoryId, Long skuId, String skuCode, String productCode,
                              String productName, String mainCategory, String subCategory, String color, String size,
                              String materialType, BigDecimal requestedWeightKg, BigDecimal actualWeightKg,
-                             BigDecimal estimatedQuantity, Integer soldQuantity, Long unitPrice, Long lineAmount,
+                             BigDecimal estimatedQuantity, Integer soldQuantity, Integer stockQuantitySnapshot,
+                             BigDecimal stockWeightKgSnapshot, Long unitPrice, Long lineAmount,
                              String memo) {
         this.saleHeaderId = saleHeaderId;
         this.inventoryId = inventoryId;
@@ -102,6 +109,8 @@ public class CircularSaleItem extends BaseEntity {
         this.actualWeightKg = actualWeightKg == null ? BigDecimal.ZERO : actualWeightKg;
         this.estimatedQuantity = estimatedQuantity == null ? BigDecimal.ZERO : estimatedQuantity;
         this.soldQuantity = soldQuantity == null ? 0 : soldQuantity;
+        this.stockQuantitySnapshot = stockQuantitySnapshot == null ? 0 : stockQuantitySnapshot;
+        this.stockWeightKgSnapshot = stockWeightKgSnapshot == null ? BigDecimal.ZERO : stockWeightKgSnapshot;
         this.unitPrice = unitPrice == null ? 0L : unitPrice;
         this.lineAmount = lineAmount == null ? 0L : lineAmount;
         this.memo = memo;


### PR DESCRIPTION
## 📌 요약
- 순환 재고 판매 목록/상세 API 응답에 화면 표시에 필요한 창고/재고 필드를 보강하고, 필드 매핑 정합성을 맞췄습니다.

<br><br>

## 🎯 작업 내용
- 판매 목록 응답 확장
  - `CircularSaleDto.ListRowRes`에 `outboundWarehouseCode`, `outboundWarehouseName` 추가
  - `CircularSaleService.list()`에서 `WhOutboundHeader.warehouseId` 기반으로 `Infrastructure` 조회 후 코드/명 매핑
- 판매 상세 응답 보강
  - 상세 헤더에 `outboundWarehouseCode`, `outboundWarehouseName` 제공
  - 상세 라인에 `availableQuantity`, `availableWeightKg` 포함(스냅샷 값 매핑)
- 판매 아이템 스냅샷 저장 구조 반영
  - 판매 라인 엔티티/DTO/서비스에서 재고 스냅샷 필드 흐름 연결
  - FE 상세 재고 컬럼과 일치하도록 응답 필드명 통일

<br><br>

## ✔️ 참고 사항
- 컴파일 에러 이슈 대응:
  - `WhOutboundHeader`에는 `getWarehouseCode()/getWarehouseName()`가 없어 직접 호출 불가
  - `warehouseId`로 `Infrastructure`를 조회해 코드/명을 매핑하도록 수정
- 페이징 자체는 기존 목록 API에 이미 구현되어 있어, 이번 백엔드 변경의 핵심은 응답 필드 확장/정합성입니다.

<br><br>

## ✔️ 관련 이슈

- Close #397 

<br><br>