### PR TITLE
feat(analytics): 소재 매출 순위를 판매량(kg) 기준으로 전환

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
@@ -83,7 +83,6 @@ public class DashboardAnalyticsService {
                     .topVendorName("-")
                     .topVendorAmount(BigDecimal.ZERO)
                     .topMaterialName("-")
-                    .topMaterialAmount(BigDecimal.ZERO)
                     .topMaterialWeight(0L)
                     .topMaterialType("-")
                     .build();
@@ -186,9 +185,8 @@ public class DashboardAnalyticsService {
                 // 카드 4 (Vendor)
                 .topVendorName(vendor.getKpi().getTopVendorName())
                 .topVendorAmount(vendor.getKpi().getTopVendorAmount())
-                // 카드 5 (Vendor 소재)
+                // 카드 5 (Vendor 소재) — 매출(원) 기준 → 판매량(kg) 기준 전환
                 .topMaterialName(vendor.getKpi().getTopMaterialName())
-                .topMaterialAmount(vendor.getKpi().getTopMaterialAmount())
                 .topMaterialWeight(topMat == null ? 0L : topMat.getUnits())
                 .topMaterialType(topMat == null ? "" : topMat.getMaterialType())
                 .build();

--- a/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/model/DashboardAnalyticsDto.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/model/DashboardAnalyticsDto.java
@@ -77,9 +77,9 @@ public class DashboardAnalyticsDto {
         private String topVendorName;
         private BigDecimal topVendorAmount;
 
-        // 카드 5 (Vendor 점프): TOP 소재
+        // 카드 5 (Vendor 점프): TOP 소재 — 매출(원) 기준 → 판매량(kg) 기준 전환으로
+        //                                topMaterialAmount(BigDecimal) 폐기, topMaterialWeight 만 유지.
         private String topMaterialName;
-        private BigDecimal topMaterialAmount;
         private Long topMaterialWeight;
         private String topMaterialType;
     }

--- a/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/VendorAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/VendorAnalyticsService.java
@@ -41,10 +41,11 @@ public class VendorAnalyticsService {
         String topVendorName = topV != null ? (String) topV[0] : "";
         long   topVendorAmt  = topV != null ? ((Number) topV[1]).longValue() : 0L;
 
+        // topMaterial: 매출 기준 → 판매량(kg) 기준으로 전환. r[1] 의미가 amount → weight.
         List<Object[]> topMList = txRepo.topMaterial(fromDate, toDateExcl);
         Object[] topM = topMList.isEmpty() ? null : topMList.get(0);
-        String topMaterialName = topM != null ? (String) topM[0] : "";
-        long   topMaterialAmt  = topM != null ? ((Number) topM[1]).longValue() : 0L;
+        String topMaterialName   = topM != null ? (String) topM[0] : "";
+        long   topMaterialWeight = topM != null ? ((Number) topM[1]).longValue() : 0L;
 
         VendorAnalyticsDto.KpiSummary kpi = VendorAnalyticsDto.KpiSummary.builder()
                 .activeVendorCount(activeVendors)
@@ -52,7 +53,7 @@ public class VendorAnalyticsService {
                 .topVendorName(topVendorName)
                 .topVendorAmount(BigDecimal.valueOf(topVendorAmt))
                 .topMaterialName(topMaterialName)
-                .topMaterialAmount(BigDecimal.valueOf(topMaterialAmt))
+                .topMaterialWeight(topMaterialWeight)
                 .totalSalesAmount(BigDecimal.valueOf(totalSales))
                 .build();
 

--- a/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/model/VendorAnalyticsDto.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/model/VendorAnalyticsDto.java
@@ -34,8 +34,8 @@ public class VendorAnalyticsDto {
         private Integer activeMaterialCount;     // 거래된 소재 종류 수
         private String  topVendorName;           // 제일 많이 거래한 거래처
         private BigDecimal topVendorAmount;      // 그 거래처 매출 (원)
-        private String  topMaterialName;         // 제일 많이 팔린 소재 (한글명)
-        private BigDecimal topMaterialAmount;    // 그 소재 매출 (원)
+        private String  topMaterialName;         // 제일 많이 팔린 소재 (한글명, 판매량 1위)
+        private Long    topMaterialWeight;       // 그 소재 판매량 (kg) — 매출 기준에서 판매량 기준으로 전환
         private BigDecimal totalSalesAmount;     // 총 판매 금액 (원)
     }
 

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
@@ -36,14 +36,14 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
         """, nativeQuery = true)
     List<Object[]> topVendor(@Param("from") Date from, @Param("to") Date to);
 
-    /** TOP 소재 (매출 1위, 한글명). */
+    /** TOP 소재 (판매량 1kg 1위, 한글명). 정렬 기준을 매출 → 판매 무게 로 변경. */
     @Query(value = """
-        SELECT p.material_name_ko AS name, SUM(t.total_amount) AS amount
+        SELECT p.material_name_ko AS name, SUM(t.weight_kg) AS weight
         FROM circular_buyer_transaction t
         JOIN circular_material_price_policy p ON p.material_code = t.material_code
         WHERE t.transacted_at >= :from AND t.transacted_at < :to
         GROUP BY p.material_name_ko
-        ORDER BY amount DESC
+        ORDER BY weight DESC
         LIMIT 1
         """, nativeQuery = true)
     List<Object[]> topMaterial(@Param("from") Date from, @Param("to") Date to);
@@ -85,6 +85,7 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
     /**
      * 소재별 집계 (순환재고 상세).
      * 결과: material_code, material_name_ko, material_group, total_weight, total_amount
+     * 정렬 기준을 매출 → 판매 무게(kg) 로 변경 — 소재 매출 순위가 kg 기준으로 노출.
      */
     @Query(value = """
         SELECT
@@ -97,7 +98,7 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
         JOIN circular_material_price_policy p ON p.material_code = t.material_code
         WHERE t.transacted_at >= :from AND t.transacted_at < :to
         GROUP BY p.material_code, p.material_name_ko, p.material_group
-        ORDER BY total_amount DESC
+        ORDER BY total_weight DESC
         """, nativeQuery = true)
     List<Object[]> aggregateByMaterial(@Param("from") Date from, @Param("to") Date to);
 


### PR DESCRIPTION
## 📌 요약
- 

<br><br>

## 🎯 작업 내용
 circularMaterialStats: sales 정렬/비중 → units(kg) 정렬/비중
- 막대 차트: 매출(원) 데이터/축/툴팁 → 판매량(kg) 표기
- 도넛: 매출 비중 → 판매량(kg) 비중
- 테이블: 판매수 컬럼 → 판매량(kg), "X kg" 단위 표기, 강조 컬럼 전환
- 헤더/요약 라벨: "소재 매출 순위/비중" → "소재 판매량 순위/비중"
- totalMaterialSales → totalMaterialWeight 변수명 변경

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
