### PR TITLE
feat(analytics): 소재 매출 순위 화면을 판매량(kg) 기준으로 전환

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/DashboardAnalyticsService.java
@@ -83,7 +83,6 @@ public class DashboardAnalyticsService {
                     .topVendorName("-")
                     .topVendorAmount(BigDecimal.ZERO)
                     .topMaterialName("-")
-                    .topMaterialAmount(BigDecimal.ZERO)
                     .topMaterialWeight(0L)
                     .topMaterialType("-")
                     .build();
@@ -186,9 +185,8 @@ public class DashboardAnalyticsService {
                 // 카드 4 (Vendor)
                 .topVendorName(vendor.getKpi().getTopVendorName())
                 .topVendorAmount(vendor.getKpi().getTopVendorAmount())
-                // 카드 5 (Vendor 소재)
+                // 카드 5 (Vendor 소재) — 매출(원) 기준 → 판매량(kg) 기준 전환
                 .topMaterialName(vendor.getKpi().getTopMaterialName())
-                .topMaterialAmount(vendor.getKpi().getTopMaterialAmount())
                 .topMaterialWeight(topMat == null ? 0L : topMat.getUnits())
                 .topMaterialType(topMat == null ? "" : topMat.getMaterialType())
                 .build();

--- a/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/model/DashboardAnalyticsDto.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/dashboardanalytics/model/DashboardAnalyticsDto.java
@@ -77,9 +77,9 @@ public class DashboardAnalyticsDto {
         private String topVendorName;
         private BigDecimal topVendorAmount;
 
-        // 카드 5 (Vendor 점프): TOP 소재
+        // 카드 5 (Vendor 점프): TOP 소재 — 매출(원) 기준 → 판매량(kg) 기준 전환으로
+        //                                topMaterialAmount(BigDecimal) 폐기, topMaterialWeight 만 유지.
         private String topMaterialName;
-        private BigDecimal topMaterialAmount;
         private Long topMaterialWeight;
         private String topMaterialType;
     }

--- a/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/VendorAnalyticsService.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/VendorAnalyticsService.java
@@ -41,10 +41,11 @@ public class VendorAnalyticsService {
         String topVendorName = topV != null ? (String) topV[0] : "";
         long   topVendorAmt  = topV != null ? ((Number) topV[1]).longValue() : 0L;
 
+        // topMaterial: 매출 기준 → 판매량(kg) 기준으로 전환. r[1] 의미가 amount → weight.
         List<Object[]> topMList = txRepo.topMaterial(fromDate, toDateExcl);
         Object[] topM = topMList.isEmpty() ? null : topMList.get(0);
-        String topMaterialName = topM != null ? (String) topM[0] : "";
-        long   topMaterialAmt  = topM != null ? ((Number) topM[1]).longValue() : 0L;
+        String topMaterialName   = topM != null ? (String) topM[0] : "";
+        long   topMaterialWeight = topM != null ? ((Number) topM[1]).longValue() : 0L;
 
         VendorAnalyticsDto.KpiSummary kpi = VendorAnalyticsDto.KpiSummary.builder()
                 .activeVendorCount(activeVendors)
@@ -52,7 +53,7 @@ public class VendorAnalyticsService {
                 .topVendorName(topVendorName)
                 .topVendorAmount(BigDecimal.valueOf(topVendorAmt))
                 .topMaterialName(topMaterialName)
-                .topMaterialAmount(BigDecimal.valueOf(topMaterialAmt))
+                .topMaterialWeight(topMaterialWeight)
                 .totalSalesAmount(BigDecimal.valueOf(totalSales))
                 .build();
 

--- a/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/model/VendorAnalyticsDto.java
+++ b/src/main/java/org/example/stockitbe/hq/analytics/vendoranalytics/model/VendorAnalyticsDto.java
@@ -34,8 +34,8 @@ public class VendorAnalyticsDto {
         private Integer activeMaterialCount;     // 거래된 소재 종류 수
         private String  topVendorName;           // 제일 많이 거래한 거래처
         private BigDecimal topVendorAmount;      // 그 거래처 매출 (원)
-        private String  topMaterialName;         // 제일 많이 팔린 소재 (한글명)
-        private BigDecimal topMaterialAmount;    // 그 소재 매출 (원)
+        private String  topMaterialName;         // 제일 많이 팔린 소재 (한글명, 판매량 1위)
+        private Long    topMaterialWeight;       // 그 소재 판매량 (kg) — 매출 기준에서 판매량 기준으로 전환
         private BigDecimal totalSalesAmount;     // 총 판매 금액 (원)
     }
 

--- a/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
+++ b/src/main/java/org/example/stockitbe/hq/circularbuyer/repository/CircularBuyerTransactionRepository.java
@@ -36,14 +36,14 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
         """, nativeQuery = true)
     List<Object[]> topVendor(@Param("from") Date from, @Param("to") Date to);
 
-    /** TOP 소재 (매출 1위, 한글명). */
+    /** TOP 소재 (판매량 1kg 1위, 한글명). 정렬 기준을 매출 → 판매 무게 로 변경. */
     @Query(value = """
-        SELECT p.material_name_ko AS name, SUM(t.total_amount) AS amount
+        SELECT p.material_name_ko AS name, SUM(t.weight_kg) AS weight
         FROM circular_buyer_transaction t
         JOIN circular_material_price_policy p ON p.material_code = t.material_code
         WHERE t.transacted_at >= :from AND t.transacted_at < :to
         GROUP BY p.material_name_ko
-        ORDER BY amount DESC
+        ORDER BY weight DESC
         LIMIT 1
         """, nativeQuery = true)
     List<Object[]> topMaterial(@Param("from") Date from, @Param("to") Date to);
@@ -85,6 +85,7 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
     /**
      * 소재별 집계 (순환재고 상세).
      * 결과: material_code, material_name_ko, material_group, total_weight, total_amount
+     * 정렬 기준을 매출 → 판매 무게(kg) 로 변경 — 소재 매출 순위가 kg 기준으로 노출.
      */
     @Query(value = """
         SELECT
@@ -97,7 +98,7 @@ public interface CircularBuyerTransactionRepository extends JpaRepository<Circul
         JOIN circular_material_price_policy p ON p.material_code = t.material_code
         WHERE t.transacted_at >= :from AND t.transacted_at < :to
         GROUP BY p.material_code, p.material_name_ko, p.material_group
-        ORDER BY total_amount DESC
+        ORDER BY total_weight DESC
         """, nativeQuery = true)
     List<Object[]> aggregateByMaterial(@Param("from") Date from, @Param("to") Date to);
 

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -182,6 +182,8 @@ public class CircularSaleService {
                     .saleNo(header.getSaleNo())
                     .status(header.getStatus())
                     .outboundNo(outbound == null ? null : outbound.getOutboundNo())
+                    .outboundWarehouseCode(outbound == null ? null : outbound.getWarehouseCode())
+                    .outboundWarehouseName(outbound == null ? null : outbound.getWarehouseName())
                     .outboundStatus(outbound == null ? null : outbound.getStatus())
                     .soldAt(header.getSoldAt())
                     .completedAt(header.getCompletedAt())

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -166,6 +166,12 @@ public class CircularSaleService {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet())
         ).stream().collect(Collectors.toMap(WhOutboundHeader::getId, Function.identity()));
+        Map<Long, Infrastructure> warehouseById = infrastructureRepository.findAllById(
+                outboundById.values().stream()
+                        .map(WhOutboundHeader::getWarehouseId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet())
+        ).stream().collect(Collectors.toMap(Infrastructure::getId, Function.identity()));
 
         Map<Long, List<CircularSaleItem>> itemsByHeader = saleItemRepository.findAllBySaleHeaderIdIn(
                 headers.getContent().stream().map(CircularSaleHeader::getId).toList()
@@ -176,14 +182,15 @@ public class CircularSaleService {
         for (CircularSaleHeader header : headers.getContent()) {
             CircularBuyer buyer = buyerById.get(header.getBuyerId());
             WhOutboundHeader outbound = outboundById.get(header.getOutboundHeaderId());
+            Infrastructure outboundWarehouse = outbound == null ? null : warehouseById.get(outbound.getWarehouseId());
             List<CircularSaleItem> items = itemsByHeader.getOrDefault(header.getId(), List.of());
             rows.add(CircularSaleDto.ListRowRes.builder()
                     .saleId(header.getId())
                     .saleNo(header.getSaleNo())
                     .status(header.getStatus())
                     .outboundNo(outbound == null ? null : outbound.getOutboundNo())
-                    .outboundWarehouseCode(outbound == null ? null : outbound.getWarehouseCode())
-                    .outboundWarehouseName(outbound == null ? null : outbound.getWarehouseName())
+                    .outboundWarehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                    .outboundWarehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
                     .outboundStatus(outbound == null ? null : outbound.getStatus())
                     .soldAt(header.getSoldAt())
                     .completedAt(header.getCompletedAt())

--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -20,6 +20,8 @@ import org.example.stockitbe.hq.circularsale.repository.CircularSaleHeaderReposi
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleItemMaterialRepository;
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleItemRepository;
 import org.example.stockitbe.hq.circularsale.repository.CircularSaleStatusHistoryRepository;
+import org.example.stockitbe.hq.infrastructure.InfrastructureRepository;
+import org.example.stockitbe.hq.infrastructure.model.Infrastructure;
 import org.example.stockitbe.hq.inventory.InventoryRepository;
 import org.example.stockitbe.hq.inventory.InventoryService;
 import org.example.stockitbe.hq.inventory.model.Inventory;
@@ -79,6 +81,7 @@ public class CircularSaleService {
     private final CircularSaleItemRepository saleItemRepository;
     private final CircularSaleItemMaterialRepository saleItemMaterialRepository;
     private final CircularSaleStatusHistoryRepository saleStatusHistoryRepository;
+    private final InfrastructureRepository infrastructureRepository;
     private final CircularBuyerRepository circularBuyerRepository;
     // Phase 3: 실제 판매 시 ESG 점수 가산용 거래 row 를 함께 INSERT 하기 위한 Repository
     private final CircularBuyerTransactionRepository transactionRepository;
@@ -103,6 +106,12 @@ public class CircularSaleService {
         // 3) 라인별 SKU/재고/소재 스냅샷 컨텍스트 구성 + 단일 창고 검증
         List<LineContext> contexts = buildLineContexts(request.getItems(), request.getMaterialType(), categoryLookup);
         Long warehouseId = resolveSingleWarehouse(contexts);
+        for (LineContext context : contexts) {
+            context.availableQuantitySnapshot = Math.max(
+                    0,
+                    context.inventory.getAvailableQuantity() == null ? 0 : context.inventory.getAvailableQuantity()
+            );
+        }
 
         // 4) 재고를 즉시 차감하지 않고 예약 수량으로 선반영
         applyInventoryReservations(contexts);
@@ -211,8 +220,37 @@ public class CircularSaleService {
                         CircularSaleItemMaterial::getSaleItemId,
                         Collectors.mapping(CircularSaleDto.MaterialRes::from, Collectors.toList())
                 ));
+        Infrastructure outboundWarehouse = header.getWarehouseId() == null ? null
+                : infrastructureRepository.findById(header.getWarehouseId()).orElse(null);
+
         List<CircularSaleDto.LineRes> lines = items.stream()
-                .map(item -> CircularSaleDto.LineRes.from(item, materialsByItem.getOrDefault(item.getId(), List.of())))
+                .map(item -> {
+                    CircularSaleDto.LineRes base = CircularSaleDto.LineRes.from(item, materialsByItem.getOrDefault(item.getId(), List.of()));
+                    return CircularSaleDto.LineRes.builder()
+                            .itemId(base.getItemId())
+                            .inventoryId(base.getInventoryId())
+                            .skuCode(base.getSkuCode())
+                            .productCode(base.getProductCode())
+                            .productName(base.getProductName())
+                            .mainCategory(base.getMainCategory())
+                            .subCategory(base.getSubCategory())
+                            .color(base.getColor())
+                            .size(base.getSize())
+                            .materialType(base.getMaterialType())
+                            .requestedWeightKg(base.getRequestedWeightKg())
+                            .actualWeightKg(base.getActualWeightKg())
+                            .estimatedQuantity(base.getEstimatedQuantity())
+                            .soldQuantity(base.getSoldQuantity())
+                            .availableQuantity(base.getAvailableQuantity())
+                            .availableWeightKg(base.getAvailableWeightKg())
+                            .warehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                            .warehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
+                            .unitPrice(base.getUnitPrice())
+                            .lineAmount(base.getLineAmount())
+                            .memo(base.getMemo())
+                            .materials(base.getMaterials())
+                            .build();
+                })
                 .toList();
 
         // 3) 상태 이력 조회
@@ -233,6 +271,8 @@ public class CircularSaleService {
                 .soldByMemberId(header.getSoldByMemberId())
                 .soldByName(header.getSoldByName())
                 .outboundHeaderId(header.getOutboundHeaderId())
+                .outboundWarehouseCode(outboundWarehouse == null ? null : outboundWarehouse.getCode())
+                .outboundWarehouseName(outboundWarehouse == null ? null : outboundWarehouse.getName())
                 .buyerCode(buyer.getCode())
                 .buyerName(buyer.getCompanyName())
                 .buyerIndustryGroup(buyer.getIndustryGroup())
@@ -501,6 +541,8 @@ public class CircularSaleService {
         List<CircularSaleItem> items = new ArrayList<>();
         for (LineContext context : contexts) {
             CircularSaleDto.CreateLineReq reqLine = context.request;
+            int stockQuantitySnapshot = Math.max(0, context.availableQuantitySnapshot == null ? 0 : context.availableQuantitySnapshot);
+            BigDecimal stockWeightKgSnapshot = estimateSnapshotWeightKg(reqLine, stockQuantitySnapshot);
             items.add(CircularSaleItem.builder()
                     .saleHeaderId(header.getId())
                     .inventoryId(reqLine.getInventoryId())
@@ -517,6 +559,8 @@ public class CircularSaleService {
                     .actualWeightKg(scale3(reqLine.getActualWeightKg() == null ? reqLine.getRequestedWeightKg() : reqLine.getActualWeightKg()))
                     .estimatedQuantity(scale3(reqLine.getEstimatedQuantity() == null ? BigDecimal.valueOf(reqLine.getSoldQuantity()) : reqLine.getEstimatedQuantity()))
                     .soldQuantity(reqLine.getSoldQuantity())
+                    .stockQuantitySnapshot(stockQuantitySnapshot)
+                    .stockWeightKgSnapshot(stockWeightKgSnapshot)
                     .unitPrice(reqLine.getUnitPrice())
                     .lineAmount(reqLine.getLineAmount())
                     .memo(reqLine.getMemo())
@@ -811,6 +855,17 @@ public class CircularSaleService {
         return value.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
     }
 
+    private BigDecimal estimateSnapshotWeightKg(CircularSaleDto.CreateLineReq reqLine, int stockQuantitySnapshot) {
+        if (stockQuantitySnapshot <= 0) return BigDecimal.ZERO.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        BigDecimal soldQty = BigDecimal.valueOf(Math.max(1, reqLine.getSoldQuantity() == null ? 0 : reqLine.getSoldQuantity()));
+        BigDecimal baseWeight = reqLine.getActualWeightKg() == null ? reqLine.getRequestedWeightKg() : reqLine.getActualWeightKg();
+        if (baseWeight == null || baseWeight.compareTo(BigDecimal.ZERO) <= 0) {
+            return BigDecimal.ZERO.setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        }
+        BigDecimal unitWeight = baseWeight.divide(soldQty, DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+        return unitWeight.multiply(BigDecimal.valueOf(stockQuantitySnapshot)).setScale(DECIMAL_SCALE_3, RoundingMode.HALF_UP);
+    }
+
     private Integer sumInt(Collection<LineContext> contexts, Function<LineContext, Integer> extractor) {
         int sum = 0;
         for (LineContext context : contexts) {
@@ -841,6 +896,7 @@ public class CircularSaleService {
         private ProductSku sku;
         private ProductMaster master;
         private Inventory inventory;
+        private Integer availableQuantitySnapshot;
         private String mainCategory;
         private String subCategory;
         private String materialType;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
@@ -234,6 +234,8 @@ public class CircularSaleDto {
         private String saleNo;
         private CircularSaleStatus status;
         private String outboundNo;
+        private String outboundWarehouseCode;
+        private String outboundWarehouseName;
         private OutboundStatus outboundStatus;
         private Date soldAt;
         private Date completedAt;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/dto/CircularSaleDto.java
@@ -136,6 +136,10 @@ public class CircularSaleDto {
         private BigDecimal actualWeightKg;
         private BigDecimal estimatedQuantity;
         private Integer soldQuantity;
+        private Integer availableQuantity;
+        private BigDecimal availableWeightKg;
+        private String warehouseCode;
+        private String warehouseName;
         private Long unitPrice;
         private Long lineAmount;
         private String memo;
@@ -157,6 +161,10 @@ public class CircularSaleDto {
                     .actualWeightKg(item.getActualWeightKg())
                     .estimatedQuantity(item.getEstimatedQuantity())
                     .soldQuantity(item.getSoldQuantity())
+                    .availableQuantity(item.getStockQuantitySnapshot())
+                    .availableWeightKg(item.getStockWeightKgSnapshot())
+                    .warehouseCode(null)
+                    .warehouseName(null)
                     .unitPrice(item.getUnitPrice())
                     .lineAmount(item.getLineAmount())
                     .memo(item.getMemo())
@@ -257,6 +265,8 @@ public class CircularSaleDto {
         private String soldByMemberId;
         private String soldByName;
         private Long outboundHeaderId;
+        private String outboundWarehouseCode;
+        private String outboundWarehouseName;
         private String buyerCode;
         private String buyerName;
         private String buyerIndustryGroup;

--- a/src/main/java/org/example/stockitbe/hq/circularsale/model/entity/CircularSaleItem.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/model/entity/CircularSaleItem.java
@@ -72,6 +72,12 @@ public class CircularSaleItem extends BaseEntity {
     @Column(name = "sold_quantity", nullable = false)
     private Integer soldQuantity;
 
+    @Column(name = "stock_quantity_snapshot", nullable = false)
+    private Integer stockQuantitySnapshot;
+
+    @Column(name = "stock_weight_kg_snapshot", nullable = false, precision = 14, scale = 3, columnDefinition = "DECIMAL(14,3)")
+    private BigDecimal stockWeightKgSnapshot;
+
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
@@ -85,7 +91,8 @@ public class CircularSaleItem extends BaseEntity {
     private CircularSaleItem(Long saleHeaderId, Long inventoryId, Long skuId, String skuCode, String productCode,
                              String productName, String mainCategory, String subCategory, String color, String size,
                              String materialType, BigDecimal requestedWeightKg, BigDecimal actualWeightKg,
-                             BigDecimal estimatedQuantity, Integer soldQuantity, Long unitPrice, Long lineAmount,
+                             BigDecimal estimatedQuantity, Integer soldQuantity, Integer stockQuantitySnapshot,
+                             BigDecimal stockWeightKgSnapshot, Long unitPrice, Long lineAmount,
                              String memo) {
         this.saleHeaderId = saleHeaderId;
         this.inventoryId = inventoryId;
@@ -102,6 +109,8 @@ public class CircularSaleItem extends BaseEntity {
         this.actualWeightKg = actualWeightKg == null ? BigDecimal.ZERO : actualWeightKg;
         this.estimatedQuantity = estimatedQuantity == null ? BigDecimal.ZERO : estimatedQuantity;
         this.soldQuantity = soldQuantity == null ? 0 : soldQuantity;
+        this.stockQuantitySnapshot = stockQuantitySnapshot == null ? 0 : stockQuantitySnapshot;
+        this.stockWeightKgSnapshot = stockWeightKgSnapshot == null ? BigDecimal.ZERO : stockWeightKgSnapshot;
         this.unitPrice = unitPrice == null ? 0L : unitPrice;
         this.lineAmount = lineAmount == null ? 0L : lineAmount;
         this.memo = memo;


### PR DESCRIPTION
## 📌 요약
- 

<br><br>

## 🎯 작업 내용
- circularMaterialStats: sales 정렬/비중 → units(kg) 정렬/비중
- 막대 차트: 매출(원) 데이터/축/툴팁 → 판매량(kg) 표기
- 도넛: 매출 비중 → 판매량(kg) 비중
- 테이블: 판매수 컬럼 → 판매량(kg), "X kg" 단위 표기, 강조 컬럼 전환
- 헤더/요약 라벨: "소재 매출 순위/비중" → "소재 판매량 순위/비중"
- totalMaterialSales → totalMaterialWeight 변수명 변경

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
