### PR TITLE
swagger: 유저, 알림, 인증

### DIFF
--- a/src/main/java/org/example/stockitbe/common/config/OpenApiConfig.java
+++ b/src/main/java/org/example/stockitbe/common/config/OpenApiConfig.java
@@ -1,0 +1,33 @@
+package org.example.stockitbe.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String COOKIE_AUTH = "AtokenCookie";
+
+    @Bean
+    public OpenAPI stockitOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Stockit API")
+                        .description("Stockit 백엔드 API 문서 — 사용자 인증 · 알림 · 계정 관리")
+                        .version("v1.0"))
+                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH))
+                .components(new Components()
+                        .addSecuritySchemes(COOKIE_AUTH, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.COOKIE)
+                                .name("Atoken")
+                                .description("로그인 후 발급된 Atoken 쿠키 값을 입력하세요.")
+                        )
+                );
+    }
+}

--- a/src/main/java/org/example/stockitbe/hq/account/AccountController.java
+++ b/src/main/java/org/example/stockitbe/hq/account/AccountController.java
@@ -1,5 +1,8 @@
 package org.example.stockitbe.hq.account;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
 import org.example.stockitbe.hq.account.model.AccountDto;
@@ -12,8 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
+@Tag(name = "본사 - 계정 관리", description = "회원 목록 조회 · 가입 신청 승인/거절 · 회원 탈퇴 처리 API (USER-005~007, 009)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/hq/account")
@@ -21,10 +23,15 @@ public class AccountController {
 
     private final AccountService accountService;
 
+    @Operation(summary = "가입 대기 회원 목록 조회",
+            description = "PENDING 상태의 회원을 페이지네이션으로 조회합니다. 정렬: 신청일 오름차순.")
     @GetMapping("/pending")
     public ResponseEntity<BaseResponse<Page<AccountDto.PendingRes>>> getPendingAccounts(
+            @Parameter(description = "이름/이메일 검색 키워드", example = "")
             @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호 (0-based)", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 (1~100)", example = "20")
             @RequestParam(defaultValue = "20") int size) {
         int safeSize = Math.min(Math.max(1, size), 100);   // 1~100 보정 (DoS 방어)
         Pageable pageable = PageRequest.of(Math.max(0, page), safeSize,
@@ -35,12 +42,19 @@ public class AccountController {
     }
 
 
+    @Operation(summary = "전체 회원 목록 조회",
+            description = "권한/상태/키워드 필터로 회원 목록을 조회합니다. 정렬: 신청일 내림차순.")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<AccountDto.PendingRes>>> getAllAccounts(
+            @Parameter(description = "이름/이메일 검색 키워드", example = "")
             @RequestParam(required = false) String keyword,
+            @Parameter(description = "권한 필터 (HQ/STORE/WAREHOUSE)", example = "STORE")
             @RequestParam(required = false) UserRole role,
+            @Parameter(description = "상태 필터 (PENDING/APPROVED/REJECTED/WITHDRAWN)", example = "APPROVED")
             @RequestParam(required = false) UserStatus status,
+            @Parameter(description = "페이지 번호 (0-based)", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 (1~100)", example = "20")
             @RequestParam(defaultValue = "20") int size) {
         int safeSize = Math.min(Math.max(1, size), 100);
         Pageable pageable = PageRequest.of(Math.max(0, page), safeSize,
@@ -52,18 +66,27 @@ public class AccountController {
 
 
 
+    @Operation(summary = "가입 신청 승인",
+            description = "대기 중인 회원을 승인하고 사원코드를 자동 발급합니다 (HQ→hq0001, STORE→st0001, WAREHOUSE→wh0001).")
     @PostMapping("/{id}/approve")
-    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> approve(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> approve(
+            @Parameter(description = "회원 ID", example = "5") @PathVariable Long id) {
         return ResponseEntity.ok(BaseResponse.success(accountService.approve(id)));
     }
 
+    @Operation(summary = "가입 신청 거절",
+            description = "대기 중인 회원의 가입 신청을 거절합니다.")
     @PostMapping("/{id}/reject")
-    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> reject(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> reject(
+            @Parameter(description = "회원 ID", example = "5") @PathVariable Long id) {
         return ResponseEntity.ok(BaseResponse.success(accountService.reject(id)));
     }
 
+    @Operation(summary = "회원 탈퇴 처리",
+            description = "회원 상태를 WITHDRAWN으로 변경하고 모든 Refresh Token을 무효화합니다.")
     @PostMapping("/{id}/withdraw")
-    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> withdraw(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<AccountDto.ProcessRes>> withdraw(
+            @Parameter(description = "회원 ID", example = "5") @PathVariable Long id) {
         return ResponseEntity.ok(BaseResponse.success(accountService.withdraw(id)));
     }
 

--- a/src/main/java/org/example/stockitbe/hq/account/model/AccountDto.java
+++ b/src/main/java/org/example/stockitbe/hq/account/model/AccountDto.java
@@ -1,5 +1,6 @@
 package org.example.stockitbe.hq.account.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.stockitbe.user.model.entity.User;
@@ -13,18 +14,32 @@ public class AccountDto {
     //  대기 회원 목록 응답
     @Getter
     @Builder
+    @Schema(description = "회원 정보 응답 (대기/전체 목록 공용)")
     public static class PendingRes {
+        @Schema(description = "회원 PK", example = "5")
         private Long id;
+        @Schema(description = "사원코드 (PENDING은 null)", example = "st0001")
         private String employeeCode;
+        @Schema(description = "이름", example = "테스트유저")
         private String name;
+        @Schema(description = "이메일", example = "swagger-test01@stockit.com")
         private String email;
+        @Schema(description = "전화번호", example = "01099990001")
         private String phoneNumber;
+        @Schema(description = "지점 코드", example = "ST001")
         private String locationCode;
+        @Schema(description = "지점명", example = "테스트 매장")
         private String locationName;
+        @Schema(description = "가입 신청 사유", example = "Swagger 테스트용 신청")
         private String applicationReason;
+        @Schema(description = "권한 (HQ/STORE/WAREHOUSE)", example = "STORE")
         private UserRole role;
+        @Schema(description = "회원 상태", example = "PENDING",
+                allowableValues = {"PENDING", "APPROVED", "REJECTED", "WITHDRAWN"})
         private UserStatus status;
+        @Schema(description = "신청 일시")
         private LocalDateTime appliedAt;
+        @Schema(description = "처리 일시 (PENDING은 null)")
         private LocalDateTime processedAt;
 
         public static PendingRes from(User entity) {
@@ -48,12 +63,19 @@ public class AccountDto {
     //  처리(승인/거절) 결과 응답
     @Getter
     @Builder
+    @Schema(description = "회원 처리 결과 응답 (승인/거절/탈퇴 공용)")
     public static class ProcessRes {
+        @Schema(description = "회원 PK", example = "5")
         private Long id;
+        @Schema(description = "발급된 사원코드", example = "st0001")
         private String employeeCode;
+        @Schema(description = "이름", example = "테스트유저")
         private String name;
+        @Schema(description = "권한", example = "STORE")
         private UserRole role;
+        @Schema(description = "변경된 상태", example = "APPROVED")
         private UserStatus status;
+        @Schema(description = "처리 일시")
         private LocalDateTime processedAt;
 
         public static ProcessRes from(User entity) {

--- a/src/main/java/org/example/stockitbe/notification/NotificationController.java
+++ b/src/main/java/org/example/stockitbe/notification/NotificationController.java
@@ -1,5 +1,8 @@
 package org.example.stockitbe.notification;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.stockitbe.common.model.BaseResponse;
@@ -10,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Tag(name = "시스템 - 알림", description = "SSE 실시간 알림 구독/푸시 · 본인 수신 알림 목록 · 읽음 처리 API (SYS-004, SYS-005)")
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
@@ -18,6 +22,8 @@ public class NotificationController {
     private final NotificationService service;
 
     // SSE 구독
+    @Operation(summary = "SSE 알림 스트림 구독",
+            description = "본인 권한에 해당하는 알림을 실시간으로 수신합니다. 응답은 text/event-stream.")
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@AuthenticationPrincipal AuthUserDetails me,
                                  HttpServletResponse response) {
@@ -33,9 +39,13 @@ public class NotificationController {
     // SSE 명시적 종료 — FE 가 페이지 unload (탭 닫기/F5/창 닫기) 시 navigator.sendBeacon 으로 호출.
     // TCP FIN 도달 못 하는 unload 상황에서도 BE Map 에서 즉시 정리되게 함.
     // sendBeacon 은 POST 만 지원 → DELETE 가 아닌 POST 채택.
+    @Operation(summary = "SSE 세션 명시적 종료",
+            description = "페이지 unload 시 sendBeacon으로 호출됩니다. sessionId의 owner만 종료 가능.")
     @PostMapping("/stream/{sessionId}/close")
     public BaseResponse<Void> closeStream(
             @AuthenticationPrincipal AuthUserDetails me,
+            @Parameter(description = "SSE 세션 UUID (구독 시 connect 이벤트로 받은 값)",
+                    example = "0db77e3c-ac0e-479c-b2ec-92759ba1ecde")
             @PathVariable String sessionId) {
         // 1. 요청 받기 2. 서비스 호출 (내부에서 sessionId owner 검증) 3. 응답 반환
         service.unsubscribeStream(sessionId, me);
@@ -43,17 +53,24 @@ public class NotificationController {
     }
 
     // 본인 수신 알림 목록
+    @Operation(summary = "본인 수신 알림 목록 조회",
+            description = "페이지네이션으로 본인 알림을 조회합니다. unreadOnly=true 이면 미확인만 반환.")
     @GetMapping
     public BaseResponse<NotificationDto.NotificationListRes> list(
             @AuthenticationPrincipal AuthUserDetails me,
+            @Parameter(description = "페이지 번호 (0-based)", example = "0")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "미확인만 조회 여부", example = "false")
             @RequestParam(required = false) Boolean unreadOnly) {
         // 1. 요청 받기 2. 서비스 호출 3. 응답 반환
         return BaseResponse.success(service.list(me, page, size, unreadOnly));
     }
 
     // 미읽음 카운트
+    @Operation(summary = "미읽음 알림 개수 조회",
+            description = "헤더 종 아이콘 미확인 카운트에 사용됩니다.")
     @GetMapping("/unread-count")
     public BaseResponse<NotificationDto.UnreadCountRes> unreadCount(
             @AuthenticationPrincipal AuthUserDetails me) {
@@ -62,8 +79,11 @@ public class NotificationController {
     }
 
     // 단건 읽음
+    @Operation(summary = "단건 알림 읽음 처리",
+            description = "알림 1건을 읽음 상태로 변경합니다. 같은 알림 두 번 호출해도 안전 (idempotent).")
     @PatchMapping("/{id}/read")
     public BaseResponse<Void> read(@AuthenticationPrincipal AuthUserDetails me,
+                                   @Parameter(description = "알림 ID", example = "1")
                                    @PathVariable Long id) {
         // 1. 요청 받기 2. 서비스 호출 3. 응답 반환
         service.read(id, me);
@@ -71,6 +91,8 @@ public class NotificationController {
     }
 
     // 본인 미읽음 전체 읽음
+    @Operation(summary = "본인 미확인 알림 전체 읽음 처리",
+            description = "본인의 미확인 알림을 일괄 읽음 처리합니다.")
     @PatchMapping("/read-all")
     public BaseResponse<Void> readAll(@AuthenticationPrincipal AuthUserDetails me) {
         // 1. 요청 받기 2. 서비스 호출 3. 응답 반환

--- a/src/main/java/org/example/stockitbe/notification/model/dto/NotificationDto.java
+++ b/src/main/java/org/example/stockitbe/notification/model/dto/NotificationDto.java
@@ -1,5 +1,6 @@
 package org.example.stockitbe.notification.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,16 +14,26 @@ public class NotificationDto {
     @Getter
     @AllArgsConstructor
     @Builder
+    @Schema(description = "알림 단건 응답")
     public static class NotificationRes {
         // 응답 필드 최소화 (2026-05-23) — FE 가 실제로 사용하는 7개만 응답.
         // 제거된 필드: refType, refId, readAt (FE 미사용 — 통신량 약 25%↓ + 페이로드 의도 명확화)
         // 제거 정책 근거: docs/plan/notification/응답 필드 최소화.md (예정) — DB 컬럼/Entity 필드는 유지.
+        @Schema(description = "알림 ID", example = "1")
         private Long id;
+        @Schema(description = "알림 종류", example = "USER_SIGNUP_PENDING",
+                allowableValues = {"INVENTORY_SHORTAGE", "INVENTORY_OUT_OF_STOCK", "USER_SIGNUP_PENDING", "CIRCULAR_CANDIDATE"})
         private String type;
+        @Schema(description = "중요도", example = "INFO",
+                allowableValues = {"INFO", "WARNING", "CRITICAL"})
         private String severity;
+        @Schema(description = "제목", example = "신규 회원가입 신청")
         private String title;
+        @Schema(description = "본문", example = "테스트유저(test@stockit.com) 회원가입 승인 대기 중입니다.")
         private String message;
+        @Schema(description = "본인 읽음 여부", example = "false")
         private boolean read;
+        @Schema(description = "발생 시각")
         private Date createdAt;
 
         // 본인 기준 읽음 상태와 함께 변환.
@@ -45,30 +56,45 @@ public class NotificationDto {
     @Getter
     @AllArgsConstructor
     @Builder
+    @Schema(description = "알림 목록 응답")
     public static class NotificationListRes {
+        @Schema(description = "알림 항목 리스트")
         private List<NotificationRes> items;
+        @Schema(description = "전체 건수", example = "27")
         private long totalElements;
+        @Schema(description = "전체 페이지 수", example = "2")
         private int totalPages;
+        @Schema(description = "현재 페이지 (0-based)", example = "0")
         private int page;
+        @Schema(description = "페이지 크기", example = "20")
         private int size;
     }
 
     @Getter
     @AllArgsConstructor
     @Builder
+    @Schema(description = "미읽음 카운트 응답")
     public static class UnreadCountRes {
+        @Schema(description = "미읽음 알림 개수", example = "4")
         private long count;
     }
 
     @Getter
     @AllArgsConstructor
     @Builder
+    @Schema(description = "SSE 푸시 페이로드")
     public static class SsePayload {
+        @Schema(description = "알림 ID", example = "1")
         private Long id;
+        @Schema(description = "알림 종류", example = "USER_SIGNUP_PENDING")
         private String type;
+        @Schema(description = "중요도", example = "INFO")
         private String severity;
+        @Schema(description = "제목", example = "신규 회원가입 신청")
         private String title;
+        @Schema(description = "본문", example = "테스트유저(test@stockit.com) 회원가입 승인 대기 중입니다.")
         private String message;
+        @Schema(description = "발생 시각")
         private Date createdAt;
 
         public static SsePayload from(Notification e) {

--- a/src/main/java/org/example/stockitbe/user/UserController.java
+++ b/src/main/java/org/example/stockitbe/user/UserController.java
@@ -1,6 +1,8 @@
 package org.example.stockitbe.user;
 
 import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,7 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-
+@Tag(name = "회원 - 인증/마이페이지", description = "회원가입 · Access Token 갱신 · 로그아웃 · 마이페이지 조회/수정 API (USER-001~004, 008)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -37,7 +39,19 @@ public class UserController {
 
 
 
+    @Operation(summary = "로그인",
+            description = "사원코드와 비밀번호로 로그인합니다. 성공 시 HttpOnly 쿠키로 Atoken(Access)/Rtoken(Refresh) 토큰이 발급됩니다. " +
+                    "실제 처리는 Spring Security의 LoginFilter가 담당하므로 이 메서드는 호출되지 않으며 Swagger 문서 노출 전용입니다.")
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<UserDto.LoginRes>> login(@RequestBody UserDto.LoginReq req) {
+        // LoginFilter (UsernamePasswordAuthenticationFilter 상속) 가 /api/user/login POST 요청을 가로챕니다.
+        // 이 메서드 본문은 실행되지 않으며 Swagger UI 노출 + OpenAPI 스키마 생성 용도입니다.
+        throw new UnsupportedOperationException("Handled by LoginFilter");
+    }
 
+
+    @Operation(summary = "회원가입 신청",
+            description = "신규 회원이 가입을 신청합니다. 본사 관리자 승인 후 사원코드가 자동 발급됩니다.")
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<UserDto.SignupRes>> signup(
             @RequestBody UserDto.SignupReq req) {
@@ -46,7 +60,8 @@ public class UserController {
 
     }
 
-
+    @Operation(summary = "Access Token 자동 갱신",
+            description = "Refresh Token 쿠키로 새 Access Token을 발급받습니다.")
     @PostMapping("/refresh")
     @Transactional
     public ResponseEntity<BaseResponse<Void>> refresh(HttpServletRequest request,
@@ -92,7 +107,8 @@ public class UserController {
 
 
 
-
+    @Operation(summary = "로그아웃",
+            description = "Access/Refresh Token 쿠키를 삭제하고 DB의 Refresh Token을 무효화합니다.")
     @PostMapping("/logout")
     @Transactional
     public ResponseEntity<BaseResponse<Void>> logout(HttpServletRequest request,
@@ -116,6 +132,8 @@ public class UserController {
         return ResponseEntity.ok(BaseResponse.success(null));
     }
 
+    @Operation(summary = "마이페이지 본인 정보 조회",
+            description = "현재 로그인한 사용자의 본인 정보를 반환합니다.")
     @GetMapping("/mypage")
     public ResponseEntity<BaseResponse<UserDto.MypageRes>> getMypage(
             @AuthenticationPrincipal AuthUserDetails userDetails) {
@@ -124,6 +142,8 @@ public class UserController {
         ));
     }
 
+    @Operation(summary = "비밀번호 변경",
+            description = "기존 비밀번호 검증 후 새 비밀번호로 변경합니다. 변경 시 모든 디바이스가 강제 로그아웃됩니다.")
     @PatchMapping("/mypage/password")
     public ResponseEntity<BaseResponse<Void>> updatePassword(
             @AuthenticationPrincipal AuthUserDetails userDetails,
@@ -136,7 +156,8 @@ public class UserController {
         return ResponseEntity.ok(BaseResponse.success(null));
     }
 
-
+    @Operation(summary = "전화번호 수정",
+            description = "본인 전화번호를 수정합니다. 하이픈 없이 010 + 8자리 숫자 형식.")
     @PatchMapping("/mypage/phone")
     public ResponseEntity<BaseResponse<UserDto.MypageRes>> updatePhone(
             @AuthenticationPrincipal AuthUserDetails userDetails,

--- a/src/main/java/org/example/stockitbe/user/model/dto/UserDto.java
+++ b/src/main/java/org/example/stockitbe/user/model/dto/UserDto.java
@@ -1,5 +1,6 @@
 package org.example.stockitbe.user.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +16,30 @@ public class UserDto {
     // 회원가입 신청 요청
     @Getter
     @NoArgsConstructor
+    @Schema(description = "회원가입 신청 요청")
     public static class SignupReq {
+        @Schema(description = "이름", example = "테스트유저", requiredMode = Schema.RequiredMode.REQUIRED)
         private String name;
+
+        @Schema(description = "이메일 (영문+숫자, 중복 불가)", example = "swagger-test01@stockit.com", requiredMode = Schema.RequiredMode.REQUIRED)
         private String email;
+
+        @Schema(description = "비밀번호 (대소문자+숫자+특수문자 8자 이상)", example = "Test1234!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String password;
+
+        @Schema(description = "전화번호 (하이픈 없이 010+8자리)", example = "01099990001", requiredMode = Schema.RequiredMode.REQUIRED)
         private String phoneNumber;
+
+        @Schema(description = "지점 코드", example = "ST001", requiredMode = Schema.RequiredMode.REQUIRED)
         private String locationCode;
+
+        @Schema(description = "지점명", example = "테스트 매장", requiredMode = Schema.RequiredMode.REQUIRED)
         private String locationName;
+
+        @Schema(description = "가입 신청 사유 (선택)", example = "Swagger 테스트용 신청")
         private String applicationReason;
+
+        @Schema(description = "권한", example = "STORE", allowableValues = {"HQ", "STORE", "WAREHOUSE"})
         private UserRole role;
 
         public User toEntity(String encodedPassword) {
@@ -46,15 +63,33 @@ public class UserDto {
     // 회원 정보 응답
     @Getter
     @Builder
+    @Schema(description = "회원가입 응답")
     public static class SignupRes {
+        @Schema(description = "회원 PK", example = "5")
         private Long id;
+
+        @Schema(description = "사원코드 (승인 전 null)", example = "null")
         private String employeeCode;
+
+        @Schema(description = "이름", example = "테스트유저")
         private String name;
+
+        @Schema(description = "이메일", example = "test01@stockit.com")
         private String email;
+
+        @Schema(description = "지점 코드", example = "ST001")
         private String locationCode;
+
+        @Schema(description = "지점명", example = "테스트 매장")
         private String locationName;
+
+        @Schema(description = "권한", example = "STORE")
         private UserRole role;
+
+        @Schema(description = "회원 상태", example = "PENDING")
         private UserStatus userStatus;
+
+        @Schema(description = "신청 일시")
         private LocalDateTime appliedAt;
 
         public static SignupRes from(User entity) {
@@ -75,34 +110,66 @@ public class UserDto {
     //  로그인 요청
     @Getter
     @NoArgsConstructor
+    @Schema(description = "로그인 요청")
     public static class LoginReq {
+        @Schema(description = "사원코드", example = "hq0001", requiredMode = Schema.RequiredMode.REQUIRED)
         private String employeeCode;
+
+        @Schema(description = "비밀번호", example = "Test1234!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String password;
     }
 
     //  로그인 응답
     @Getter
     @Builder
+    @Schema(description = "로그인 응답")
     public static class LoginRes {
+        @Schema(description = "사원코드", example = "hq0001")
         private String employeeCode;
+
+        @Schema(description = "이름", example = "홍길동")
         private String name;
+
+        @Schema(description = "권한", example = "HQ")
         private UserRole role;
+
+        @Schema(description = "지점 코드", example = "HQ001")
         private String locationCode;
+
+        @Schema(description = "지점명", example = "본사")
         private String locationName;
     }
 
     //  마이페이지
     @Getter
     @Builder
+    @Schema(description = "마이페이지 응답")
     public static class MypageRes {
+        @Schema(description = "회원 PK", example = "1")
         private Long id;
+
+        @Schema(description = "사원코드", example = "hq0001")
         private String employeeCode;
+
+        @Schema(description = "이름", example = "홍길동")
         private String name;
+
+        @Schema(description = "이메일", example = "hong@stockit.com")
         private String email;
+
+        @Schema(description = "지점 코드", example = "HQ001")
         private String locationCode;
+
+        @Schema(description = "지점명", example = "본사")
         private String locationName;
+
+        @Schema(description = "권한", example = "HQ")
         private UserRole role;
+
+        @Schema(description = "회원 상태", example = "APPROVED")
         private UserStatus status;
+
+        @Schema(description = "전화번호", example = "01012345678")
         private String phoneNumber;
 
         public static MypageRes from(User entity) {
@@ -123,15 +190,21 @@ public class UserDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "전화번호 변경 요청")
     public static class UpdatePhoneReq {
+        @Schema(description = "새 전화번호 (하이픈 없이 010+8자리)", example = "01098765432", requiredMode = Schema.RequiredMode.REQUIRED)
         private String phoneNumber;
     }
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "비밀번호 변경 요청")
     public static class UpdatePasswordReq {
+        @Schema(description = "현재 비밀번호", example = "Test1234!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String currentPassword;
+
+        @Schema(description = "새 비밀번호 (대소문자+숫자+특수문자 8자 이상)", example = "NewPass1234!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String newPassword;
     }
 


### PR DESCRIPTION
## 📌 요약
- 본인 담당 도메인(회원/알림/본사 계정 관리)에 Swagger(OpenAPI 3) 어노테이션을 추가하고, 팀 컨벤션에 맞춰 정리했습니다.
- Cookie 기반 인증(Atoken)을 Swagger UI에서 사용할 수 있도록 SecurityScheme을 등록하고, LoginFilter가 가로채는 로그인 엔드포인트도 문서에 노출했습니다.

<br><br>

## 🎯 작업 내용
- **OpenApiConfig 신규 생성** — Cookie 기반 SecurityScheme(`AtokenCookie`) 등록으로 Swagger UI에서 Authorize 가능하게 구성
- **UserController** — 회원가입/로그인/토큰 갱신/로그아웃/마이페이지 6개 엔드포인트에 `@Tag`, `@Operation`, `@Parameter` 추가
- **NotificationController** — SSE 구독/세션 종료/알림 목록/미읽음 카운트/단건·전체 읽음 6개 엔드포인트 문서화
- **AccountController** — 가입 대기/전체 회원 목록/승인/거절/탈퇴 5개 엔드포인트 문서화
- **3개 DTO(UserDto/NotificationDto/AccountDto)** — 필드별 `@Schema(description, example)` 부여로 Try it out 자동 예제값 제공
- **로그인 엔드포인트 Swagger 노출** — `LoginFilter`가 가로채는 `POST /api/user/login`을 UserController에 더미 메서드로 추가하여 Swagger UI에서 직접 로그인 가능하게 처리
- **팀 컨벤션 통일** — Tag 명을 `"영역 - 세부기능 (요구사항 ID)"` 형식으로 정리 (예: `회원 - 인증/마이페이지 (USER-001~004, 008)`, `시스템 - 알림 (SYS-004, SYS-005)`, `본사 - 계정 관리 (USER-005~007, 009)`)


<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
