### PR TITLE
feat(esg): KOC25-30 전환 + 월별 시세 집계 + 차트 필터 개선

### DIFF
--- a/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
+++ b/src/main/java/org/example/stockitbe/hq/circularsale/CircularSaleService.java
@@ -739,7 +739,7 @@ public class CircularSaleService {
      * Phase 3: 실제 판매 완료 시 ESG 점수 가산을 위해 circular_buyer_transaction 에도 거래 row 를 INSERT.
      *  - sale_item 별로 transaction 1건씩 생성 (product 별 정밀 ESG 점수)
      *  - DONATION은 buyer=null (entity optional=true), doneeName 기록
-     *  - 거래 시점 단가/금액은 sale_item 의 값을 그대로 스냅샷 (KAU 시세와 무관, 실제 거래가 기준)
+     *  - 거래 시점 단가/금액은 sale_item 의 값을 그대로 스냅샷 (배출권 시세와 무관, 실제 거래가 기준)
      */
     private void createTransactionsFromSale(CircularSaleHeader header,
                                              CircularBuyer buyer,

--- a/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceApiClient.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceApiClient.java
@@ -82,7 +82,7 @@ public class CarbonPriceApiClient {
 
 
     /**
-     * KAU25 시세 최근 2주 일별 데이터 조회.
+     * 배출권 시세 최근 2주 일별 데이터 조회 (target-symbol = KOC25-30).
      *
      * 정책 — Graceful Degradation:
      *  - 네트워크 / 파싱 / 외부 API 비정상응답 모두 빈 리스트로 반환

--- a/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceController.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceController.java
@@ -29,4 +29,12 @@ public class CarbonPriceController {
     ) {
         return ResponseEntity.ok(BaseResponse.success(carbonPriceService.getTrend(period)));
     }
+
+    /** 월별 집계 시계열 — 최근 N개월의 월말 종가 반환. KOC 류 장기 트렌드 표현용. */
+    @GetMapping("/carbon-price/trend/monthly")
+    public ResponseEntity<BaseResponse<List<CarbonPriceDto.Snapshot>>> getMonthlyTrend(
+            @RequestParam(defaultValue = "12") int months
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(carbonPriceService.getMonthlyTrend(months)));
+    }
 }

--- a/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceService.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/carbonprice/CarbonPriceService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -20,20 +22,24 @@ public class CarbonPriceService {
     @Value("${esg.carbon-api.fallback-price:9200}")
     private int fallbackPrice;
 
-    /** 그래프 기간 옵션 — FE 탭과 1:1 매핑 */
+    /** 그래프 기간 옵션 — FE 탭과 1:1 매핑.
+     *  dayRange 는 호출 시점 today 기준 minusDays 값 (휴장일 포함 여유분).
+     *  SEVEN_DAYS 는 KPI 카드 "7거래일 최고/최저" 계산용으로도 사용되어 enum 보존. */
     public enum Period {
         SEVEN_DAYS(14),
         ONE_MONTH(45),
+        THREE_MONTHS(100),
         SIX_MONTHS(200);
 
         public final int dayRange;
         Period(int dayRange) { this.dayRange = dayRange; }
     }
 
-    /** 가장 최근 거래일의 KAU 종가 (KPI 카드용) — 14일 범위에서 추출 */
+    /** 가장 최근 거래일의 배출권 종가 (KPI 카드용) — 14일 범위에서 추출.
+     *  KOC 류는 거래일 드물어서 trqu>0 만으로는 빈 결과 빈번 → clpr 기반으로 변경. */
     public CarbonPriceDto.Snapshot getLatestPrice() {
         List<CarbonPriceDto.Item> items = apiClient.fetchRecentPrices().stream()
-                .filter(this::hasTrading)
+                .filter(this::hasClosingPrice)
                 .toList();
         return items.stream()
                 .max(Comparator.comparing(CarbonPriceDto.Item::getBasDt))
@@ -45,19 +51,59 @@ public class CarbonPriceService {
                 });
     }
 
-    /** 시계열 — 기간 옵션에 따라 호출 범위 다르게, 거래량 0 제외 */
+    /** 시계열 — 기간 옵션에 따라 호출 범위 다르게, 종가(clpr) 있는 날만 표시.
+     *  KOC 류는 거래량 0 인 날이 대부분이라 hasTrading 만으로는 차트가 비어버림.
+     *  → clpr(전일 종가) 만 있으면 차트에 포함 (실제 거래 없이 마감가 유지되는 채권 시세 표현 방식). */
     public List<CarbonPriceDto.Snapshot> getTrend(Period period) {
         LocalDate today = LocalDate.now();
         LocalDate from = today.minusDays(period.dayRange);
 
         return apiClient.fetchPrices(from, today).stream()
-                .filter(this::hasTrading)              // 거래량 > 0 만
+                .filter(this::hasClosingPrice)         // 종가 > 0 만 (거래량 0 도 허용)
                 .sorted(Comparator.comparing(CarbonPriceDto.Item::getBasDt))
                 .map(this::toSnapshot)
                 .toList();
     }
 
-    /** 거래량 > 0 인지 검사 (실제 거래된 날짜만 의미 있음) */
+    /** 월별 시계열 — 최근 N개월의 "월말 종가" 반환.
+     *  KOC 류는 일별 차트가 거의 평탄 → 월별 집계로 장기 트렌드 가시화.
+     *  각 월의 가장 늦은 날짜(=월말 직전 거래일)의 clpr 을 대표값으로 사용 — 금융 시세 보고 관행.
+     *
+     * @param months 최근 몇 개월치를 가져올지 (기본 12개월 = 1년 트렌드)
+     */
+    public List<CarbonPriceDto.Snapshot> getMonthlyTrend(int months) {
+        LocalDate today = LocalDate.now();
+        // months+1 개월 호출 — 현재월 + 과거 N개월. 외부 API daily 데이터를 모두 받아옴.
+        LocalDate from = today.minusMonths(months);
+
+        // 월별 그룹핑: key=YYYYMM, value=그 달의 마지막 거래일 Item
+        Map<String, CarbonPriceDto.Item> lastOfMonth = apiClient.fetchPrices(from, today).stream()
+                .filter(this::hasClosingPrice)
+                .collect(Collectors.toMap(
+                        item -> item.getBasDt().substring(0, 6),   // YYYYMM 부분만 키로 사용
+                        item -> item,
+                        (a, b) -> a.getBasDt().compareTo(b.getBasDt()) >= 0 ? a : b   // 더 늦은 날짜 우선
+                ));
+
+        return lastOfMonth.values().stream()
+                .sorted(Comparator.comparing(CarbonPriceDto.Item::getBasDt))
+                .map(this::toSnapshot)
+                .toList();
+    }
+
+    /** 종가(clpr) 가 0 보다 큰지 검사 — 거래 없어도 종가가 있으면 차트 표시 대상. */
+    private boolean hasClosingPrice(CarbonPriceDto.Item item) {
+        String clpr = item.getClpr();
+        if (clpr == null || clpr.isBlank()) return false;
+        try {
+            return Long.parseLong(clpr.replace(",", "")) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /** 거래량 > 0 인지 검사 — 최신 종가 추출 시에도 종가 기반으로 변경되어 사용처 없음 (호환용 보존). */
+    @SuppressWarnings("unused")
     private boolean hasTrading(CarbonPriceDto.Item item) {
         String trqu = item.getTrqu();
         if (trqu == null || trqu.isBlank()) return false;

--- a/src/main/java/org/example/stockitbe/hq/esg/carbonprice/model/CarbonPriceDto.java
+++ b/src/main/java/org/example/stockitbe/hq/esg/carbonprice/model/CarbonPriceDto.java
@@ -47,7 +47,7 @@ public class CarbonPriceDto {
         private String basDt;     // 기준일자 YYYYMMDD
         private String srtnCd;    // 단축코드
         private String isinCd;    // ISIN 코드
-        private String itmsNm;    // 종목명 (KAU25 등)
+        private String itmsNm;    // 종목명 (KOC25-30, KAU25 등)
         private String clpr;      // 종가 (원/톤)
         private String vs;        // 전일대비
         private String fltRt;     // 등락률
@@ -63,7 +63,7 @@ public class CarbonPriceDto {
     @Getter @AllArgsConstructor @NoArgsConstructor
     public static class Snapshot {
         private int pricePerTon;    // 원/톤
-        private String symbol;      // KAU25
+        private String symbol;      // KOC25-30 (현행) / KAU25
         private String basDt;       // YYYYMMDD
         private String fltRt;       // 등락률
         private boolean fallback;   // 폴백값 여부

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -71,8 +71,8 @@ esg:
   carbon-api:
     base-url: https://apis.data.go.kr/1160100/service/GetGeneralProductInfoService
     service-key: ${PUBLIC_DATA_API_KEY}
-    target-symbol: KAU25       # 현재 거래 활성 종목
-    fallback-price: 9200
+    target-symbol: KOC25-30    # 외부사업 인증실적 (Korean Offset Credit, 2025년물·2030 만기) — KAU25 와 동시기물
+    fallback-price: 13000      # KOC25-30 최근 종가 기준
 
 management:
   endpoint:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -66,8 +66,8 @@ esg:
   carbon-api:
     base-url: https://apis.data.go.kr/1160100/service/GetGeneralProductInfoService
     service-key: ${PUBLIC_DATA_API_KEY}
-    target-symbol: KAU25       # 현재 거래 활성 종목
-    fallback-price: 9200
+    target-symbol: KOC25-30    # 외부사업 인증실적 (Korean Offset Credit, 2025년물·2030 만기) — KAU25 와 동시기물
+    fallback-price: 13000      # KOC25-30 최근 종가 기준
 
 management:
   endpoint:


### PR DESCRIPTION
- 탄소 배출권 외부 연동 종목 KAU25 → KOC25-30 (Korean Offset Credit)
- 신규 엔드포인트 GET /carbon-price/trend/monthly?months=N · 일별 응답을 YYYYMM 으로 group-by 해서 월말 종가 추출 (금융 시세 보고 관행)
- 차트 필터 hasTrading → hasClosingPrice 변경 · KOC 류는 거래량 0 이지만 종가는 유지되는 채권 시세 특성 대응
- Period enum 에 THREE_MONTHS(100) 추가, ONE_YEAR 제거
- fallback-price 9200 → 13000 (KOC25-30 기준)

## 📌 요약
- 

<br><br>

## 🎯 작업 내용
- 
- 
- 

<br><br>

## ✔️ 참고 사항
- 
- 

<br><br>

## ✔️ 관련 이슈

- Close #이슈번호

<br><br>
