### PR TITLE
feat: 순환 재고 기부시 출고 리스트에 기부처 이름 뜨도록 수정

### DIFF
--- a/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
+++ b/src/main/java/org/example/stockitbe/warehouse/outbound/WhOutboundService.java
@@ -88,7 +88,7 @@ public class WhOutboundService {
                         h,
                         myWarehouse.getCode(),
                         myWarehouse.getName(),
-                        destinationNameById.get(h.getDestinationId())
+                        resolveListDestinationName(h, destinationNameById)
                 ))
                 .toList();
     }
@@ -378,6 +378,13 @@ public class WhOutboundService {
             }
         }
         return nameById;
+    }
+
+    // [목록용 목적지명 해석] ID 맵에 없으면 엔티티의 destination_name 필드를 fallback으로 사용한다. (DONATION 기부처명 처리)
+    private String resolveListDestinationName(WhOutboundHeader h, Map<Long, String> nameById) {
+        String mapped = nameById.get(h.getDestinationId());
+        if (mapped != null) return mapped;
+        return h.getDestinationName();
     }
 
     // [목적지명 단건 조회] destinationType에 따라 인프라/거래처에서 이름을 조회한다.


### PR DESCRIPTION
## 📌 요약
- 순환 재고 기부 시에도 출고 창고에서 순환재고 판매 유형으로 출고 나가는거 수정

<br><br>

## 🎯 작업 내용
- 순환 재고 기부 유형 추가
- 기부 시 기부처 이름 제대로 로드 안되던거 수정


<br><br>

